### PR TITLE
Implemented Avro field replacer converter.

### DIFF
--- a/gobblin-core/src/main/java/gobblin/converter/avro/replacer/AvroFieldReplacer.java
+++ b/gobblin-core/src/main/java/gobblin/converter/avro/replacer/AvroFieldReplacer.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.converter.avro.replacer;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Properties;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.Maps;
+
+import gobblin.configuration.WorkUnitState;
+import gobblin.converter.Converter;
+import gobblin.converter.DataConversionException;
+import gobblin.converter.SchemaConversionException;
+import gobblin.converter.SingleRecordIterable;
+import gobblin.util.ClassAliasResolver;
+import gobblin.util.ForkOperatorUtils;
+
+
+/**
+ * Replaces string fields in avro records.
+ *
+ * Usage: this class reads the fields to be replaced from configuration keys of the form:
+ * {@link #REPLACE_FIELD_KEY}.<my-field> = <replacer-alias>[:<parameters>]
+ * For example, to replace the field "myField" with the constant "myValue", use
+ * {@link #REPLACE_FIELD_KEY}.myField = constant:myValue
+ *
+ * {@link AvroFieldReplacer} can use any {@link StringValueReplacer} specified by alias by the user. For simplicity,
+ * some {@link StringValueReplacer} take a single string argument which is passed in the same configuration key separated
+ * by a ":" from the replacer-alias.
+ */
+public class AvroFieldReplacer extends Converter<Schema, Schema, GenericRecord, GenericRecord>{
+
+  public static final String REPLACE_FIELD_KEY = "converter.avro.replacer.field";
+
+  private static final Splitter SPLITTER = Splitter.on(":").limit(2);
+
+  private final Map<String, StringValueReplacer> replacementMap = Maps.newHashMap();
+
+  @Override
+  public Schema convertSchema(Schema inputSchema, WorkUnitState workUnit)
+      throws SchemaConversionException {
+
+    try {
+      String fieldPathKey = ForkOperatorUtils.getPropertyNameForBranch(workUnit, REPLACE_FIELD_KEY);
+
+      ClassAliasResolver<StringValueReplacer.ReplacerFactory> resolver = new ClassAliasResolver<>(StringValueReplacer.ReplacerFactory.class);
+      Properties properties = workUnit.getProperties();
+
+      for (Map.Entry<Object, Object> entry : properties.entrySet()) {
+        if (entry.getKey() instanceof String && entry.getValue() instanceof String && ((String) entry.getKey()).startsWith(fieldPathKey)) {
+          String fieldName = ((String) entry.getKey()).substring(fieldPathKey.length() + 1);
+          Iterator<String> it = SPLITTER.split((String) entry.getValue()).iterator();
+          StringValueReplacer.ReplacerFactory factory = resolver.resolveClass(it.next()).newInstance();
+          this.replacementMap.put(fieldName, factory.buildReplacer(it.hasNext() ? it.next() : "", properties));
+        }
+      }
+
+      return inputSchema;
+    } catch (ReflectiveOperationException roe) {
+      throw new SchemaConversionException("Failed to instantiate " + AvroFieldReplacer.class, roe);
+    }
+  }
+
+  @Override
+  public Iterable<GenericRecord> convertRecord(Schema outputSchema, GenericRecord inputRecord, WorkUnitState workUnit)
+      throws DataConversionException {
+    for (Map.Entry<String, StringValueReplacer> entry : this.replacementMap.entrySet()) {
+      Object currentValue = inputRecord.get(entry.getKey());
+      if (currentValue != null && currentValue instanceof String) {
+        inputRecord.put(entry.getKey(), entry.getValue().replace((String) inputRecord.get(entry.getKey())));
+      }
+    }
+    return new SingleRecordIterable<>(inputRecord);
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/converter/avro/replacer/ConstantReplacer.java
+++ b/gobblin-core/src/main/java/gobblin/converter/avro/replacer/ConstantReplacer.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.converter.avro.replacer;
+
+import java.util.Properties;
+
+import gobblin.annotation.Alias;
+
+import lombok.AllArgsConstructor;
+
+
+/**
+ * Replaces strings by a constant value (passed in as parameter in the configuration key {@link AvroFieldReplacer#REPLACE_FIELD_KEY}.
+ *
+ * Usage: {@link AvroFieldReplacer#REPLACE_FIELD_KEY}.<my-field> = constant:<replacement-value>
+ */
+@AllArgsConstructor
+public class ConstantReplacer implements StringValueReplacer {
+
+  @Alias(value = "constant")
+  public static class Factory implements ReplacerFactory {
+    @Override
+    public StringValueReplacer buildReplacer(String configurationValue, Properties properties) {
+      return new ConstantReplacer(configurationValue);
+    }
+  }
+
+  private final String replacement;
+
+  @Override
+  public String replace(String originalValue) {
+    return replacement;
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/converter/avro/replacer/Sha1Replacer.java
+++ b/gobblin-core/src/main/java/gobblin/converter/avro/replacer/Sha1Replacer.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.converter.avro.replacer;
+
+import java.util.Properties;
+
+import org.apache.commons.codec.digest.DigestUtils;
+
+import gobblin.annotation.Alias;
+
+
+/**
+ * Replaces a {@link String} by it's hex Sha1 encoding. Takes no parameters.
+ */
+public class Sha1Replacer implements StringValueReplacer {
+
+  @Alias(value = "sha1")
+  public static class Factory implements ReplacerFactory {
+    @Override
+    public StringValueReplacer buildReplacer(String configurationValue, Properties properties) {
+      return new Sha1Replacer();
+    }
+  }
+
+  @Override
+  public String replace(String originalValue) {
+    return DigestUtils.sha1Hex(originalValue);
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/converter/avro/replacer/StringValueReplacer.java
+++ b/gobblin-core/src/main/java/gobblin/converter/avro/replacer/StringValueReplacer.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.converter.avro.replacer;
+
+import java.util.Properties;
+
+
+/**
+ * Replaces a {@link String} value for a different {@link String}. Used in {@link AvroFieldReplacer}.
+ */
+public interface StringValueReplacer {
+
+  /**
+   * Builds a {@link StringValueReplacer}.
+   */
+  interface ReplacerFactory {
+    /**
+     * Build a {@link StringValueReplacer}.
+     * @param configurationValue A parameter passed in by the user for this replacer. If the user did not pass a parameter,
+     *                           use "" instead.
+     * @param properties The full job properties.
+     * @return a {@link StringValueReplacer}.
+     */
+    StringValueReplacer buildReplacer(String configurationValue, Properties properties);
+  }
+
+  /**
+   * Compute the replacement for the input string.
+   */
+  String replace(String originalValue);
+}

--- a/gobblin-core/src/test/java/gobblin/converter/avro/replacer/AvroFieldReplacerTest.java
+++ b/gobblin-core/src/test/java/gobblin/converter/avro/replacer/AvroFieldReplacerTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.converter.avro.replacer;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.GenericRecordBuilder;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import gobblin.configuration.WorkUnitState;
+
+
+public class AvroFieldReplacerTest {
+
+  public static final Schema SCHEMA = (new Schema.Parser()).parse("{\"namespace\": \"example.avro\",\n"
+      + " \"type\": \"record\",\n" + " \"name\": \"MyRecord\",\n" + " \"fields\": [\n"
+      + "     {\"name\": \"name\", \"type\": \"string\"},\n"
+      + "     {\"name\": \"favorite_color\", \"type\": [\"string\", \"null\"]}\n" + " ]\n" + "}");
+
+  @Test
+  public void test() throws Exception {
+
+    GenericRecord record = new GenericRecordBuilder(SCHEMA).set("name", "myName").set("favorite_color", "blue").build();
+
+    AvroFieldReplacer replacer = new AvroFieldReplacer();
+    WorkUnitState workUnitState = new WorkUnitState();
+    workUnitState.setProp(AvroFieldReplacer.REPLACE_FIELD_KEY + ".name", "constant:myReplacement");
+
+    Schema outputSchema = replacer.convertSchema(SCHEMA, workUnitState);
+    Iterable<GenericRecord> it = replacer.convertRecord(outputSchema, record, workUnitState);
+    GenericRecord outputRecord = it.iterator().next();
+    Assert.assertEquals(outputRecord.get("name"), "myReplacement");
+    Assert.assertEquals(outputRecord.get("favorite_color"), "blue");
+
+    workUnitState.setProp(AvroFieldReplacer.REPLACE_FIELD_KEY + ".favorite_color", "constant:red");
+    outputSchema = replacer.convertSchema(SCHEMA, workUnitState);
+    it = replacer.convertRecord(outputSchema, record, workUnitState);
+    outputRecord = it.iterator().next();
+    Assert.assertEquals(outputRecord.get("name"), "myReplacement");
+    Assert.assertEquals(outputRecord.get("favorite_color"), "red");
+
+  }
+
+}

--- a/gobblin-core/src/test/java/gobblin/converter/avro/replacer/Sha1ReplacerTest.java
+++ b/gobblin-core/src/test/java/gobblin/converter/avro/replacer/Sha1ReplacerTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.converter.avro.replacer;
+
+import java.util.Properties;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class Sha1ReplacerTest {
+
+  @Test
+  public void test() {
+    StringValueReplacer replacer = new Sha1Replacer.Factory().buildReplacer("", new Properties());
+    Assert.assertEquals(replacer.replace("a"), DigestUtils.sha1Hex("a"));
+  }
+
+}


### PR DESCRIPTION
This implements a converter that can replace string fields in Avro records for other string, supporting custom replacements. Also implemented two default replacements: constant and sha1.