### PR TITLE
[GOBBLIN-174] fix distcp-ng, so it does not remove existing target files

### DIFF
--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveCopyEntityHelper.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveCopyEntityHelper.java
@@ -619,10 +619,27 @@ public class HiveCopyEntityHelper {
       if (shouldCopy) {
         builder.copyFile(sourcePath);
       } else {
-        // if not copying, we want to keep the file in the target
+        // If not copying, we want to keep the file in the target
         // at the end of this loop, all files in targetExistingPaths will be marked for deletion, so remove this file
         targetExistingPaths.remove(newPath);
         desiredTargetExistingPaths.remove(newPath);
+      }
+
+      // If target already has the path and it should be copied,
+      // delete the existing target path, even if deleteMethod is NO_DELETE
+      if (targetExistingPaths.containsKey(newPath) && shouldCopy) {
+        builder.deleteFile(newPath);
+        targetExistingPaths.remove(newPath);
+        desiredTargetExistingPaths.remove(newPath);
+      }
+    }
+
+    // If deleteMethod is NO_DELETE, clear targetExistingPaths,
+    // so nothing goes to pathsToDelete
+    if (helper.deleteMethod == DeregisterFileDeleteMethod.NO_DELETE) {
+      for (Path delete : targetExistingPaths.keySet()) {
+        targetExistingPaths.remove(delete);
+        desiredTargetExistingPaths.remove(delete);
       }
     }
 

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveCopyEntityHelper.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveCopyEntityHelper.java
@@ -624,23 +624,6 @@ public class HiveCopyEntityHelper {
         targetExistingPaths.remove(newPath);
         desiredTargetExistingPaths.remove(newPath);
       }
-
-      // If target already has the path and it should be copied,
-      // delete the existing target path, even if deleteMethod is NO_DELETE
-      if (targetExistingPaths.containsKey(newPath) && shouldCopy) {
-        builder.deleteFile(newPath);
-        targetExistingPaths.remove(newPath);
-        desiredTargetExistingPaths.remove(newPath);
-      }
-    }
-
-    // If deleteMethod is NO_DELETE, clear targetExistingPaths,
-    // so nothing goes to pathsToDelete
-    if (helper.deleteMethod == DeregisterFileDeleteMethod.NO_DELETE) {
-      for (Path delete : targetExistingPaths.keySet()) {
-        targetExistingPaths.remove(delete);
-        desiredTargetExistingPaths.remove(delete);
-      }
     }
 
     multiTimer.nextStage(Stages.COMPUTE_DELETE_PATHS);

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/UnpartitionedTableFileSet.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/UnpartitionedTableFileSet.java
@@ -70,6 +70,7 @@ public class UnpartitionedTableFileSet extends HiveFileSet {
             // Update the location of files while keep the existing table entity.
             log.warn("Source table will not be deregistered while file locaiton has been changed, update source table's"
                 + " file location to" + this.helper.getTargetTable().getDataLocation());
+            existingTargetTable = Optional.absent();
             break ;
           case REPLACE_TABLE:
             // Required to de-register the original table.


### PR DESCRIPTION
fixing fullPathdiff() so it does not remove existing target files in case NO_DELETE delete method is specified.

@abti  @ibuenros  Kindly review.