### PR TITLE
[GOBBLIN-175] Escape string in hive query for avro2orc conversion

### DIFF
--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/query/HiveAvroORCQueryGenerator.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/query/HiveAvroORCQueryGenerator.java
@@ -511,7 +511,7 @@ public class HiveAvroORCQueryGenerator {
       if (hiveColumns.isPresent()) {
         hiveColumns.get().put(name, type);
       }
-      columns.append(String.format("  `%s` %s COMMENT '%s'", name, type, comment));
+      columns.append(String.format("  `%s` %s COMMENT '%s'", name, type, escapeStringForHive(comment)));
     }
 
     return columns.toString();
@@ -848,7 +848,7 @@ public class HiveAvroORCQueryGenerator {
             ddl.add(String.format("USE %s%n", finalDbName));
             ddl.add(String.format("ALTER TABLE `%s` CHANGE COLUMN %s %s %s COMMENT '%s'",
                 finalTableName, evolvedColumn.getKey(), evolvedColumn.getKey(), evolvedColumn.getValue(),
-                destinationField.getComment()));
+                escapeStringForHive(destinationField.getComment())));
           }
           found = true;
           break;
@@ -1101,4 +1101,16 @@ public class HiveAvroORCQueryGenerator {
       return String.format("'%s'", value);
     }
   };
+
+  private static String escapeStringForHive(String st) {
+    char backslash = '\\';
+    char singleQuote = '\'';
+    char semicolon = ';';
+    String escapedSingleQuote = String.valueOf(backslash) + String.valueOf(singleQuote);
+    String escapedSemicolon = String.valueOf(backslash) + String.valueOf(semicolon);
+
+    st = st.replace(String.valueOf(singleQuote), escapedSingleQuote)
+        .replace(String.valueOf(semicolon), escapedSemicolon);
+    return st;
+  }
 }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-175


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Created a escapeStringForHive method in HiveAvroORCQueryGenerator.java
This method is currently responsible for escaping single quotes and semicolons of the comment section in a hive query

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Change for escaping the string is very trivial. Hence test is not added

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

