### PR TITLE
[GOBBLIN-173] Add pattern support for job-level blacklist in distcpNG/replication

### DIFF
--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/replication/ConfigBasedCopyableDatasetFinder.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/replication/ConfigBasedCopyableDatasetFinder.java
@@ -49,15 +49,14 @@ public class ConfigBasedCopyableDatasetFinder extends ConfigBasedDatasetsFinder 
   }
 
   protected Callable<Void> findDatasetsCallable(final ConfigClient confClient,
-      final URI u, final Properties p, Optional<List<String>> blacklistPatterns, Optional<List<String>> whitelistPatterns,
-      final Collection<Dataset> datasets) {
+      final URI u, final Properties p, Optional<List<String>> blacklistPatterns, final Collection<Dataset> datasets) {
     return new Callable<Void>() {
       @Override
       public Void call() throws Exception {
         // Process each {@link Config}, find dataset and add those into the datasets
         Config c = confClient.getConfig(u);
         List<Dataset> datasetForConfig =
-            new ConfigBasedMultiDatasets(c, p, blacklistPatterns, whitelistPatterns).getConfigBasedDatasetList();
+            new ConfigBasedMultiDatasets(c, p, blacklistPatterns).getConfigBasedDatasetList();
         datasets.addAll(datasetForConfig);
         return null;
       }

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/replication/ConfigBasedDataset.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/replication/ConfigBasedDataset.java
@@ -81,6 +81,13 @@ public class ConfigBasedDataset implements CopyableDataset {
     calculateDatasetURN();
   }
 
+  public ConfigBasedDataset(ReplicationConfiguration rc, Properties props, CopyRoute copyRoute, String datasetURN) {
+    this.props = props;
+    this.copyRoute = copyRoute;
+    this.rc = rc;
+    this.datasetURN = datasetURN;
+  }
+
   private void calculateDatasetURN(){
     EndPoint e = this.copyRoute.getCopyTo();
     if (e instanceof HadoopFsEndPoint) {

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/replication/ConfigBasedDataset.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/replication/ConfigBasedDataset.java
@@ -70,14 +70,11 @@ public class ConfigBasedDataset implements CopyableDataset {
   private final CopyRoute copyRoute;
   private final ReplicationConfiguration rc;
   private String datasetURN;
-  private boolean watermarkEnabled;
 
   public ConfigBasedDataset(ReplicationConfiguration rc, Properties props, CopyRoute copyRoute) {
     this.props = props;
     this.copyRoute = copyRoute;
     this.rc = rc;
-    this.watermarkEnabled = Boolean.parseBoolean
-        (this.props.getProperty(ConfigBasedDatasetsFinder.WATERMARK_ENABLE, "true"));
     calculateDatasetURN();
   }
 
@@ -120,16 +117,14 @@ public class ConfigBasedDataset implements CopyableDataset {
       return copyableFiles;
     }
 
-    if (this.watermarkEnabled) {
-      if ((!copyFromRaw.getWatermark().isPresent() && copyToRaw.getWatermark().isPresent()) || (
-          copyFromRaw.getWatermark().isPresent() && copyToRaw.getWatermark().isPresent()
-              && copyFromRaw.getWatermark().get().compareTo(copyToRaw.getWatermark().get()) <= 0)) {
-        log.info(
-            "No need to copy as destination watermark >= source watermark with source watermark {}, for dataset with metadata {}",
-            copyFromRaw.getWatermark().isPresent() ? copyFromRaw.getWatermark().get().toJson() : "N/A",
-            this.rc.getMetaData());
-        return copyableFiles;
-      }
+    if ((!copyFromRaw.getWatermark().isPresent() && copyToRaw.getWatermark().isPresent())
+        || (copyFromRaw.getWatermark().isPresent() && copyToRaw.getWatermark().isPresent()
+            && copyFromRaw.getWatermark().get().compareTo(copyToRaw.getWatermark().get()) <= 0)) {
+      log.info(
+          "No need to copy as destination watermark >= source watermark with source watermark {}, for dataset with metadata {}",
+          copyFromRaw.getWatermark().isPresent() ? copyFromRaw.getWatermark().get().toJson() : "N/A",
+          this.rc.getMetaData());
+      return copyableFiles;
     }
 
     HadoopFsEndPoint copyFrom = (HadoopFsEndPoint) copyFromRaw;
@@ -206,7 +201,7 @@ public class ConfigBasedDataset implements CopyableDataset {
           deleteCommitStep, 0));
     }
 
-    // generate the watermark file even if watermark checking is disabled. Make sure it can come into functional once disired.
+    // generate the watermark file
     if ((!watermarkMetadataCopied) && copyFrom.getWatermark().isPresent()) {
       copyableFiles.add(new PostPublishStep(copyTo.getDatasetPath().toString(), Maps.<String, String> newHashMap(),
           new WatermarkMetadataGenerationCommitStep(copyTo.getFsURI().toString(), copyTo.getDatasetPath(),

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/replication/ConfigBasedDatasetsFinder.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/replication/ConfigBasedDatasetsFinder.java
@@ -154,9 +154,10 @@ public abstract class ConfigBasedDatasetsFinder implements DatasetsFinder {
   }
 
   /**
-   * Semantic of two-level black/whitelist:
+   * Semantic of black/whitelist:
    * - Whitelist always respect blacklist.
-   * - Job-level black/whitelist is NOT OVERRIDING dataset-level black/whitelist but enhance it.
+   * - Job-level blacklist is reponsible for dataset filtering instead of dataset discovery. i.e.
+   *   There's no implementation of job-level whitelist currently. 
    */
   protected Set<URI> getValidDatasetURIs(Path datasetCommonRoot) {
     Collection<URI> allDatasetURIs;

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/replication/ConfigBasedDatasetsFinder.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/replication/ConfigBasedDatasetsFinder.java
@@ -95,6 +95,11 @@ public abstract class ConfigBasedDatasetsFinder implements DatasetsFinder {
   // Tag-based dataset discover happens at the first, before the job-level glob-pattern based filtering.
   public static final String JOB_LEVEL_BLACKLIST = CopyConfiguration.COPY_PREFIX + ".configBased.blacklist" ;
 
+  // There are some cases that WATERMARK checking is desired, like
+  // Unexpected data loss on target while not changing watermark accordingly.
+  // This configuration make WATERMARK checking configurable for operation convenience, default true
+  public static final String WATERMARK_ENABLE = CopyConfiguration.COPY_PREFIX + ".configBased.watermark.enabled" ;
+
 
   protected final String storeRoot;
   protected final Path commonRoot;

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/replication/ConfigBasedDatasetsFinder.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/replication/ConfigBasedDatasetsFinder.java
@@ -108,9 +108,11 @@ public abstract class ConfigBasedDatasetsFinder implements DatasetsFinder {
   protected final ConfigClient configClient;
   protected final Properties props;
   private final int threadPoolSize;
-  private FileSystem fs;
 
-  public final Optional<List<String>> blacklistPatterns;
+  /**
+   * The blacklist Pattern, will be used in ConfigBasedDataset class which has the access to FileSystem.
+   */
+  private final Optional<List<String>> blacklistPatterns;
 
 
   public ConfigBasedDatasetsFinder(FileSystem fs, Properties jobProps) throws IOException {
@@ -123,7 +125,6 @@ public abstract class ConfigBasedDatasetsFinder implements DatasetsFinder {
     Preconditions.checkArgument(jobProps.containsKey(GOBBLIN_CONFIG_STORE_DATASET_COMMON_ROOT),
         "missing required config entery " + GOBBLIN_CONFIG_STORE_DATASET_COMMON_ROOT);
 
-    this.fs = fs;
     this.storeRoot = jobProps.getProperty(ConfigurationKeys.CONFIG_MANAGEMENT_STORE_URI);
     this.commonRoot = PathUtils.mergePaths(new Path(this.storeRoot),
         new Path(jobProps.getProperty(GOBBLIN_CONFIG_STORE_DATASET_COMMON_ROOT)));
@@ -162,7 +163,7 @@ public abstract class ConfigBasedDatasetsFinder implements DatasetsFinder {
    * Semantic of black/whitelist:
    * - Whitelist always respect blacklist.
    * - Job-level blacklist is reponsible for dataset filtering instead of dataset discovery. i.e.
-   *   There's no implementation of job-level whitelist currently. 
+   *   There's no implementation of job-level whitelist currently.
    */
   protected Set<URI> getValidDatasetURIs(Path datasetCommonRoot) {
     Collection<URI> allDatasetURIs;

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/replication/ConfigBasedMultiDatasets.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/replication/ConfigBasedMultiDatasets.java
@@ -55,7 +55,6 @@ public class ConfigBasedMultiDatasets {
   private final Properties props;
   private final List<Dataset> datasets = new ArrayList<>();
   private Optional<List<Pattern>> blacklist = Optional.of(new ArrayList<>());
-  private Optional<List<Pattern>> whitelist = Optional.of(new ArrayList<>());
 
 
   /**
@@ -71,7 +70,7 @@ public class ConfigBasedMultiDatasets {
   }
 
   public ConfigBasedMultiDatasets (Config c, Properties props,
-      Optional<List<String>> blacklistPatterns, Optional<List<String>> whitelistPatterns){
+      Optional<List<String>> blacklistPatterns){
     this.props = props;
     blacklist = patternListInitHelper(blacklistPatterns);
 
@@ -146,7 +145,10 @@ public class ConfigBasedMultiDatasets {
               if (blacklistFilteringHelper(configBasedDataset, this.blacklist)){
                 this.datasets.add(configBasedDataset);
               }
-
+              else{
+                log.info("Dataset" + configBasedDataset.datasetURN() + " has been filtered out because of blacklist pattern:"
+                    + this.blacklist.get().toString());
+              }
             }
           }
         }// inner for loops ends
@@ -172,12 +174,19 @@ public class ConfigBasedMultiDatasets {
           if (blacklistFilteringHelper(configBasedDataset, this.blacklist)){
             this.datasets.add(configBasedDataset);
           }
+          else{
+            log.info("Dataset" + configBasedDataset.datasetURN() + " has been filtered out because of blacklist pattern:"
+                + this.blacklist.get().toString());
+          }
         }
       }
     }
   }
 
   @VisibleForTesting
+  /**
+   * Return false if the target configBasedDataset should be kept in the blacklist.
+   */
   public boolean blacklistFilteringHelper(ConfigBasedDataset configBasedDataset, Optional<List<Pattern>> patternList){
     String datasetURN = configBasedDataset.datasetURN();
     if (patternList.isPresent()) {

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/profile/ConfigBasedCleanabledDatasetFinder.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/profile/ConfigBasedCleanabledDatasetFinder.java
@@ -16,9 +16,11 @@
  */
 package gobblin.data.management.retention.profile;
 
+import com.google.common.base.Optional;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Collection;
+import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.Callable;
 
@@ -52,7 +54,7 @@ public class ConfigBasedCleanabledDatasetFinder extends ConfigBasedDatasetsFinde
   }
 
   protected Callable<Void> findDatasetsCallable(final ConfigClient confClient,
-      final URI u, final Properties p, final Collection<Dataset> datasets) {
+      final URI u, final Properties p, Optional<List<String>> blacklistURNs, Optional<List<String>> whitelistURNs, final Collection<Dataset> datasets) {
     return new Callable<Void>() {
       @Override
       public Void call() throws Exception {

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/profile/ConfigBasedCleanabledDatasetFinder.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/profile/ConfigBasedCleanabledDatasetFinder.java
@@ -54,7 +54,7 @@ public class ConfigBasedCleanabledDatasetFinder extends ConfigBasedDatasetsFinde
   }
 
   protected Callable<Void> findDatasetsCallable(final ConfigClient confClient,
-      final URI u, final Properties p, Optional<List<String>> blacklistURNs, Optional<List<String>> whitelistURNs, final Collection<Dataset> datasets) {
+      final URI u, final Properties p, Optional<List<String>> blacklistURNs, final Collection<Dataset> datasets) {
     return new Callable<Void>() {
       @Override
       public Void call() throws Exception {

--- a/gobblin-data-management/src/test/java/gobblin/data/management/copy/replication/ConfigBasedDatasetsFinderTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/copy/replication/ConfigBasedDatasetsFinderTest.java
@@ -18,14 +18,7 @@
 package gobblin.data.management.copy.replication;
 
 import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableList;
-import com.typesafe.config.Config;
-import gobblin.configuration.ConfigurationKeys;
-import gobblin.dataset.Dataset;
-import java.io.BufferedWriter;
 import java.io.IOException;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
@@ -40,8 +33,6 @@ import org.apache.hadoop.fs.Path;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import static gobblin.data.management.copy.replication.ConfigBasedDatasetsFinder.*;
 
 
 /**


### PR DESCRIPTION
Updates July 25th:
After discussion with @abti and feature requestor we figured out the desired output is a configStore-based dataset finder plus glob-pattern support for filtering out some unwanted trash files. Only with ConfigStore this is impossible as configstore only have a logical view of dataset configuration, which is not necessary the same as the real dataset. Also configStore is not necessary to be implemented based on file system.

The approach here is to rely on configStore to finish dataset discovery first, and resolve the black/whitelist in the `ConfigBasedDataset.java` level, which in current stage only handles file system based dataset. 

Also here we specified the semantics of two-level black/whitelist. The job-level black/whitelist is mainly for hot-fix in convenience of operation purpose, and it will NOT override config-based black/whitelist. That is, job-level black/whitelist is an enhancement not overriding.