### PR TITLE
Adding test/common/Log4jUtils to simplify logging setup in tests

### DIFF
--- a/gobblin-test-harness/build.gradle
+++ b/gobblin-test-harness/build.gradle
@@ -18,6 +18,10 @@ repositories {
 }
 
 dependencies {
+  compile externalDependency.jodaTime
+  compile externalDependency.log4j
+  compile externalDependency.slf4j
+
   testCompile project(":gobblin-api")
   testCompile project(":gobblin-core")
   testCompile project(":gobblin-runtime")

--- a/gobblin-test-harness/src/main/java/gobblin/test/common/Log4jUtils.java
+++ b/gobblin-test-harness/src/main/java/gobblin/test/common/Log4jUtils.java
@@ -1,0 +1,92 @@
+package gobblin.test.common;
+
+import java.io.IOException;
+
+import org.apache.log4j.Appender;
+import org.apache.log4j.ConsoleAppender;
+import org.apache.log4j.FileAppender;
+import org.apache.log4j.Layout;
+import org.apache.log4j.Level;
+import org.apache.log4j.PatternLayout;
+import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Helper class for configuring test Log4j logging */
+public class Log4jUtils {
+  public static Logger LOG = LoggerFactory.getLogger(Log4jUtils.class);
+
+  public static final Layout STANDARD_LAYOUT =
+      new PatternLayout("%d{ISO8601} +%r [%p] {%c{2}} (%t)  %m%n");
+
+  /** Helper method to change the Log4j logging level given a SLF4J facade */
+  public static void changeLoggingLevel(Logger slf4jLogger, Level log4jLevel) {
+    org.apache.log4j.Logger log4jLogger = org.apache.log4j.Logger.getLogger(slf4jLogger.getName());
+    log4jLogger.setLevel(log4jLevel);
+  }
+
+  /** Helper method to change the Log4j logging level given a SLF4J facade */
+  public static void changeLoggingLevel(Logger slf4jLogger, String log4jLevel) {
+    changeLoggingLevel(slf4jLogger, Level.toLevel(log4jLevel));
+  }
+
+  /**
+   * Programatically configures the root Log4j logger to send the logs to a file. This is useful
+   * for tests where console logging may not be visible or may be too verbose. Note that this method
+   * will leave the file. Typically, the file should be under /tmp/ so it gets removed eventually.
+   *
+   * @param  filePath     the logging file to write to; typically, under /tmp/
+   * @param  log4jLevel   the string constant for logging level, e.g. DEBUG, INFO, ERROR
+   */
+  public static void logToFile(String filePath, String log4jLevel) {
+    org.apache.log4j.Logger rootLogger = org.apache.log4j.Logger.getRootLogger();
+    try {
+      Appender fileAppender = new FileAppender(STANDARD_LAYOUT, filePath);
+      rootLogger.addAppender(fileAppender);
+      rootLogger.setLevel(Level.toLevel(log4jLevel));
+    }
+    catch (IOException e) {
+      LOG.error("Unable to setup logging: "+ e, e);
+    }
+  }
+
+  /**
+   * Programatically configures the root Log4j logger to send the logs to console.
+   *
+   * @param  log4jLevel   the string constant for logging level, e.g. DEBUG, INFO, ERROR
+   */
+  public static void logToConsole(String log4jLevel) {
+    org.apache.log4j.Logger rootLogger = org.apache.log4j.Logger.getRootLogger();
+    Appender consoleAppender = new ConsoleAppender(STANDARD_LAYOUT);
+    rootLogger.addAppender(consoleAppender);
+    rootLogger.setLevel(Level.toLevel(log4jLevel));
+  }
+
+  /**
+   * Convenience method to setup logging for a test class. It will create a timestamped log file
+   * under /tmp/ with the test class name.
+   *
+   * <p>NOTE: this method will reset any existing Log4j configs!
+   *
+   * @param testClass       the test class for which logging is configured; it will be used for the
+   *                        log file name.
+   * @param log4jLevel      the string constant for logging level, e.g. DEBUG, INFO, ERROR
+   * @param logToConsole    if true, enable logging to console as well
+   */
+  public static void configureLoggingForTest(Class<?> testClass, String log4jLevel,
+      boolean logToConsole) {
+    DateTimeFormatter fileTimestampFormat = DateTimeFormat.forPattern("yyyyMMdd-HHmmss.SSS");
+    String logFilePath = String.format("/tmp/%s.%s.log", testClass.getSimpleName(),
+        fileTimestampFormat.print(new DateTime()));
+    org.apache.log4j.Logger rootLogger = org.apache.log4j.Logger.getRootLogger();
+    rootLogger.removeAllAppenders();
+    logToFile(logFilePath, log4jLevel);
+    if (logToConsole) {
+      logToConsole(log4jLevel);
+    }
+
+  }
+
+}

--- a/gobblin-test-harness/src/test/java/gobblin/test/common/TestLog4jUtils.java
+++ b/gobblin-test-harness/src/test/java/gobblin/test/common/TestLog4jUtils.java
@@ -1,0 +1,98 @@
+package gobblin.test.common;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.util.Enumeration;
+
+import org.apache.log4j.Appender;
+import org.apache.log4j.ConsoleAppender;
+import org.apache.log4j.FileAppender;
+import org.apache.log4j.Level;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/** Simple unit tests for {@link Log4jUtils} */
+public class TestLog4jUtils {
+  org.apache.log4j.Logger rootLogger;
+  private Enumeration<Appender> savedRootAppenders;
+  private Level savedRootLevel;
+
+  @BeforeClass
+  @SuppressWarnings("unchecked")
+  public void setUp() {
+    this.rootLogger = org.apache.log4j.Logger.getRootLogger();
+    this.savedRootLevel = this.rootLogger.getLevel();
+    this.savedRootAppenders = this.rootLogger.getAllAppenders();
+  }
+
+  @AfterClass
+  public void tearDown() {
+    this.rootLogger.removeAllAppenders();
+    this.rootLogger.setLevel(this.savedRootLevel);
+    while (this.savedRootAppenders.hasMoreElements()) {
+      this.rootLogger.addAppender(this.savedRootAppenders.nextElement());
+    }
+  }
+
+  @Test
+  public void testChangeLoggingLevel() {
+    Logger log = LoggerFactory.getLogger(TestLog4jUtils.class.getName() + ".testChangeLoggingLevel");
+    Log4jUtils.changeLoggingLevel(log, "DEBUG");
+    Assert.assertEquals(org.apache.log4j.Logger.getLogger(log.getName()).getLevel(), Level.DEBUG);
+    Log4jUtils.changeLoggingLevel(log, "ERROR");
+    Assert.assertEquals(org.apache.log4j.Logger.getLogger(log.getName()).getLevel(), Level.ERROR);
+  }
+
+  @Test(dependsOnMethods="testChangeLoggingLevel")
+  public void testConfigureLoggingForTest() {
+    //count log files from previous runs
+    File tmpDir = new File("/tmp");
+    String[] logFiles = tmpDir.list(new FilenameFilter() {
+      @Override
+      public boolean accept(File dir, String name) {
+        return name.contains(TestLog4jUtils.class.getSimpleName());
+      }
+    });
+    int initialLogFileNum = null == logFiles ? 0 : logFiles.length;
+
+    Log4jUtils.configureLoggingForTest(TestLog4jUtils.class, "DEBUG", true);
+    Assert.assertEquals(rootLogger.getLevel(), Level.DEBUG);
+    @SuppressWarnings("unchecked")
+    Enumeration<Appender> allAppenders = rootLogger.getAllAppenders();
+    boolean hasFileAppender = false;
+    boolean hasConsoleAppender = false;
+    FileAppender fileAppender = null;
+    this.rootLogger.debug("Starting appender asserts");
+    while (allAppenders.hasMoreElements()) {
+      Appender appender = allAppenders.nextElement();
+      if (appender instanceof ConsoleAppender) {
+        hasConsoleAppender = true;
+      } else if (appender instanceof FileAppender) {
+        hasFileAppender = true;
+        fileAppender = (FileAppender)appender;
+      }
+      this.rootLogger.info("hasFileAppender=" + hasFileAppender);
+      this.rootLogger.info("hasConsoleAppender=" + hasConsoleAppender);
+    }
+    Assert.assertTrue(hasFileAppender);
+    Assert.assertTrue(hasConsoleAppender);
+    this.rootLogger.debug("Done with appender asserts");
+
+    this.rootLogger.debug("Check for log file");
+    this.rootLogger.info("initialLogFileNum=" + initialLogFileNum);
+    fileAppender.close();
+    logFiles = tmpDir.list(new FilenameFilter() {
+      @Override
+      public boolean accept(File dir, String name) {
+        return name.contains(TestLog4jUtils.class.getSimpleName());
+      }
+    });
+    int finalLogFileNum = null == logFiles ? 0 : logFiles.length;
+    Assert.assertEquals(finalLogFileNum, initialLogFileNum + 1);
+  }
+
+}


### PR DESCRIPTION
Add helper class Log4jUtils that has convenience methods to control logging in a unit test

@pcadabam  can you review ?
