### PR TITLE
[GOBBLIN-175] Escape string in hive query for avro2orc conversion

### DIFF
--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/query/HiveAvroORCQueryGenerator.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/query/HiveAvroORCQueryGenerator.java
@@ -511,7 +511,7 @@ public class HiveAvroORCQueryGenerator {
       if (hiveColumns.isPresent()) {
         hiveColumns.get().put(name, type);
       }
-      columns.append(String.format("  `%s` %s COMMENT '%s'", name, type, comment));
+      columns.append(String.format("  `%s` %s COMMENT '%s'", name, type, escapeStringForHive(comment)));
     }
 
     return columns.toString();
@@ -848,7 +848,7 @@ public class HiveAvroORCQueryGenerator {
             ddl.add(String.format("USE %s%n", finalDbName));
             ddl.add(String.format("ALTER TABLE `%s` CHANGE COLUMN %s %s %s COMMENT '%s'",
                 finalTableName, evolvedColumn.getKey(), evolvedColumn.getKey(), evolvedColumn.getValue(),
-                destinationField.getComment()));
+                escapeStringForHive(destinationField.getComment())));
           }
           found = true;
           break;
@@ -1101,4 +1101,16 @@ public class HiveAvroORCQueryGenerator {
       return String.format("'%s'", value);
     }
   };
+
+  private static String escapeStringForHive(String st) {
+    char backslash = '\\';
+    char singleQuote = '\'';
+    char semicolon = ';';
+    String escapedSingleQuote = String.valueOf(backslash) + String.valueOf(singleQuote);
+    String escapedSemicolon = String.valueOf(backslash) + String.valueOf(semicolon);
+
+    st = st.replace(String.valueOf(singleQuote), escapedSingleQuote)
+        .replace(String.valueOf(semicolon), escapedSemicolon);
+    return st;
+  }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/GOBBLIN-175

Created a escapeStringForHive method in HiveAvroORCQueryGenerator.java
This method is currently responsible for escaping single quotes and semicolons of the comment section in a hive query

Change for escaping the string is very trivial. Hence test is not added