### PR TITLE
[GOBBLIN-195] Ability to switch Avro schema namespace switch before registering with Kafka Avro Schema registry

### DIFF
--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/kafka/schemareg/KafkaSchemaRegistryConfigurationKeys.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/kafka/schemareg/KafkaSchemaRegistryConfigurationKeys.java
@@ -24,4 +24,5 @@ public class KafkaSchemaRegistryConfigurationKeys {
   public final static String KAFKA_SCHEMA_REGISTRY_CLASS = "kafka.schemaRegistry.class";
   public final static String KAFKA_SCHEMA_REGISTRY_URL = "kafka.schemaRegistry.url";
   public final static String KAFKA_SCHEMA_REGISTRY_CACHE = "kafka.schemaRegistry.cache";
+  public final static String KAFKA_SCHEMA_REGISTRY_OVERRIDE_NAMESPACE = "kafka.schemaRegistry.overrideNamespace";
 }

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/metrics/reporter/util/KafkaAvroReporterUtil.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/metrics/reporter/util/KafkaAvroReporterUtil.java
@@ -65,11 +65,9 @@ public class KafkaAvroReporterUtil {
       }
 
       // If no entry found in the config value, mark it absent
-      if (namespaceOverridesMap.size() == 0) {
-        return Optional.<Map<String, String>>absent();
+      if (namespaceOverridesMap.size() != 0) {
+        return Optional.of(namespaceOverridesMap);
       }
-
-      return Optional.of(namespaceOverridesMap);
     }
 
     return Optional.<Map<String, String>>absent();

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/metrics/reporter/util/KafkaAvroReporterUtil.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/metrics/reporter/util/KafkaAvroReporterUtil.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gobblin.metrics.reporter.util;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import org.apache.gobblin.kafka.schemareg.KafkaSchemaRegistryConfigurationKeys;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Splitter;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+
+public class KafkaAvroReporterUtil {
+
+  private static final Splitter SPLIT_BY_COMMA = Splitter.on(",").omitEmptyStrings().trimResults();
+  private static final Splitter SPLIT_BY_COLON = Splitter.on(":").omitEmptyStrings().trimResults();
+
+  /***
+   * This method extracts Map of namespaces to override in Kafka schema from Config.
+   *
+   * Example config:
+   * kafka.schemaRegistry.overrideNamespace = namespace1:replacement1,namespace2:replacement2
+   *
+   * For the above example, this method will create a Map with values:
+   * {
+   *   "namespace1" : "replacement1",
+   *   "namespace2" : "replacement2"
+   * }
+   *
+   * @param properties Properties properties.
+   * @return Map of namespace overrides.
+   */
+  public static Optional<Map<String, String>> extractOverrideNamespace(Properties properties) {
+    if (properties.containsKey(KafkaSchemaRegistryConfigurationKeys.KAFKA_SCHEMA_REGISTRY_OVERRIDE_NAMESPACE)) {
+
+      Map<String, String> namespaceOverridesMap = Maps.newHashMap();
+      List<String> namespaceOverrides = Lists.newArrayList(SPLIT_BY_COMMA.split(properties
+          .getProperty(KafkaSchemaRegistryConfigurationKeys.KAFKA_SCHEMA_REGISTRY_OVERRIDE_NAMESPACE)));
+
+      for (String namespaceOverride : namespaceOverrides) {
+        List<String> override = Lists.newArrayList(SPLIT_BY_COLON.split(namespaceOverride));
+        if (override.size() != 2) {
+          throw new RuntimeException("Namespace override should be of the format originalNamespace:replacementNamespace,"
+              + " found: " + namespaceOverride);
+        }
+        namespaceOverridesMap.put(override.get(0), override.get(1));
+      }
+
+      // If no entry found in the config value, mark it absent
+      if (namespaceOverridesMap.size() == 0) {
+        return Optional.<Map<String, String>>absent();
+      }
+
+      return Optional.of(namespaceOverridesMap);
+    }
+
+    return Optional.<Map<String, String>>absent();
+  }
+}

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/AvroUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/AvroUtils.java
@@ -626,18 +626,6 @@ public class AvroUtils {
     // Process all Schema Types
     // (Primitives are simply cloned)
     switch (schema.getType()) {
-      case ARRAY:
-        newSchema = Schema.createArray(switchNamespace(schema.getElementType(), namespaceOverride));
-        break;
-      case BOOLEAN:
-        newSchema = Schema.create(schema.getType());
-        break;
-      case BYTES:
-        newSchema = Schema.create(schema.getType());
-        break;
-      case DOUBLE:
-        newSchema = Schema.create(schema.getType());
-        break;
       case ENUM:
         newNamespace = namespaceOverride.containsKey(schema.getNamespace()) ? namespaceOverride.get(schema.getNamespace())
             : schema.getNamespace();
@@ -650,20 +638,8 @@ public class AvroUtils {
         newSchema =
             Schema.createFixed(schema.getName(), schema.getDoc(), newNamespace, schema.getFixedSize());
         break;
-      case FLOAT:
-        newSchema = Schema.create(schema.getType());
-        break;
-      case INT:
-        newSchema = Schema.create(schema.getType());
-        break;
-      case LONG:
-        newSchema = Schema.create(schema.getType());
-        break;
       case MAP:
         newSchema = Schema.createMap(switchNamespace(schema.getValueType(), namespaceOverride));
-        break;
-      case NULL:
-        newSchema = Schema.create(schema.getType());
         break;
       case RECORD:
         newNamespace = namespaceOverride.containsKey(schema.getNamespace()) ? namespaceOverride.get(schema.getNamespace())
@@ -680,9 +656,6 @@ public class AvroUtils {
             schema.isError());
         newSchema.setFields(newFields);
         break;
-      case STRING:
-        newSchema = Schema.create(schema.getType());
-        break;
       case UNION:
         List<Schema> newUnionMembers = new ArrayList<>();
         if (null != schema.getTypes() && schema.getTypes().size() > 0) {
@@ -691,6 +664,19 @@ public class AvroUtils {
           }
         }
         newSchema = Schema.createUnion(newUnionMembers);
+        break;
+      case ARRAY:
+        newSchema = Schema.createArray(switchNamespace(schema.getElementType(), namespaceOverride));
+        break;
+      case BOOLEAN:
+      case BYTES:
+      case DOUBLE:
+      case FLOAT:
+      case INT:
+      case LONG:
+      case NULL:
+      case STRING:
+        newSchema = Schema.create(schema.getType());
         break;
       default:
         String exceptionMessage = String.format("Schema namespace replacement failed for \"%s\" ", schema);

--- a/gobblin-utility/src/test/java/org/apache/gobblin/util/AvroUtilsTest.java
+++ b/gobblin-utility/src/test/java/org/apache/gobblin/util/AvroUtilsTest.java
@@ -217,8 +217,6 @@ public class AvroUtilsTest {
     for(Schema.Field field : newSchema.getFields()) {
       Assert.assertEquals(field, schema.getField(field.name()));
     }
-
-    Assert.assertEquals(newNamespace, AvroUtils.switchNamespace(schema, map).getNamespace());
   }
 
   @Test public void testSerializeAsPath() throws Exception {

--- a/gobblin-utility/src/test/java/org/apache/gobblin/util/AvroUtilsTest.java
+++ b/gobblin-utility/src/test/java/org/apache/gobblin/util/AvroUtilsTest.java
@@ -21,6 +21,8 @@ import java.io.IOException;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+
 import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
@@ -36,6 +38,8 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import com.google.common.collect.Maps;
 
 
 public class AvroUtilsTest {
@@ -194,6 +198,27 @@ public class AvroUtilsTest {
     Assert.assertEquals(schema,
         AvroUtils.switchName(AvroUtils.switchName(schema, newName), schema.getName()));
 
+  }
+
+  @Test
+  public void testSwitchNamespace() {
+    String originalNamespace = "originalNamespace";
+    String originalName = "originalName";
+    String newNamespace = "newNamespace";
+    Schema schema = SchemaBuilder.builder(originalNamespace).record(originalName).fields().
+        requiredDouble("double").optionalFloat("float").endRecord();
+
+    Map<String, String> map = Maps.newHashMap();
+    map.put(originalNamespace, newNamespace);
+    Schema newSchema = AvroUtils.switchNamespace(schema, map);
+
+    Assert.assertEquals(newSchema.getNamespace(), newNamespace);
+    Assert.assertEquals(newSchema.getName(), originalName);
+    for(Schema.Field field : newSchema.getFields()) {
+      Assert.assertEquals(field, schema.getField(field.name()));
+    }
+
+    Assert.assertEquals(newNamespace, AvroUtils.switchNamespace(schema, map).getNamespace());
   }
 
   @Test public void testSerializeAsPath() throws Exception {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-195


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Ability to switch Avro schema namespace switch before registering with Kafka Avro Schema registry. This is useful when we want to maintain backward compatibility with the schema registered in the registry since registry does not allows for difference in namespace. 
This however has no impact on write / read of actual Avro bytes for the event because they are mapped back to the fields irrespective of namespace. 

Through this, if the following config is set, it will help gobblin-metrics be backwards compatible with the schema already registered in Kafka Avro Schema Registry: 

kafka.schemaRegistry.overrideNamespace = org.apache.gobblin.metrics:gobblin.metrics


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Added

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

