### PR TITLE
[GOBBLIN-183] Gobblin data management copy empty directories

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/CopyConfiguration.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/CopyConfiguration.java
@@ -51,6 +51,9 @@ public class CopyConfiguration {
   public static final String DESTINATION_GROUP_KEY = COPY_PREFIX + ".dataset.destination.group";
   public static final String PRIORITIZATION_PREFIX = COPY_PREFIX + ".prioritization";
 
+  /**
+   * Include empty directories in the source for copy
+   */
   public static final String INCLUDE_EMPTY_DIRECTORIES = COPY_PREFIX + ".includeEmptyDirectories";
 
   public static final String PRIORITIZER_ALIAS_KEY = PRIORITIZATION_PREFIX + ".prioritizerAlias";

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/CopyConfiguration.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/CopyConfiguration.java
@@ -51,6 +51,8 @@ public class CopyConfiguration {
   public static final String DESTINATION_GROUP_KEY = COPY_PREFIX + ".dataset.destination.group";
   public static final String PRIORITIZATION_PREFIX = COPY_PREFIX + ".prioritization";
 
+  public static final String INCLUDE_EMPTY_DIRECTORIES = COPY_PREFIX + ".includeEmptyDirectories";
+
   public static final String PRIORITIZER_ALIAS_KEY = PRIORITIZATION_PREFIX + ".prioritizerAlias";
   public static final String MAX_COPY_PREFIX = PRIORITIZATION_PREFIX + ".maxCopy";
 

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/CopyableFile.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/CopyableFile.java
@@ -203,7 +203,7 @@ public class CopyableFile extends CopyEntity implements File {
             this.configuration.getTargetFs(), this.destination);
       }
       if (this.checksum == null) {
-        FileChecksum checksumTmp = this.originFs.getFileChecksum(this.origin.getPath());
+        FileChecksum checksumTmp = this.origin.isDirectory() ? null : this.originFs.getFileChecksum(this.origin.getPath());
         this.checksum = checksumTmp == null ? new byte[0] : checksumTmp.getBytes();
       }
       if (this.fileSet == null) {

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/RecursiveCopyableDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/RecursiveCopyableDataset.java
@@ -150,7 +150,7 @@ public class RecursiveCopyableDataset implements CopyableDataset, FileSystemData
   @VisibleForTesting
   protected List<FileStatus> getFilesAtPath(FileSystem fs, Path path, PathFilter fileFilter) throws IOException {
     try {
-      return FileListUtils.listFilesRecursively(fs, path, fileFilter);
+      return FileListUtils.getFilesToCopyAtPath(fs, path, fileFilter);
     } catch (FileNotFoundException fnfe) {
       return Lists.newArrayList();
     }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/RecursiveCopyableDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/RecursiveCopyableDataset.java
@@ -66,7 +66,7 @@ public class RecursiveCopyableDataset implements CopyableDataset, FileSystemData
   private final boolean update;
   private final boolean delete;
 
-  // Include empty directories in the source to copy
+  // Include empty directories in the source for copy
   private final boolean includeEmptyDirectories;
   // Delete empty directories in the destination
   private final boolean deleteEmptyDirectories;

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/RecursiveCopyableDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/RecursiveCopyableDataset.java
@@ -65,7 +65,12 @@ public class RecursiveCopyableDataset implements CopyableDataset, FileSystemData
   private final CopyableFileFilter copyableFileFilter;
   private final boolean update;
   private final boolean delete;
+
+  // Include empty directories in the source to copy
+  private final boolean includeEmptyDirectories;
+  // Delete empty directories in the destination
   private final boolean deleteEmptyDirectories;
+
   private final Properties properties;
 
   public RecursiveCopyableDataset(final FileSystem fs, Path rootPath, Properties properties, Path glob) {
@@ -80,6 +85,8 @@ public class RecursiveCopyableDataset implements CopyableDataset, FileSystemData
     this.update = Boolean.parseBoolean(properties.getProperty(UPDATE_KEY));
     this.delete = Boolean.parseBoolean(properties.getProperty(DELETE_KEY));
     this.deleteEmptyDirectories = Boolean.parseBoolean(properties.getProperty(DELETE_EMPTY_DIRECTORIES_KEY));
+    this.includeEmptyDirectories =
+        Boolean.parseBoolean(properties.getProperty(CopyConfiguration.INCLUDE_EMPTY_DIRECTORIES));
     this.properties = properties;
   }
 
@@ -150,7 +157,7 @@ public class RecursiveCopyableDataset implements CopyableDataset, FileSystemData
   @VisibleForTesting
   protected List<FileStatus> getFilesAtPath(FileSystem fs, Path path, PathFilter fileFilter) throws IOException {
     try {
-      return FileListUtils.listFilesToCopyAtPath(fs, path, fileFilter);
+      return FileListUtils.listFilesToCopyAtPath(fs, path, fileFilter, includeEmptyDirectories);
     } catch (FileNotFoundException fnfe) {
       return Lists.newArrayList();
     }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/RecursiveCopyableDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/RecursiveCopyableDataset.java
@@ -150,7 +150,7 @@ public class RecursiveCopyableDataset implements CopyableDataset, FileSystemData
   @VisibleForTesting
   protected List<FileStatus> getFilesAtPath(FileSystem fs, Path path, PathFilter fileFilter) throws IOException {
     try {
-      return FileListUtils.getFilesToCopyAtPath(fs, path, fileFilter);
+      return FileListUtils.listFilesToCopyAtPath(fs, path, fileFilter);
     } catch (FileNotFoundException fnfe) {
       return Lists.newArrayList();
     }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/RecursivePathFinder.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/RecursivePathFinder.java
@@ -61,7 +61,7 @@ public class RecursivePathFinder {
     }
     PathFilter actualFilter =
         skipHiddenPaths ? new AndPathFilter(new HiddenFilter(), this.pathFilter) : this.pathFilter;
-    List<FileStatus> files = FileListUtils.getFilesToCopyAtPath(this.fs, this.rootPath, actualFilter);
+    List<FileStatus> files = FileListUtils.listFilesToCopyAtPath(this.fs, this.rootPath, actualFilter);
 
     return Sets.newHashSet(files);
   }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/RecursivePathFinder.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/RecursivePathFinder.java
@@ -46,22 +46,27 @@ public class RecursivePathFinder {
   private final Path rootPath;
   private final FileSystem fs;
   private final PathFilter pathFilter;
+  private final boolean includeEmptyDirectories;
 
   public RecursivePathFinder(final FileSystem fs, Path rootPath, Properties properties) {
     this.rootPath = PathUtils.getPathWithoutSchemeAndAuthority(rootPath);
     this.fs = fs;
 
     this.pathFilter = DatasetUtils.instantiatePathFilter(properties);
+    this.includeEmptyDirectories =
+        Boolean.parseBoolean(properties.getProperty(CopyConfiguration.INCLUDE_EMPTY_DIRECTORIES));
   }
 
-  public Set<FileStatus> getPaths(boolean skipHiddenPaths) throws IOException {
+  public Set<FileStatus> getPaths(boolean skipHiddenPaths)
+      throws IOException {
 
     if (!this.fs.exists(this.rootPath)) {
       return Sets.newHashSet();
     }
     PathFilter actualFilter =
         skipHiddenPaths ? new AndPathFilter(new HiddenFilter(), this.pathFilter) : this.pathFilter;
-    List<FileStatus> files = FileListUtils.listFilesToCopyAtPath(this.fs, this.rootPath, actualFilter);
+    List<FileStatus> files =
+        FileListUtils.listFilesToCopyAtPath(this.fs, this.rootPath, actualFilter, includeEmptyDirectories);
 
     return Sets.newHashSet(files);
   }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/RecursivePathFinder.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/RecursivePathFinder.java
@@ -61,7 +61,7 @@ public class RecursivePathFinder {
     }
     PathFilter actualFilter =
         skipHiddenPaths ? new AndPathFilter(new HiddenFilter(), this.pathFilter) : this.pathFilter;
-    List<FileStatus> files = FileListUtils.listFilesRecursively(this.fs, this.rootPath, actualFilter);
+    List<FileStatus> files = FileListUtils.getFilesToCopyAtPath(this.fs, this.rootPath, actualFilter);
 
     return Sets.newHashSet(files);
   }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/extractor/FileAwareInputStreamExtractor.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/extractor/FileAwareInputStreamExtractor.java
@@ -23,6 +23,7 @@ import org.apache.gobblin.data.management.copy.FileAwareInputStream;
 import org.apache.gobblin.source.extractor.DataRecordException;
 import org.apache.gobblin.source.extractor.Extractor;
 import org.apache.gobblin.util.HadoopUtils;
+import org.apache.gobblin.util.io.EmptyInputStream;
 import org.apache.gobblin.util.io.MeteredInputStream;
 
 import java.io.IOException;
@@ -80,6 +81,9 @@ public class FileAwareInputStreamExtractor implements Extractor<String, FileAwar
           this.state == null ? HadoopUtils.newConfiguration() : HadoopUtils.getConfFromState(this.state);
       FileSystem fsFromFile = this.file.getOrigin().getPath().getFileSystem(conf);
       this.recordRead = true;
+      if (this.file.getFileStatus().isDirectory()) {
+        return new FileAwareInputStream(this.file, EmptyInputStream.instance);
+      }
       return new FileAwareInputStream(this.file,
           MeteredInputStream.builder().in(fsFromFile.open(this.file.getFileStatus().getPath())).build());
     }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
@@ -206,6 +206,11 @@ public class FileAwareInputStreamDataWriter extends InstrumentedDataWriter<FileA
       log.info(String.format("Recovering persisted file %s to %s.", persistedFile.get().getPath(), writeAt));
       this.fs.rename(persistedFile.get().getPath(), writeAt);
     } else {
+      // Copy empty directories
+      if (copyableFile.getFileStatus().isDirectory()) {
+        this.fs.mkdirs(writeAt);
+        return;
+      }
 
       OutputStream os =
           this.fs.create(writeAt, true, this.fs.getConf().getInt("io.file.buffer.size", 4096), replication, blockSize);

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/FileListUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/FileListUtils.java
@@ -68,7 +68,14 @@ public class FileListUtils {
     return results;
   }
 
-  public static List<FileStatus> getFilesToCopyAtPath(FileSystem fs, Path path, PathFilter fileFilter) throws IOException {
+  /**
+   * Given a path to copy, list all files rooted at the given path to copy
+   *
+   * @param fs the file system of the path
+   * @param path root path to copy
+   * @param fileFilter a filter only applied to root
+   */
+  public static List<FileStatus> listFilesToCopyAtPath(FileSystem fs, Path path, PathFilter fileFilter) throws IOException {
     List<FileStatus> files = Lists.newArrayList();
     FileStatus rootFile = fs.getFileStatus(path);
 
@@ -106,7 +113,7 @@ public class FileListUtils {
     if (fileStatus.isDirectory()) {
       for (FileStatus status : fs.listStatus(fileStatus.getPath(),
           applyFilterToDirectories ? fileFilter : NO_OP_PATH_FILTER)) {
-        if (fileStatus.isDirectory()) {
+        if (status.isDirectory()) {
           // Number of files collected before diving into the directory
           int numFilesBefore = files.size();
 
@@ -119,10 +126,10 @@ public class FileListUtils {
              * This is effectively an empty directory, which needs explicit copying. Has there any data file
              * in the directory, the directory would be created as a side-effect of copying the data file
              */
-            files.add(fileStatus);
+            files.add(status);
           }
         } else {
-          files.add(fileStatus);
+          files.add(status);
         }
       }
     } else if (fileFilter.accept(fileStatus.getPath())) {

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/io/EmptyInputStream.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/io/EmptyInputStream.java
@@ -1,0 +1,16 @@
+package org.apache.gobblin.util.io;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+
+public class EmptyInputStream extends InputStream {
+  public static final InputStream instance = new EmptyInputStream();
+
+  private EmptyInputStream() {}
+  @Override
+  public int read()
+      throws IOException {
+    return 0;
+  }
+}

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/io/EmptyInputStream.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/io/EmptyInputStream.java
@@ -1,9 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.gobblin.util.io;
 
 import java.io.IOException;
 import java.io.InputStream;
 
 
+/**
+ * An {@link InputStream} with empty content
+ */
 public class EmptyInputStream extends InputStream {
   public static final InputStream instance = new EmptyInputStream();
 

--- a/gobblin-utility/src/test/java/org/apache/gobblin/util/FileListUtilsTest.java
+++ b/gobblin-utility/src/test/java/org/apache/gobblin/util/FileListUtilsTest.java
@@ -146,4 +146,47 @@ public class FileListUtilsTest {
     }
   }
 
+  public void testListFilesToCopyAtPath() throws IOException {
+    FileSystem localFs = FileSystem.getLocal(new Configuration());
+    Path baseDir = new Path(FILE_UTILS_TEST_DIR, "fileListTestDir4");
+    try {
+      if (localFs.exists(baseDir)) {
+        localFs.delete(baseDir, true);
+      }
+      localFs.mkdirs(baseDir);
+
+      // Empty root directory
+      List<FileStatus> testFiles = FileListUtils.listFilesToCopyAtPath(localFs, baseDir, FileListUtils.NO_OP_PATH_FILTER);
+      Assert.assertEquals(testFiles.size(), 1);
+      Assert.assertEquals(testFiles.get(0).getPath().getName(), baseDir.getName());
+
+      // With an empty sub directory
+      Path subDir = new Path(baseDir, "subDir");
+      localFs.mkdirs(subDir);
+      testFiles = FileListUtils.listFilesToCopyAtPath(localFs, baseDir, FileListUtils.NO_OP_PATH_FILTER);
+      Assert.assertEquals(testFiles.size(), 1);
+      Assert.assertEquals(testFiles.get(0).getPath().getName(), subDir.getName());
+
+      // With file subDir/tes1
+      Path test1Path = new Path(subDir, TEST_FILE_NAME1);
+      localFs.create(test1Path);
+      testFiles = FileListUtils.listFilesToCopyAtPath(localFs, baseDir, FileListUtils.NO_OP_PATH_FILTER);
+      Assert.assertEquals(testFiles.size(), 1);
+      Assert.assertEquals(testFiles.get(0).getPath().getName(), test1Path.getName());
+
+      // With file subDir/test2
+      Path test2Path = new Path(subDir, TEST_FILE_NAME2);
+      localFs.create(test2Path);
+      testFiles = FileListUtils.listFilesToCopyAtPath(localFs, baseDir, FileListUtils.NO_OP_PATH_FILTER);
+      Assert.assertEquals(testFiles.size(), 2);
+      Set<String> fileNames = Sets.newHashSet();
+      for (FileStatus testFileStatus : testFiles) {
+        fileNames.add(testFileStatus.getPath().getName());
+      }
+      Assert.assertTrue(fileNames.contains(TEST_FILE_NAME1) && fileNames.contains(TEST_FILE_NAME2));
+    } finally {
+      localFs.delete(baseDir, true);
+    }
+  }
+
 }

--- a/gobblin-utility/src/test/java/org/apache/gobblin/util/FileListUtilsTest.java
+++ b/gobblin-utility/src/test/java/org/apache/gobblin/util/FileListUtilsTest.java
@@ -156,28 +156,32 @@ public class FileListUtilsTest {
       localFs.mkdirs(baseDir);
 
       // Empty root directory
-      List<FileStatus> testFiles = FileListUtils.listFilesToCopyAtPath(localFs, baseDir, FileListUtils.NO_OP_PATH_FILTER);
+      List<FileStatus> testFiles = FileListUtils.listFilesToCopyAtPath(localFs, baseDir, FileListUtils.NO_OP_PATH_FILTER, true);
       Assert.assertEquals(testFiles.size(), 1);
       Assert.assertEquals(testFiles.get(0).getPath().getName(), baseDir.getName());
 
       // With an empty sub directory
       Path subDir = new Path(baseDir, "subDir");
       localFs.mkdirs(subDir);
-      testFiles = FileListUtils.listFilesToCopyAtPath(localFs, baseDir, FileListUtils.NO_OP_PATH_FILTER);
+      testFiles = FileListUtils.listFilesToCopyAtPath(localFs, baseDir, FileListUtils.NO_OP_PATH_FILTER, true);
       Assert.assertEquals(testFiles.size(), 1);
       Assert.assertEquals(testFiles.get(0).getPath().getName(), subDir.getName());
+
+      // Disable include empty directories
+      testFiles = FileListUtils.listFilesToCopyAtPath(localFs, baseDir, FileListUtils.NO_OP_PATH_FILTER, false);
+      Assert.assertEquals(testFiles.size(), 0);
 
       // With file subDir/tes1
       Path test1Path = new Path(subDir, TEST_FILE_NAME1);
       localFs.create(test1Path);
-      testFiles = FileListUtils.listFilesToCopyAtPath(localFs, baseDir, FileListUtils.NO_OP_PATH_FILTER);
+      testFiles = FileListUtils.listFilesToCopyAtPath(localFs, baseDir, FileListUtils.NO_OP_PATH_FILTER, true);
       Assert.assertEquals(testFiles.size(), 1);
       Assert.assertEquals(testFiles.get(0).getPath().getName(), test1Path.getName());
 
       // With file subDir/test2
       Path test2Path = new Path(subDir, TEST_FILE_NAME2);
       localFs.create(test2Path);
-      testFiles = FileListUtils.listFilesToCopyAtPath(localFs, baseDir, FileListUtils.NO_OP_PATH_FILTER);
+      testFiles = FileListUtils.listFilesToCopyAtPath(localFs, baseDir, FileListUtils.NO_OP_PATH_FILTER, true);
       Assert.assertEquals(testFiles.size(), 2);
       Set<String> fileNames = Sets.newHashSet();
       for (FileStatus testFileStatus : testFiles) {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA]
    - https://issues.apache.org/jira/browse/GOBBLIN-183


### Description
- [x] Here are some details about my PR:
Previously creating `CopyableFile` from a `DataSet` will ignore empty directories or empty tables. This PR provides a new method `FileListUtils#getFilesToCopyAtPath` to add empty directory if no data file is found along the path.

### Tests
- [x] My PR adds the following unit tests
  - `FileListUtilsTest.testListFilesToCopyAtPath`


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

