### PR TITLE
[GOBBLIN-184] Call the flush method of CloseOnFlushWriterWrapper when…

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/writer/CloseOnFlushWriterWrapper.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/writer/CloseOnFlushWriterWrapper.java
@@ -28,6 +28,7 @@ import com.google.common.base.Preconditions;
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.records.ControlMessageHandler;
+import org.apache.gobblin.records.FlushControlMessageHandler;
 import org.apache.gobblin.stream.RecordEnvelope;
 import org.apache.gobblin.util.Decorator;
 import org.apache.gobblin.util.FinalState;
@@ -126,7 +127,13 @@ public class CloseOnFlushWriterWrapper<D> extends WriterWrapper<D> implements De
 
   @Override
   public ControlMessageHandler getMessageHandler() {
-    return this.writer.getMessageHandler();
+    // if close on flush is configured then create a handler that will invoke the wrapper's flush to perform close
+    // on flush operations, otherwise return the wrapped writer's handler.
+    if (this.closeOnFlush) {
+      return new FlushControlMessageHandler(this);
+    } else {
+      return this.writer.getMessageHandler();
+    }
   }
 
   /**


### PR DESCRIPTION
… a FlushControlMessage is received

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-184


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Call the flush method of CloseOnFlushWriterWrapper when a FlushControlMessage is received.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

