### PR TITLE
[GOBBLIN-192] Allow log4j configuration to be specified on command line

### DIFF
--- a/gobblin-aws/src/main/java/org/apache/gobblin/aws/GobblinAWSClusterManager.java
+++ b/gobblin-aws/src/main/java/org/apache/gobblin/aws/GobblinAWSClusterManager.java
@@ -163,8 +163,10 @@ public class GobblinAWSClusterManager extends GobblinClusterManager {
         System.exit(1);
       }
 
-      Log4jConfigHelper.updateLog4jConfiguration(GobblinAWSClusterManager.class,
-          GobblinAWSConfigurationKeys.GOBBLIN_AWS_LOG4J_CONFIGURATION_FILE);
+      if (System.getProperty("log4j.configuration") == null) {
+        Log4jConfigHelper.updateLog4jConfiguration(GobblinAWSClusterManager.class,
+                GobblinAWSConfigurationKeys.GOBBLIN_AWS_LOG4J_CONFIGURATION_FILE);
+      }
 
       LOGGER.info(JvmUtils.getJvmInputArguments());
 

--- a/gobblin-aws/src/main/java/org/apache/gobblin/aws/GobblinAWSTaskRunner.java
+++ b/gobblin-aws/src/main/java/org/apache/gobblin/aws/GobblinAWSTaskRunner.java
@@ -178,8 +178,10 @@ public class GobblinAWSTaskRunner extends GobblinTaskRunner {
         System.exit(1);
       }
 
-      Log4jConfigHelper.updateLog4jConfiguration(GobblinTaskRunner.class,
-          GobblinAWSConfigurationKeys.GOBBLIN_AWS_LOG4J_CONFIGURATION_FILE);
+      if (System.getProperty("log4j.configuration") == null) {
+        Log4jConfigHelper.updateLog4jConfiguration(GobblinTaskRunner.class,
+                GobblinAWSConfigurationKeys.GOBBLIN_AWS_LOG4J_CONFIGURATION_FILE);
+      }
 
       LOGGER.info(JvmUtils.getJvmInputArguments());
 


### PR DESCRIPTION
Currently, `GobblinAWSClusterManager` and `GobblinAWSTaskRunner` hardcodes the log4j configuration.  This PR allows `log4j.configuration` to be specified on the command line.  If so, it overrides the hardcoded configuration.  This lets users bootstrap the AWS cluster on their own without relying on `GobblinAWSClusterLauncher`.

