### PR TITLE
[GOBBLIN-189] add dataset path to 'dataset published' events

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/CopyableFile.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/CopyableFile.java
@@ -58,6 +58,9 @@ public class CopyableFile extends CopyEntity implements File {
   /** Complete destination {@link Path} of the file. */
   private Path destination;
 
+  /** Common path for dataset to which this CopyableFile belongs. */
+  public String datasetOutputPath;
+
   /** Desired {@link OwnerAndPermission} of the destination path. */
   private OwnerAndPermission destinationOwnerAndPermission;
 
@@ -89,7 +92,8 @@ public class CopyableFile extends CopyEntity implements File {
   @lombok.Builder(builderClassName = "Builder", builderMethodName = "_hiddenBuilder")
   public CopyableFile(FileStatus origin, Path destination, OwnerAndPermission destinationOwnerAndPermission,
       List<OwnerAndPermission> ancestorsOwnerAndPermission, byte[] checksum, PreserveAttributes preserve,
-      String fileSet, long originTimestamp, long upstreamTimestamp, Map<String, String> additionalMetadata) {
+      String fileSet, long originTimestamp, long upstreamTimestamp, Map<String, String> additionalMetadata,
+      String datasetOutputPath) {
     super(fileSet, additionalMetadata);
     this.origin = origin;
     this.destination = destination;
@@ -99,6 +103,7 @@ public class CopyableFile extends CopyEntity implements File {
     this.preserve = preserve;
     this.originTimestamp = originTimestamp;
     this.upstreamTimestamp = upstreamTimestamp;
+    this.datasetOutputPath = datasetOutputPath;
   }
 
   /**
@@ -145,6 +150,7 @@ public class CopyableFile extends CopyEntity implements File {
     private CopyConfiguration configuration;
     private FileSystem originFs;
     private Map<String, String> additionalMetadata;
+    private String datasetOutputPath;
 
     private Builder originFS(FileSystem originFs) {
       this.originFs = originFs;
@@ -219,7 +225,7 @@ public class CopyableFile extends CopyEntity implements File {
 
       return new CopyableFile(this.origin, this.destination, this.destinationOwnerAndPermission,
           this.ancestorsOwnerAndPermission, this.checksum, this.preserve, this.fileSet, this.originTimestamp,
-          this.upstreamTimestamp, this.additionalMetadata);
+          this.upstreamTimestamp, this.additionalMetadata, this.datasetOutputPath);
     }
 
     private List<OwnerAndPermission> replicateAncestorsOwnerAndPermission(FileSystem originFs, Path originPath,

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/RecursiveCopyableDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/RecursiveCopyableDataset.java
@@ -129,7 +129,7 @@ public class RecursiveCopyableDataset implements CopyableDataset, FileSystemData
       Path thisTargetPath = new Path(configuration.getPublishDir(), filePathRelativeToSearchPath);
 
       copyableFiles.add(CopyableFile.fromOriginAndDestination(this.fs, file, thisTargetPath, configuration)
-          .fileSet(datasetURN())
+          .fileSet(datasetURN()).datasetOutputPath(thisTargetPath.toString())
           .ancestorsOwnerAndPermission(CopyableFile.resolveReplicatedOwnerAndPermissionsRecursively(this.fs,
               file.getPath().getParent(), nonGlobSearchPath, configuration))
           .build());

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HivePartitionFileSet.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HivePartitionFileSet.java
@@ -149,7 +149,8 @@ public class HivePartitionFileSet extends HiveFileSet {
       multiTimer.nextStage(HiveCopyEntityHelper.Stages.CREATE_COPY_UNITS);
       for (CopyableFile.Builder builder : hiveCopyEntityHelper.getCopyableFilesFromPaths(diffPathSet.filesToCopy,
           hiveCopyEntityHelper.getConfiguration(), Optional.of(this.partition))) {
-        copyEntities.add(builder.fileSet(fileSet).checksum(new byte[0]).build());
+        copyEntities.add(builder.fileSet(fileSet).checksum(new byte[0])
+            .datasetOutputPath(desiredTargetLocation.location.toString()).build());
       }
 
       log.info("Created {} copy entities for partition {}", copyEntities.size(), this.partition.getCompleteName());

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/UnpartitionedTableFileSet.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/UnpartitionedTableFileSet.java
@@ -120,7 +120,7 @@ public class UnpartitionedTableFileSet extends HiveFileSet {
 
     for (CopyableFile.Builder builder : this.helper.getCopyableFilesFromPaths(diffPathSet.filesToCopy, this.helper.getConfiguration(),
         Optional.<Partition> absent())) {
-      copyEntities.add(builder.fileSet(fileSet).build());
+      copyEntities.add(builder.fileSet(fileSet).datasetOutputPath(desiredTargetLocation.location.toString()).build());
     }
 
     multiTimer.close();

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/ConcurrentBoundedWorkUnitListTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/ConcurrentBoundedWorkUnitListTest.java
@@ -145,7 +145,7 @@ public class ConcurrentBoundedWorkUnitListTest {
 
     return new CopyableFile(origin, targetPath, new OwnerAndPermission(null, null, null),
         Lists.<OwnerAndPermission>newArrayList(), null, PreserveAttributes.fromMnemonicString(""), "", 0, 0, Maps
-        .<String, String>newHashMap());
+        .<String, String>newHashMap(), "");
 
   }
 

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/CopySourcePrioritizationTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/CopySourcePrioritizationTest.java
@@ -220,7 +220,7 @@ public class CopySourcePrioritizationTest {
   private static CopyableFile createCopyableFile(String path, String fileSet) {
     return new CopyableFile(new FileStatus(0, false, 0, 0, 0, new Path(path)), new Path(path),
         new OwnerAndPermission("owner", "group", FsPermission.getDefault()), null, null,
-        PreserveAttributes.fromMnemonicString(""), fileSet, 0, 0, Maps.<String, String>newHashMap());
+        PreserveAttributes.fromMnemonicString(""), fileSet, 0, 0, Maps.<String, String>newHashMap(), "");
   }
 
   public static class MyPrioritizer implements FileSetComparator {

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/CopyableFileTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/CopyableFileTest.java
@@ -48,7 +48,7 @@ public class CopyableFileTest {
             new OwnerAndPermission("owner", "group", FsPermission.getDefault()),
             Lists.newArrayList(new OwnerAndPermission("owner2", "group2", FsPermission.getDefault())),
             "checksum".getBytes(), PreserveAttributes.fromMnemonicString(""), "", 0, 0, Maps
-            .<String, String>newHashMap());
+            .<String, String>newHashMap(), "");
 
     String s = CopyEntity.serialize(copyableFile);
     CopyEntity de = CopyEntity.deserialize(s);
@@ -63,7 +63,7 @@ public class CopyableFileTest {
         new CopyableFile(null, null, new OwnerAndPermission("owner", "group",
             FsPermission.getDefault()), Lists.newArrayList(new OwnerAndPermission(null, "group2", FsPermission
             .getDefault())), "checksum".getBytes(), PreserveAttributes.fromMnemonicString(""), "", 0, 0,
-            Maps.<String, String>newHashMap());
+            Maps.<String, String>newHashMap(), "");
 
     String serialized = CopyEntity.serialize(copyableFile);
     CopyEntity deserialized = CopyEntity.deserialize(serialized);

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/CopyableFileUtils.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/CopyableFileUtils.java
@@ -39,7 +39,7 @@ public class CopyableFileUtils {
     FileStatus status = new FileStatus(0l, false, 0, 0l, 0l, new Path(resourcePath));
 
     return new CopyableFile(status, new Path(getRandomPath()), null, null, null,
-        PreserveAttributes.fromMnemonicString(""), "", 0 ,0, Maps.<String, String>newHashMap());
+        PreserveAttributes.fromMnemonicString(""), "", 0 ,0, Maps.<String, String>newHashMap(), "");
   }
 
   public static CopyableFile getTestCopyableFile() {
@@ -83,7 +83,7 @@ public class CopyableFileUtils {
     Path destinationRelativePath = new Path(relativePath);
 
     return new CopyableFile(status, new Path(destinationPath), ownerAndPermission, null, null,
-        PreserveAttributes.fromMnemonicString(""), "", 0, 0, Maps.<String, String>newHashMap());
+        PreserveAttributes.fromMnemonicString(""), "", 0, 0, Maps.<String, String>newHashMap(), "");
   }
 
   private static String getRandomPath() {

--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/sla/SlaEventKeys.java
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/sla/SlaEventKeys.java
@@ -35,4 +35,5 @@ public class SlaEventKeys {
 
   public static final String SOURCE_URI = "sourceCluster";
   public static final String DESTINATION_URI = "destinationCluster";
+  public static final String DATASET_OUTPUT_PATH = "datasetOutputPath";
 }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!
@ibuenros Kindly review.

### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-XXX


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
It will add dataset path in gobblintrackingevent_distcp_ng, which can be used to find the , partition type and dataset path of the dataset.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Adding one more field to events is trivial. Hence test is not added

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

