### PR TITLE
[GOBBLIN-194] Fix a NullPointerException that can occur if a partitioned

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/publisher/BaseDataPublisher.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/publisher/BaseDataPublisher.java
@@ -465,10 +465,16 @@ public class BaseDataPublisher extends SingleTaskDataPublisher {
             branchId,
             getMetadataOutputFileForBranch(anyState, branchId));
       } else {
+        String metadataFilename = getMetadataFileNameForBranch(anyState, branchId);
+        if (mdOutputPath == null || metadataFilename == null) {
+          LOG.info("Metadata filename not set for branch " + String.valueOf(branchId) + ": not publishing metadata.");
+          continue;
+        }
+
         for (String partition : partitions) {
           publishMetadata(getMergedMetadataForPartitionAndBranch(partition, branchId),
               branchId,
-              new Path(new Path(mdOutputPath, partition), getMetadataFileNameForBranch(anyState, branchId)));
+              new Path(new Path(mdOutputPath, partition), metadataFilename));
         }
       }
     }


### PR DESCRIPTION
writer is used and a filename for metadata output has not been set.

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-194


### Description
- [x ] Here are some details about my PR, including screenshots (if applicable):

Push the null check up the stack so we can catch null parameters before trying to build a Path object out of them.

### Tests
- [x ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Test for this specific use case

### Commits
- [x ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

