### PR TITLE
[GOBBLIN-159] Allow Helix jobs to be gracefully canceled

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJob.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJob.java
@@ -33,9 +33,7 @@ import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 
 import org.apache.gobblin.annotation.Alpha;
-import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.metrics.Tag;
-import org.apache.gobblin.runtime.JobException;
 import org.apache.gobblin.runtime.JobLauncher;
 import org.apache.gobblin.runtime.listeners.JobListener;
 import org.apache.gobblin.scheduler.BaseGobblinJob;
@@ -74,7 +72,7 @@ public class GobblinHelixJob extends BaseGobblinJob implements InterruptableJob 
               Boolean.toString(GobblinClusterConfigurationKeys.JOB_EXECUTE_IN_SCHEDULING_THREAD_DEFAULT)))) {
         jobScheduler.runJob(jobProps, jobListener, jobLauncher);
       } else {
-        cancellable = jobScheduler.submitJob(jobProps, jobListener, jobLauncher);
+        cancellable = jobScheduler.scheduleJobImmediately(jobProps, jobListener, jobLauncher);
       }
     } catch (Throwable t) {
       throw new JobExecutionException(t);

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJob.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJob.java
@@ -19,12 +19,14 @@ package org.apache.gobblin.cluster;
 
 import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.Future;
 
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.helix.HelixManager;
 
+import org.quartz.InterruptableJob;
 import org.quartz.Job;
 import org.quartz.JobDataMap;
 import org.quartz.JobExecutionContext;
@@ -38,6 +40,7 @@ import org.apache.gobblin.runtime.JobLauncher;
 import org.apache.gobblin.runtime.listeners.JobListener;
 import org.apache.gobblin.scheduler.BaseGobblinJob;
 import org.apache.gobblin.scheduler.JobScheduler;
+import org.quartz.UnableToInterruptJobException;
 
 
 /**
@@ -48,7 +51,9 @@ import org.apache.gobblin.scheduler.JobScheduler;
  */
 @Alpha
 @Slf4j
-public class GobblinHelixJob extends BaseGobblinJob {
+public class GobblinHelixJob extends BaseGobblinJob implements InterruptableJob {
+  private Future cancellable = null;
+
   @Override
   public void executeImpl(JobExecutionContext context) throws JobExecutionException {
     JobDataMap dataMap = context.getJobDetail().getJobDataMap();
@@ -65,28 +70,32 @@ public class GobblinHelixJob extends BaseGobblinJob {
 
     try {
       final JobLauncher jobLauncher = new GobblinHelixJobLauncher(jobProps, helixManager, appWorkDir, eventMetadata);
-
       if (Boolean.valueOf(jobProps.getProperty(GobblinClusterConfigurationKeys.JOB_EXECUTE_IN_SCHEDULING_THREAD,
-          Boolean.toString(GobblinClusterConfigurationKeys.JOB_EXECUTE_IN_SCHEDULING_THREAD_DEFAULT)))) {
+              Boolean.toString(GobblinClusterConfigurationKeys.JOB_EXECUTE_IN_SCHEDULING_THREAD_DEFAULT)))) {
         jobScheduler.runJob(jobProps, jobListener, jobLauncher);
       } else {
-        // if not executing in the scheduling thread then submit a runnable to the job scheduler's ExecutorService
-        // for asynchronous execution.
-        Runnable runnable = new Runnable() {
-          @Override
-          public void run() {
-            try {
-              jobScheduler.runJob(jobProps, jobListener, jobLauncher);
-            } catch (JobException je) {
-              log.error("Failed to run job " + jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY), je);
-            }
-          }
-        };
-
-        jobScheduler.submitRunnableToExecutor(runnable);
+        cancellable = jobScheduler.submitJob(jobProps, jobListener, jobLauncher);
       }
     } catch (Throwable t) {
       throw new JobExecutionException(t);
+    }
+  }
+
+  @Override
+  public void interrupt() throws UnableToInterruptJobException {
+    if (cancellable != null) {
+      try {
+        if (cancellable.cancel(false)) {
+          return;
+        }
+      } catch (Exception e) {
+        log.error("Failed to gracefully cancel job. Attempting to force cancellation.", e);
+      }
+      try {
+        cancellable.cancel(true);
+      } catch (Exception e) {
+        throw new UnableToInterruptJobException(e);
+      }
     }
   }
 }

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/scheduler/JobScheduler.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/scheduler/JobScheduler.java
@@ -236,7 +236,20 @@ public class JobScheduler extends AbstractIdleService {
     }
   }
 
-  public Future submitJob(Properties jobProps, JobListener jobListener, JobLauncher jobLauncher) {
+  /**
+   * Schedule a job immediately.
+   *
+   * <p>
+   *   This method calls the Quartz scheduler to scheduler the job.
+   * </p>
+   *
+   * @param jobProps Job configuration properties
+   * @param jobListener {@link JobListener} used for callback,
+   *                    can be <em>null</em> if no callback is needed.
+   * @throws JobException when there is anything wrong
+   *                      with scheduling the job
+   */
+  public Future<?> scheduleJobImmediately(Properties jobProps, JobListener jobListener, JobLauncher jobLauncher) {
     Runnable runnable = new Runnable() {
       @Override
       public void run() {
@@ -248,7 +261,6 @@ public class JobScheduler extends AbstractIdleService {
       }
     };
     final Future<?> future = this.jobExecutor.submit(runnable);
-    this.submitRunnableToExecutor(runnable);
     return new Future() {
       @Override
       public boolean cancel(boolean mayInterruptIfRunning) {


### PR DESCRIPTION
The current implementation of GobblinHelixJob does not allow them to be canceled.  This means that when the master node is restarted, jobs are left in a zombie state.  These zombie jobs consume resources and write output, but do not count as a job.  This leads to reduced cluster performance and duplicate data.  This PR adds the ability for jobs to be gracefully cancelled.

@abti Can you look at this and see if this is headed the right direction.  Also, is there an easy way to add helix tests that would cover this scenario?
