### PR TITLE
[GOBBLIN-202] Added JMX reporting of task execution queue size and time.

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -176,6 +176,11 @@ public class ConfigurationKeys {
   public static final boolean DEFAULT_CLEANUP_STAGING_DATA_PER_TASK = true;
   public static final String CLEANUP_STAGING_DATA_BY_INITIALIZER = "cleanup.staging.data.by.initializer";
 
+  public static final String QUEUED_TASK_TIME_MAX_SIZE = "taskexecutor.queued_task_time.history.max_size";
+  public static final int DEFAULT_QUEUED_TASK_TIME_MAX_SIZE = 2048;
+  public static final String QUEUED_TASK_TIME_MAX_AGE = "taskexecutor.queued_task_time.history.max_age";
+  public static final long DEFAULT_QUEUED_TASK_TIME_MAX_AGE = TimeUnit.HOURS.toMillis(1);
+
   /** Optional, for user to specified which template to use, inside .job file */
   public static final String JOB_TEMPLATE_PATH = "job.template" ;
 

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinTaskRunner.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinTaskRunner.java
@@ -60,6 +60,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.eventbus.EventBus;
@@ -69,6 +70,7 @@ import com.google.common.util.concurrent.ServiceManager;
 
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigValueFactory;
 
 import org.apache.gobblin.annotation.Alpha;
 import org.apache.gobblin.configuration.ConfigurationKeys;
@@ -159,7 +161,8 @@ public class GobblinTaskRunner {
     Path appWorkDir = appWorkDirOptional.isPresent() ? appWorkDirOptional.get() :
         GobblinClusterUtils.getAppWorkDirPath(this.fs, applicationName, applicationId);
 
-    List<Service> services = Lists.newArrayList(taskExecutor, taskStateTracker, new JMXReportingService());
+    List<Service> services = Lists.newArrayList(taskExecutor, taskStateTracker,
+        new JMXReportingService(ImmutableMap.of("task.executor" ,taskExecutor.getTaskExecutorQueueMetricSet())));
     services.addAll(getServices());
 
     this.serviceManager = new ServiceManager(services);


### PR DESCRIPTION
Autoscaling the Gobblin AWS worker nodes based on CPU is not very efficient.  It is better to scale based on the amount of time that tasks wait in the queue before running.  This PR added some JMX metrics to TaskExecutor that can be used as part of a custom CloudWatch metric for autoscaling in AWS.  

Pulling these JMX metrics and creating the custom CloudWatch metric are outside the scope of this PR.  We do this with a lambda function that every minute:

1. Looks up all live instances of the worker ASG in AWS
1. Find the private/public DNS for the live instances
1. Communicates with jolokia to pull the count and time metrics
1. Computes a global average and logs it

There is a CloudWatch log filter setup that turns the logged metric into a custom CloudWatch metric.  The ASG has been changed to use the new metric to control scaling.
