### PR TITLE
Add lead time functionality to DatePartitionedRetrievers

### DIFF
--- a/gobblin-core/src/main/java/gobblin/source/PartitionAwareFileRetrieverUtils.java
+++ b/gobblin-core/src/main/java/gobblin/source/PartitionAwareFileRetrieverUtils.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gobblin.source;
+
+import org.joda.time.Duration;
+
+import gobblin.configuration.State;
+import gobblin.util.DatePartitionType;
+
+import static gobblin.source.PartitionedFileSourceBase.DATE_PARTITIONED_SOURCE_PARTITION_LEAD_TIME;
+import static gobblin.source.PartitionedFileSourceBase.DATE_PARTITIONED_SOURCE_PARTITION_LEAD_TIME_GRANULARITY;
+import static gobblin.source.PartitionedFileSourceBase.DEFAULT_DATE_PARTITIONED_SOURCE_PARTITION_LEAD_TIME_GRANULARITY;
+import static gobblin.source.PartitionedFileSourceBase.DEFAULT_PARTITIONED_SOURCE_PARTITION_LEAD_TIME;
+
+
+/**
+ * Utility functions for parsing configuration parameters commonly used by {@link PartitionAwareFileRetriever}
+ * objects.
+ */
+public class PartitionAwareFileRetrieverUtils {
+  /**
+   * Retrieve the lead time duration from the LEAD_TIME and LEAD_TIME granularity config settings.
+   * @param state
+   * @return
+   */
+  public static Duration getLeadTimeDurationFromConfig(State state) {
+    String leadTimeProp = state.getProp(DATE_PARTITIONED_SOURCE_PARTITION_LEAD_TIME);
+    if (leadTimeProp == null || leadTimeProp.length() == 0) {
+      return DEFAULT_PARTITIONED_SOURCE_PARTITION_LEAD_TIME;
+    }
+
+    int leadTime = Integer.parseInt(leadTimeProp);
+
+    DatePartitionType leadTimeGranularity = DEFAULT_DATE_PARTITIONED_SOURCE_PARTITION_LEAD_TIME_GRANULARITY;
+
+    String leadTimeGranularityProp = state.getProp(DATE_PARTITIONED_SOURCE_PARTITION_LEAD_TIME_GRANULARITY);
+    if (leadTimeGranularityProp != null) {
+      leadTimeGranularity = DatePartitionType.valueOf(leadTimeGranularityProp);
+    }
+
+    return new Duration(leadTime * leadTimeGranularity.getUnitMilliseconds());
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/source/PartitionAwareFileRetrieverUtils.java
+++ b/gobblin-core/src/main/java/gobblin/source/PartitionAwareFileRetrieverUtils.java
@@ -34,8 +34,6 @@ import static gobblin.source.PartitionedFileSourceBase.DEFAULT_PARTITIONED_SOURC
 public class PartitionAwareFileRetrieverUtils {
   /**
    * Retrieve the lead time duration from the LEAD_TIME and LEAD_TIME granularity config settings.
-   * @param state
-   * @return
    */
   public static Duration getLeadTimeDurationFromConfig(State state) {
     String leadTimeProp = state.getProp(DATE_PARTITIONED_SOURCE_PARTITION_LEAD_TIME);

--- a/gobblin-core/src/main/java/gobblin/source/PartitionedFileSourceBase.java
+++ b/gobblin-core/src/main/java/gobblin/source/PartitionedFileSourceBase.java
@@ -25,6 +25,7 @@ import java.util.Map;
 
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.joda.time.Duration;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 import org.slf4j.Logger;
@@ -75,6 +76,21 @@ public abstract class PartitionedFileSourceBase<SCHEMA, DATA> extends FileBasedS
       DATE_PARTITIONED_SOURCE_PREFIX + ".partition.granularity";
   public static final DatePartitionType DEFAULT_DATE_PARTITIONED_SOURCE_PARTITION_GRANULARITY =
       DatePartitionType.HOUR;
+
+  /**
+   * The partition 'lead time' allows a job to ignore a date partition for a given amount of time.
+   * For example, if the lead_time is set to 1 day and the job is run on Jul 1 2017 at 2am, the job
+   * will only process partitions from Jun 30 2017 at 2am and before.
+   */
+  public static final String DATE_PARTITIONED_SOURCE_PARTITION_LEAD_TIME =
+      DATE_PARTITIONED_SOURCE_PREFIX + ".partition.lead_time.size";
+  public static final Duration DEFAULT_PARTITIONED_SOURCE_PARTITION_LEAD_TIME = new Duration(0);
+
+  public static final String DATE_PARTITIONED_SOURCE_PARTITION_LEAD_TIME_GRANULARITY =
+      DATE_PARTITIONED_SOURCE_PREFIX + ".partition.lead_time.granularity";
+
+  public static final DatePartitionType DEFAULT_DATE_PARTITIONED_SOURCE_PARTITION_LEAD_TIME_GRANULARITY =
+      DEFAULT_DATE_PARTITIONED_SOURCE_PARTITION_GRANULARITY;
 
   /**
   * A String of the format defined by {@link #DATE_PARTITIONED_SOURCE_PARTITION_PATTERN} or

--- a/gobblin-core/src/main/java/gobblin/source/RegexBasedPartitionedRetriever.java
+++ b/gobblin-core/src/main/java/gobblin/source/RegexBasedPartitionedRetriever.java
@@ -91,14 +91,14 @@ public class RegexBasedPartitionedRetriever implements PartitionAwareFileRetriev
       throws IOException {
     // This implementation assumes snapshots are always in the root directory and the number of them
     // remains relatively small
-    long maxTimeToProcess = new DateTime().minus(leadTime).getMillis();
+    long maxAllowedWatermark = new DateTime().minus(leadTime).getMillis();
 
     try {
       this.helper.connect();
       FileSystem fs = helper.getFileSystem();
       List<FileInfo> filesToProcess = new ArrayList<>();
 
-      List<FileInfo> outerDirectories = getOuterDirectories(fs, minWatermark, maxTimeToProcess);
+      List<FileInfo> outerDirectories = getOuterDirectories(fs, minWatermark, maxAllowedWatermark);
       for (FileInfo outerDirectory: outerDirectories) {
         FileStatus[] files = fs.listStatus(
             new Path(outerDirectory.getFilePath()),

--- a/gobblin-core/src/main/java/gobblin/source/RegexBasedPartitionedRetriever.java
+++ b/gobblin-core/src/main/java/gobblin/source/RegexBasedPartitionedRetriever.java
@@ -27,6 +27,8 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathFilter;
+import org.joda.time.DateTime;
+import org.joda.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,6 +47,7 @@ public class RegexBasedPartitionedRetriever implements PartitionAwareFileRetriev
   private HadoopFsHelper helper;
   private Path sourceDir;
   private final String expectedExtension;
+  private Duration leadTime;
 
   public RegexBasedPartitionedRetriever(String expectedExtension) {
     this.expectedExtension = expectedExtension;
@@ -57,6 +60,7 @@ public class RegexBasedPartitionedRetriever implements PartitionAwareFileRetriev
       PartitionedFileSourceBase.DATE_PARTITIONED_SOURCE_PARTITION_PATTERN
     );
 
+    this.leadTime = PartitionAwareFileRetrieverUtils.getLeadTimeDurationFromConfig(state);
     this.pattern = Pattern.compile(regexPattern);
     this.helper = new HadoopFsHelper(state);
     this.sourceDir = new Path(state.getProp(ConfigurationKeys.SOURCE_FILEBASED_DATA_DIRECTORY));
@@ -87,12 +91,14 @@ public class RegexBasedPartitionedRetriever implements PartitionAwareFileRetriev
       throws IOException {
     // This implementation assumes snapshots are always in the root directory and the number of them
     // remains relatively small
+    long maxTimeToProcess = new DateTime().minus(leadTime).getMillis();
+
     try {
       this.helper.connect();
       FileSystem fs = helper.getFileSystem();
       List<FileInfo> filesToProcess = new ArrayList<>();
 
-      List<FileInfo> outerDirectories = getOuterDirectories(fs, minWatermark);
+      List<FileInfo> outerDirectories = getOuterDirectories(fs, minWatermark, maxTimeToProcess);
       for (FileInfo outerDirectory: outerDirectories) {
         FileStatus[] files = fs.listStatus(
             new Path(outerDirectory.getFilePath()),
@@ -117,7 +123,7 @@ public class RegexBasedPartitionedRetriever implements PartitionAwareFileRetriev
     }
   }
 
-  private List<FileInfo> getOuterDirectories(FileSystem fs, long minWatermark) throws IOException {
+  private List<FileInfo> getOuterDirectories(FileSystem fs, long minWatermark, long maxAllowedWatermark) throws IOException {
     LOGGER.debug("Listing contents of {}", sourceDir);
 
     FileStatus[] fileStatus = fs.listStatus(sourceDir);
@@ -133,7 +139,7 @@ public class RegexBasedPartitionedRetriever implements PartitionAwareFileRetriev
         long watermark = getWatermarkFromString(
             extractWatermarkFromDirectory(file.getPath().getName())
         );
-        if (watermark > minWatermark) {
+        if (watermark > minWatermark && watermark < maxAllowedWatermark) {
           LOGGER.info("Processing directory {} with watermark {}",
               file.getPath(),
               watermark);
@@ -143,8 +149,8 @@ public class RegexBasedPartitionedRetriever implements PartitionAwareFileRetriev
               watermark
           ));
         } else {
-          LOGGER.info("Ignoring directory {} - watermark {} is less than minWatermark {}", file.getPath(), watermark,
-              minWatermark);
+          LOGGER.info("Ignoring directory {} - watermark {} is not between minWatermark {} and (now-leadTime) {}",
+              file.getPath(), watermark, minWatermark, maxAllowedWatermark);
         }
       } catch (IllegalArgumentException e) {
         LOGGER.info("Directory {} ({}) does not match pattern {}; skipping", file.getPath().getName(),

--- a/gobblin-utility/src/main/java/gobblin/util/DatePartitionType.java
+++ b/gobblin-utility/src/main/java/gobblin/util/DatePartitionType.java
@@ -17,12 +17,13 @@ import java.util.Map;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeFieldType;
+import org.joda.time.chrono.ISOChronology;
 
 
 /**
  * Temporal granularity types for writing ({@link gobblin.writer.partitioner.TimeBasedWriterPartitioner}) and reading
  * ({@link gobblin.source.DatePartitionedAvroFileSource}) date partitioned data.
- * 
+ *
  * @author Lorand Bendig
  *
  */
@@ -62,7 +63,7 @@ public enum DatePartitionType {
 
   /**
    * @param pattern full partitioning pattern
-   * @return a DateTimeFieldType corresponding to the smallest temporal unit in the pattern. 
+   * @return a DateTimeFieldType corresponding to the smallest temporal unit in the pattern.
    * E.g for yyyy/MM/dd {@link DateTimeFieldType#dayOfMonth()}
    */
   public static DateTimeFieldType getLowestIntervalUnit(String pattern) {
@@ -75,15 +76,23 @@ public enum DatePartitionType {
     }
     return intervalUnit;
   }
-  
+
+  /**
+   * Get the number of milliseconds associated with a partition type. Eg
+   * getUnitMilliseconds() of DatePartitionType.MINUTE = 60,000.
+   */
+  public long getUnitMilliseconds() {
+    return dateTimeField.getDurationType().getField(ISOChronology.getInstance()).getUnitMillis();
+  }
+
   public DateTimeFieldType getDateTimeFieldType() {
     return dateTimeField;
   }
-  
+
   public int getField(DateTime dateTime) {
     return dateTime.get(this.dateTimeField);
   }
-  
+
   public String getDateTimePattern() {
     return dateTimePattern;
   }

--- a/gobblin-utility/src/test/java/gobblin/util/DatePartitionTypeTest.java
+++ b/gobblin-utility/src/test/java/gobblin/util/DatePartitionTypeTest.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gobblin.util;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class DatePartitionTypeTest {
+  @Test
+  public void testGetMillis() {
+    Assert.assertEquals(DatePartitionType.MINUTE.getUnitMilliseconds(), 60000L);
+    Assert.assertEquals(DatePartitionType.HOUR.getUnitMilliseconds(), 60 * 60 * 1000L);
+  }
+}


### PR DESCRIPTION
Add lead time functionality to DatePartitionedRetrievers. Directories
that were created after (now() - lead time) will be ignored by the
source.

 - If anyone can think of better naming than 'lead time' please let me know - thought about using maxWatermark but I figured that could be confusing
 - I put the config parsing code in a separate class to be consistent with other pieces of Gobblin, although I know there could be an argument for just putting the method as part of the PartitionAwareFileRetriever interface
