### PR TITLE
[GOBBLIN-6] Support eventual consistent filesystems like S3

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/util/RecordCountProvider.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/util/RecordCountProvider.java
@@ -37,7 +37,7 @@ public abstract class RecordCountProvider {
    * Convert a {@link Path} from another {@link RecordCountProvider} so that it can be used
    * in {@link #getRecordCount(Path)} of this {@link RecordCountProvider}.
    */
-  public Path convertPath(Path path, RecordCountProvider src) {
+  public Path convertPath(Path path, String extension, RecordCountProvider src) {
     if (this.getClass().equals(src.getClass())) {
       return path;
     }

--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/MRCompactor.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/MRCompactor.java
@@ -25,6 +25,7 @@ import static org.apache.gobblin.compaction.mapreduce.MRCompactorJobRunner.Statu
 import static org.apache.gobblin.compaction.mapreduce.MRCompactorJobRunner.Status.COMMITTED;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
@@ -45,6 +46,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocalFileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapreduce.Job;
+import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -255,6 +257,8 @@ public class MRCompactor implements Compactor {
   public static final String COMPACTION_TRACKING_EVENTS_NAMESPACE = COMPACTION_PREFIX + "tracking.events";
 
   public static final String COMPACTION_INPUT_PATH_TIME = COMPACTION_PREFIX + "input.path.time";
+  public static final String COMPACTION_FILE_EXTENSION =
+      COMPACTION_PREFIX + "extension";
 
   private static final long COMPACTION_JOB_WAIT_INTERVAL_SECONDS = 10;
   private static final Map<Dataset, Job> RUNNING_MR_JOBS = Maps.newConcurrentMap();

--- a/gobblin-core-base/src/main/java/org/apache/gobblin/writer/AsyncWriterManager.java
+++ b/gobblin-core-base/src/main/java/org/apache/gobblin/writer/AsyncWriterManager.java
@@ -43,12 +43,12 @@ import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
 import javax.annotation.Nonnull;
-
 import lombok.Getter;
 import lombok.Setter;
 
 import org.apache.gobblin.ack.Ackable;
 import org.apache.gobblin.configuration.State;
+import org.apache.gobblin.exception.NonTransientException;
 import org.apache.gobblin.instrumented.Instrumentable;
 import org.apache.gobblin.instrumented.Instrumented;
 import org.apache.gobblin.metrics.GobblinMetrics;
@@ -60,8 +60,6 @@ import org.apache.gobblin.stream.RecordEnvelope;
 import org.apache.gobblin.util.ConfigUtils;
 import org.apache.gobblin.util.ExecutorsUtils;
 import org.apache.gobblin.util.FinalState;
-import org.apache.gobblin.writer.exception.NonTransientException;
-
 
 /**
  * A Data Writer to use as a base for writing async writers.

--- a/gobblin-core/build.gradle
+++ b/gobblin-core/build.gradle
@@ -53,7 +53,6 @@ dependencies {
   compile externalDependency.scala
   compile externalDependency.lombok
   compile externalDependency.typesafeConfig
-  compile externalDependency.guavaretrying
   compile externalDependency.findBugsAnnotations
   compile externalDependency.oltu
   compile externalDependency.opencsv

--- a/gobblin-core/src/main/java/org/apache/gobblin/publisher/BaseDataPublisher.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/publisher/BaseDataPublisher.java
@@ -28,9 +28,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.gobblin.lineage.LineageInfo;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -43,14 +43,20 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.io.Closer;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigRenderOptions;
 
+import org.apache.gobblin.config.ConfigBuilder;
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.configuration.WorkUnitState;
+import org.apache.gobblin.lineage.LineageInfo;
 import org.apache.gobblin.metadata.MetadataMerger;
 import org.apache.gobblin.metadata.types.StaticStringMetadataMerger;
 import org.apache.gobblin.util.ForkOperatorUtils;
@@ -62,6 +68,7 @@ import org.apache.gobblin.writer.FsDataWriter;
 import org.apache.gobblin.writer.FsWriterMetrics;
 import org.apache.gobblin.writer.PartitionIdentifier;
 
+import static org.apache.gobblin.util.retry.RetryerFactory.*;
 
 /**
  * A basic implementation of {@link SingleTaskDataPublisher} that publishes the data from the writer output directory
@@ -105,6 +112,25 @@ public class BaseDataPublisher extends SingleTaskDataPublisher {
    * for aggregating this information from all workunits so it can be published.
    */
   protected final Map<PartitionIdentifier, MetadataMerger<String>> metadataMergers;
+  protected final boolean shouldRetry;
+
+  static final String DATA_PUBLISHER_RETRY_PREFIX = ConfigurationKeys.DATA_PUBLISHER_PREFIX + ".retry.";
+  static final String PUBLISH_RETRY_ENABLED = DATA_PUBLISHER_RETRY_PREFIX + "enabled";
+
+  static final Config PUBLISH_RETRY_DEFAULTS;
+  protected final Config retrierConfig;
+
+  static {
+    Map<String, Object> configMap =
+        ImmutableMap.<String, Object>builder()
+            .put(RETRY_TIME_OUT_MS, TimeUnit.MINUTES.toMillis(2L))   //Overall retry for 2 minutes
+            .put(RETRY_INTERVAL_MS, TimeUnit.SECONDS.toMillis(5L)) //Try to retry 5 seconds
+            .put(RETRY_MULTIPLIER, 2L) // Muliply by 2 every attempt
+            .put(RETRY_TYPE, RetryType.EXPONENTIAL.name())
+            .build();
+    PUBLISH_RETRY_DEFAULTS = ConfigFactory.parseMap(configMap);
+  };
+
 
   public BaseDataPublisher(State state)
       throws IOException {
@@ -118,6 +144,7 @@ public class BaseDataPublisher extends SingleTaskDataPublisher {
     }
 
     this.numBranches = this.getState().getPropAsInt(ConfigurationKeys.FORK_BRANCHES_KEY, 1);
+    this.shouldRetry = this.getState().getPropAsBoolean(PUBLISH_RETRY_ENABLED, false);
 
     this.writerFileSystemByBranches = Lists.newArrayListWithCapacity(this.numBranches);
     this.publisherFileSystemByBranches = Lists.newArrayListWithCapacity(this.numBranches);
@@ -150,6 +177,19 @@ public class BaseDataPublisher extends SingleTaskDataPublisher {
           ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.DATA_PUBLISHER_PERMISSIONS, this.numBranches, i),
           FsPermission.getDefault().toShort(), ConfigurationKeys.PERMISSION_PARSING_RADIX)));
     }
+
+    if (this.shouldRetry) {
+      this.retrierConfig = ConfigBuilder.create()
+          .loadProps(this.getState().getProperties(), DATA_PUBLISHER_RETRY_PREFIX)
+          .build()
+          .withFallback(PUBLISH_RETRY_DEFAULTS);
+      LOG.info("Retry enabled for publish with config : "+ retrierConfig.root().render(ConfigRenderOptions.concise()));
+
+    }else {
+      LOG.info("Retry disabled for publish.");
+      this.retrierConfig = WriterUtils.NO_RETRY_CONFIG;
+    }
+
 
     this.parallelRunnerThreads =
         state.getPropAsInt(ParallelRunner.PARALLEL_RUNNER_THREADS_KEY, ParallelRunner.DEFAULT_PARALLEL_RUNNER_THREADS);
@@ -312,8 +352,8 @@ public class BaseDataPublisher extends SingleTaskDataPublisher {
 
     if (publishSingleTaskData) {
       // Create final output directory
-      WriterUtils.mkdirsWithRecursivePermission(this.publisherFileSystemByBranches.get(branchId), publisherOutputDir,
-          this.permissions.get(branchId));
+      WriterUtils.mkdirsWithRecursivePermissionWithRetry(this.publisherFileSystemByBranches.get(branchId), publisherOutputDir,
+          this.permissions.get(branchId), retrierConfig);
       addSingleTaskWriterOutputToExistingDir(writerOutputDir, publisherOutputDir, state, branchId, parallelRunner);
     } else {
       if (writerOutputPathsMoved.contains(writerOutputDir)) {
@@ -341,8 +381,8 @@ public class BaseDataPublisher extends SingleTaskDataPublisher {
         this.publisherFileSystemByBranches.get(branchId).delete(publisherOutputDir, true);
       } else {
         // Create the parent directory of the final output directory if it does not exist
-        WriterUtils.mkdirsWithRecursivePermission(this.publisherFileSystemByBranches.get(branchId),
-            publisherOutputDir.getParent(), this.permissions.get(branchId));
+        WriterUtils.mkdirsWithRecursivePermissionWithRetry(this.publisherFileSystemByBranches.get(branchId),
+            publisherOutputDir.getParent(), this.permissions.get(branchId), retrierConfig);
       }
 
       movePath(parallelRunner, state, writerOutputDir, publisherOutputDir, branchId);
@@ -392,8 +432,8 @@ public class BaseDataPublisher extends SingleTaskDataPublisher {
       String pathSuffix = taskOutputFile
           .substring(taskOutputFile.indexOf(writerOutputDir.toString()) + writerOutputDir.toString().length() + 1);
       Path publisherOutputPath = new Path(publisherOutputDir, pathSuffix);
-      WriterUtils.mkdirsWithRecursivePermission(this.publisherFileSystemByBranches.get(branchId),
-          publisherOutputPath.getParent(), this.permissions.get(branchId));
+      WriterUtils.mkdirsWithRecursivePermissionWithRetry(this.publisherFileSystemByBranches.get(branchId),
+          publisherOutputPath.getParent(), this.permissions.get(branchId), retrierConfig);
 
       movePath(parallelRunner, workUnitState, taskOutputPath, publisherOutputPath, branchId);
     }
@@ -588,9 +628,9 @@ public class BaseDataPublisher extends SingleTaskDataPublisher {
 
       FileSystem fs = this.metaDataWriterFileSystemByBranches.get(branchId);
 
-      if (!fs.exists(metadataOutputPath.getParent())) {
-        WriterUtils.mkdirsWithRecursivePermission(fs, metadataOutputPath, this.permissions.get(branchId));
-      }
+        if (!fs.exists(metadataOutputPath.getParent())) {
+          WriterUtils.mkdirsWithRecursivePermissionWithRetry(fs, metadataOutputPath, this.permissions.get(branchId), retrierConfig);
+        }
 
       //Delete the file if metadata already exists
       if (fs.exists(metadataOutputPath)) {

--- a/gobblin-core/src/main/java/org/apache/gobblin/publisher/TimePartitionedDataPublisher.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/publisher/TimePartitionedDataPublisher.java
@@ -59,8 +59,8 @@ public class TimePartitionedDataPublisher extends BaseDataPublisher {
           filePathStr.substring(filePathStr.indexOf(writerOutput.toString()) + writerOutput.toString().length() + 1);
       Path outputPath = new Path(publisherOutput, pathSuffix);
 
-      WriterUtils.mkdirsWithRecursivePermission(this.publisherFileSystemByBranches.get(branchId), outputPath.getParent(),
-          this.permissions.get(branchId));
+      WriterUtils.mkdirsWithRecursivePermissionWithRetry(this.publisherFileSystemByBranches.get(branchId), outputPath.getParent(),
+            this.permissions.get(branchId), this.retrierConfig);
 
       movePath(parallelRunner, workUnitState, status.getPath(), outputPath, branchId);
     }

--- a/gobblin-core/src/main/java/org/apache/gobblin/publisher/TimestampDataPublisher.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/publisher/TimestampDataPublisher.java
@@ -52,8 +52,8 @@ public class TimestampDataPublisher extends BaseDataPublisher {
       Set<Path> writerOutputPathsMoved) throws IOException {
     Path publisherOutputDir = getPublisherOutputDir(state, branchId);
     if (!this.publisherFileSystemByBranches.get(branchId).exists(publisherOutputDir)) {
-      WriterUtils.mkdirsWithRecursivePermission(this.publisherFileSystemByBranches.get(branchId),
-          publisherOutputDir, this.permissions.get(branchId));
+      WriterUtils.mkdirsWithRecursivePermissionWithRetry(this.publisherFileSystemByBranches.get(branchId),
+          publisherOutputDir, this.permissions.get(branchId), this.retrierConfig);
     }
     super.publishData(state, branchId, publishSingleTaskData, writerOutputPathsMoved);
   }
@@ -74,8 +74,8 @@ public class TimestampDataPublisher extends BaseDataPublisher {
     Path newDst = new Path(new Path(outputDir, getDbTableName(schemaName)), timestamp);
 
     if (!this.publisherFileSystemByBranches.get(branchId).exists(newDst)) {
-      WriterUtils.mkdirsWithRecursivePermission(this.publisherFileSystemByBranches.get(branchId),
-          newDst.getParent(), this.permissions.get(branchId));
+      WriterUtils.mkdirsWithRecursivePermissionWithRetry(this.publisherFileSystemByBranches.get(branchId),
+          newDst.getParent(), this.permissions.get(branchId), this.retrierConfig);
     }
 
     super.movePath(parallelRunner, state, src, newDst, branchId);

--- a/gobblin-core/src/main/java/org/apache/gobblin/writer/RetryWriter.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/writer/RetryWriter.java
@@ -37,12 +37,12 @@ import com.google.common.base.Predicate;
 
 import org.apache.gobblin.commit.SpeculativeAttemptAwareConstruct;
 import org.apache.gobblin.configuration.State;
+import org.apache.gobblin.exception.NonTransientException;
 import org.apache.gobblin.instrumented.Instrumented;
 import org.apache.gobblin.metrics.GobblinMetrics;
 import org.apache.gobblin.records.ControlMessageHandler;
 import org.apache.gobblin.stream.RecordEnvelope;
 import org.apache.gobblin.util.FinalState;
-import org.apache.gobblin.writer.exception.NonTransientException;
 
 /**
  * Retry writer follows decorator pattern that retries on inner writer's failure.

--- a/gobblin-core/src/main/java/org/apache/gobblin/writer/http/SalesforceRestWriter.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/writer/http/SalesforceRestWriter.java
@@ -20,9 +20,11 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.gobblin.converter.http.RestEntry;
+import org.apache.gobblin.exception.NonTransientException;
 import org.apache.http.HttpHeaders;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpUriRequest;
@@ -46,9 +48,6 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-
-import org.apache.gobblin.converter.http.RestEntry;
-import org.apache.gobblin.writer.exception.NonTransientException;
 
 /**
  * Writes to Salesforce via RESTful API, supporting INSERT_ONLY_NOT_EXIST, and UPSERT.

--- a/gobblin-core/src/test/java/org/apache/gobblin/writer/RetryWriterTest.java
+++ b/gobblin-core/src/test/java/org/apache/gobblin/writer/RetryWriterTest.java
@@ -16,17 +16,17 @@
  */
 package org.apache.gobblin.writer;
 
-import static org.mockito.Mockito.*;
-
 import java.io.IOException;
-
-import org.apache.gobblin.configuration.State;
-import org.apache.gobblin.stream.RecordEnvelope;
-import org.apache.gobblin.writer.exception.NonTransientException;
-import org.apache.gobblin.util.FinalState;
 
 import org.junit.Assert;
 import org.testng.annotations.Test;
+
+import org.apache.gobblin.configuration.State;
+import org.apache.gobblin.exception.NonTransientException;
+import org.apache.gobblin.stream.RecordEnvelope;
+import org.apache.gobblin.util.FinalState;
+
+import static org.mockito.Mockito.*;
 
 @Test(groups = { "gobblin.writer" })
 public class RetryWriterTest {

--- a/gobblin-modules/google-ingestion/src/main/java/org/apache/gobblin/source/extractor/extract/google/GoogleAnalyticsUnsampledExtractor.java
+++ b/gobblin-modules/google-ingestion/src/main/java/org/apache/gobblin/source/extractor/extract/google/GoogleAnalyticsUnsampledExtractor.java
@@ -35,8 +35,8 @@ import com.github.rholder.retry.RetryException;
 import com.github.rholder.retry.Retryer;
 import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.services.analytics.Analytics;
-import com.google.api.services.analytics.model.UnsampledReport;
 import com.google.api.services.analytics.Analytics.Management.UnsampledReports.Insert;
+import com.google.api.services.analytics.model.UnsampledReport;
 import com.google.api.services.drive.Drive;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
@@ -47,22 +47,23 @@ import com.google.common.io.Closer;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
-import static org.apache.gobblin.retry.RetryerFactory.*;
-import static org.apache.gobblin.configuration.ConfigurationKeys.*;
-import static org.apache.gobblin.source.extractor.extract.google.GoogleCommonKeys.*;
-import static org.apache.gobblin.source.extractor.extract.google.GoogleAnalyticsUnsampledSource.*;
 import org.apache.gobblin.config.ConfigBuilder;
 import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.configuration.WorkUnitState;
+import org.apache.gobblin.exception.NonTransientException;
 import org.apache.gobblin.instrumented.Instrumented;
 import org.apache.gobblin.metrics.GobblinMetrics;
-import org.apache.gobblin.retry.RetryerFactory;
 import org.apache.gobblin.source.extractor.DataRecordException;
 import org.apache.gobblin.source.extractor.Extractor;
 import org.apache.gobblin.source.extractor.extract.LongWatermark;
 import org.apache.gobblin.source.extractor.filebased.CsvFileDownloader;
 import org.apache.gobblin.source.workunit.WorkUnit;
-import org.apache.gobblin.writer.exception.NonTransientException;
+import org.apache.gobblin.util.retry.RetryerFactory;
+
+import static org.apache.gobblin.configuration.ConfigurationKeys.*;
+import static org.apache.gobblin.source.extractor.extract.google.GoogleAnalyticsUnsampledSource.*;
+import static org.apache.gobblin.source.extractor.extract.google.GoogleCommonKeys.*;
+import static org.apache.gobblin.util.retry.RetryerFactory.*;
 
 /**
  * Extracts Google Analytics(GA) unsampled report data.

--- a/gobblin-modules/google-ingestion/src/test/java/org/apache/gobblin/source/extractor/extract/google/GoogleAnalyticsUnsampledExtractorTest.java
+++ b/gobblin-modules/google-ingestion/src/test/java/org/apache/gobblin/source/extractor/extract/google/GoogleAnalyticsUnsampledExtractorTest.java
@@ -34,11 +34,17 @@ import com.google.api.services.analytics.Analytics.Management.UnsampledReports.G
 import com.google.api.services.analytics.model.UnsampledReport;
 import com.google.api.services.analytics.model.UnsampledReport.DriveDownloadDetails;
 
-import static org.apache.gobblin.retry.RetryerFactory.*;
-import static org.apache.gobblin.source.extractor.extract.google.GoogleAnalyticsUnsampledExtractor.*;
 import org.apache.gobblin.configuration.WorkUnitState;
+import org.apache.gobblin.exception.NonTransientException;
 import org.apache.gobblin.source.extractor.Extractor;
-import org.apache.gobblin.writer.exception.NonTransientException;
+
+import static org.apache.gobblin.source.extractor.extract.google.GoogleAnalyticsUnsampledExtractor.DOWNLOAD_TYPE_GOOGLE_DRIVE;
+import static org.apache.gobblin.source.extractor.extract.google.GoogleAnalyticsUnsampledExtractor.POLL_RETRY_PREFIX;
+import static org.apache.gobblin.source.extractor.extract.google.GoogleAnalyticsUnsampledExtractor.ReportCreationStatus;
+import static org.apache.gobblin.util.retry.RetryerFactory.RETRY_INTERVAL_MS;
+import static org.apache.gobblin.util.retry.RetryerFactory.RETRY_TIME_OUT_MS;
+import static org.mockito.Mockito.*;
+
 
 @Test(groups = { "gobblin.source.extractor.google" })
 public class GoogleAnalyticsUnsampledExtractorTest {

--- a/gobblin-utility/build.gradle
+++ b/gobblin-utility/build.gradle
@@ -35,6 +35,7 @@ dependencies {
   compile externalDependency.jasypt
   compile externalDependency.lombok
   compile externalDependency.metricsCore
+  compile externalDependency.guavaretrying
   compile externalDependency.guice
   compile externalDependency.typesafeConfig
   compile externalDependency.commonsPool

--- a/gobblin-utility/src/main/java/org/apache/gobblin/exception/NonTransientException.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/exception/NonTransientException.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.gobblin.writer.exception;
+package org.apache.gobblin.exception;
 
 /**
  * NonTransientException that shows this is a permanent failure where retry cannot solve.

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/recordcount/CompactionRecordCountProvider.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/recordcount/CompactionRecordCountProvider.java
@@ -20,11 +20,10 @@ package org.apache.gobblin.util.recordcount;
 import java.util.Random;
 import java.util.regex.Pattern;
 
+import org.apache.gobblin.util.RecordCountProvider;
 import org.apache.hadoop.fs.Path;
 
 import com.google.common.base.Preconditions;
-
-import org.apache.gobblin.util.RecordCountProvider;
 
 
 /**
@@ -46,6 +45,13 @@ public class CompactionRecordCountProvider extends RecordCountProvider {
    * Construct the file name as {filenamePrefix}{recordCount}.{SystemCurrentTimeInMills}.{RandomInteger}{SUFFIX}.
    */
   public static String constructFileName(String filenamePrefix, long recordCount) {
+    return constructFileName(filenamePrefix, SUFFIX, recordCount);
+  }
+
+  /**
+   * Construct the file name as {filenamePrefix}{recordCount}.{SystemCurrentTimeInMills}.{RandomInteger}{extension}.
+   */
+  public static String constructFileName(String filenamePrefix, String extension, long recordCount) {
     Preconditions.checkArgument(
         filenamePrefix.equals(M_OUTPUT_FILE_PREFIX) || filenamePrefix.equals(MR_OUTPUT_FILE_PREFIX),
         String.format("%s is not a supported prefix, which should be %s, or %s.", filenamePrefix, M_OUTPUT_FILE_PREFIX,
@@ -57,9 +63,10 @@ public class CompactionRecordCountProvider extends RecordCountProvider {
     sb.append(Long.toString(System.currentTimeMillis()));
     sb.append(SEPARATOR);
     sb.append(Integer.toString(RANDOM.nextInt(Integer.MAX_VALUE)));
-    sb.append(SUFFIX);
+    sb.append(extension);
     return sb.toString();
   }
+
 
   /**
    * Get the record count through filename.
@@ -81,12 +88,11 @@ public class CompactionRecordCountProvider extends RecordCountProvider {
    * This method currently supports converting the given {@link Path} from {@link IngestionRecordCountProvider}.
    * The converted {@link Path} will start with {@link #M_OUTPUT_FILE_PREFIX}.
    */
-  @Override
-  public Path convertPath(Path path, RecordCountProvider src) {
+  public Path convertPath(Path path, String extension, RecordCountProvider src) {
     if (this.getClass().equals(src.getClass())) {
       return path;
     } else if (src.getClass().equals(IngestionRecordCountProvider.class)) {
-      String newFileName = constructFileName(M_OUTPUT_FILE_PREFIX, src.getRecordCount(path));
+      String newFileName = constructFileName(M_OUTPUT_FILE_PREFIX, extension, src.getRecordCount(path));
       return new Path(path.getParent(), newFileName);
     } else {
       throw getNotImplementedException(src);

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/retry/RetryerFactory.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/retry/RetryerFactory.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.gobblin.retry;
+package org.apache.gobblin.util.retry;
 
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -31,7 +31,7 @@ import com.google.common.collect.ImmutableMap;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
-import org.apache.gobblin.writer.exception.NonTransientException;
+import org.apache.gobblin.exception.NonTransientException;
 
 /**
  * Factory class that builds Retryer.


### PR DESCRIPTION
In our environment we use Gobblin for shipping logs to s3. Gobblin on it's own works pretty well but at a couple of place it assumes the underlying fs is consistent which is not true in some case like in some S3 region.
To overcome this I added a couple of retry if the created dir/file fails to exist right away after publish.
The following changes were added:
- Refactored RetryWriter to gobblin-core to be able use in WriterUtils and not having circular dependencies.
- Introducing mkdirsWithRecursivePermissionWithRetry to be able set retry if directory does not exists right after creation on eventual consistent fs.
- Adding retry to publisher (data.publisher.retry.enabled=true) like TimestampDataPublisher, TimePartitinedDataPublisher to support eventual consisteny filesystem targets
- Tmp fs can be specified with compaction.tmp.fs in compaction job to be able use hdfs for tmp fs and store result on S3. Earlier it was not possible to use differnet fs for tmp and target.
- Retry can be set for compaction if you don't want to fail right away if directory fails to show up right away which can happen on eventual consistent fs (compaction.retry.enabled=true)
- Adding dataset name for compaction mr job name which makes significantly easier to identify which compaction job belongs to which dataset.
- Some minor modification to support non avro extensions