### PR TITLE
[GOBBLIN-168] Standardize Github PR template for Gobblin

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+Dear Gobblin maintainers,
+
+Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!
+
+
+### JIRA
+- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
+    - https://issues.apache.org/jira/browse/GOBBLIN-XXX
+
+
+### Description
+- [ ] Here are some details about my PR, including screenshots (if applicable):
+
+
+### Tests
+- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
+
+
+### Commits
+- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
+    1. Subject is separated from body by a blank line
+    2. Subject is limited to 50 characters
+    3. Subject does not end with a period
+    4. Subject uses the imperative mood ("add", not "adding")
+    5. Body wraps at 72 characters
+    6. Body explains "what" and "why", not "how"
+


### PR DESCRIPTION
Standardize the Github PR template, so that new PRs are created with proper title, subject and commit messages. This should leverage learnings from existing Apache projects.