### PR TITLE
Fix the hasJoinOperation when SQL statement has limit

### DIFF
--- a/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/source/jdbc/JdbcExtractor.java
+++ b/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/source/jdbc/JdbcExtractor.java
@@ -38,6 +38,7 @@ import java.util.Map;
 
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOrderBy;
 import org.apache.calcite.sql.SqlSelect;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.sql.parser.SqlParser;
@@ -1148,9 +1149,19 @@ public abstract class JdbcExtractor extends QueryBasedExtractor<JsonArray, JsonE
 
     SqlParser sqlParser = SqlParser.create(selectQuery);
     try {
-      SqlSelect sqlSelect = (SqlSelect)sqlParser.parseQuery();
-      SqlNode node = sqlSelect.getFrom();
-      return node.getKind() == SqlKind.JOIN;
+
+      SqlNode all = sqlParser.parseQuery();
+      SqlSelect query;
+      SqlNode from;
+      if (all instanceof SqlSelect) {
+        query = (SqlSelect) all;
+      } else if (all instanceof SqlOrderBy) {
+        query = (SqlSelect) ((SqlOrderBy) all).query;
+      } else {
+        throw new UnsupportedOperationException("The select query is type of " + all.getClass() + " which is not supported here");
+      }
+      from = query.getFrom();
+      return from.getKind() == SqlKind.JOIN;
     } catch (SqlParseException e) {
       return false;
     }

--- a/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/source/jdbc/JdbcExtractor.java
+++ b/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/source/jdbc/JdbcExtractor.java
@@ -1152,7 +1152,6 @@ public abstract class JdbcExtractor extends QueryBasedExtractor<JsonArray, JsonE
 
       SqlNode all = sqlParser.parseQuery();
       SqlSelect query;
-      SqlNode from;
       if (all instanceof SqlSelect) {
         query = (SqlSelect) all;
       } else if (all instanceof SqlOrderBy) {
@@ -1160,8 +1159,7 @@ public abstract class JdbcExtractor extends QueryBasedExtractor<JsonArray, JsonE
       } else {
         throw new UnsupportedOperationException("The select query is type of " + all.getClass() + " which is not supported here");
       }
-      from = query.getFrom();
-      return from.getKind() == SqlKind.JOIN;
+      return query.getFrom().getKind() == SqlKind.JOIN;
     } catch (SqlParseException e) {
       return false;
     }

--- a/gobblin-modules/gobblin-sql/src/test/java/org/apache/gobblin/source/jdbc/JdbcExtractorTest.java
+++ b/gobblin-modules/gobblin-sql/src/test/java/org/apache/gobblin/source/jdbc/JdbcExtractorTest.java
@@ -131,6 +131,8 @@ public class JdbcExtractorTest {
     Assert.assertTrue(result);
     result = JdbcExtractor.hasJoinOperation("select a.fromLoc from a , b");
     Assert.assertTrue(result);
+    result = JdbcExtractor.hasJoinOperation("select a.fromLoc from a , b  limit 100");
+    Assert.assertTrue(result);
     result = JdbcExtractor.hasJoinOperation("select a.fromLoc from a ,     b");
     Assert.assertTrue(result);
 
@@ -143,6 +145,11 @@ public class JdbcExtractorTest {
     // complex query
     result = JdbcExtractor.hasJoinOperation(
         "select a.fromLoc from (Select dest as fromLoc, id from b) as a, c where a.id < c.id");
+    Assert.assertTrue(result);
+
+    // complex query with limit
+    result = JdbcExtractor.hasJoinOperation(
+        "select a.fromLoc from (Select dest as fromLoc, id from b) as a, c where a.id < c.id limit 10");
     Assert.assertTrue(result);
   }
 }

--- a/gobblin-modules/gobblin-sql/src/test/java/org/apache/gobblin/source/jdbc/JdbcExtractorTest.java
+++ b/gobblin-modules/gobblin-sql/src/test/java/org/apache/gobblin/source/jdbc/JdbcExtractorTest.java
@@ -133,6 +133,8 @@ public class JdbcExtractorTest {
     Assert.assertTrue(result);
     result = JdbcExtractor.hasJoinOperation("select a.fromLoc from a , b  limit 100");
     Assert.assertTrue(result);
+    result = JdbcExtractor.hasJoinOperation("select a.fromLoc from a limit 100");
+    Assert.assertFalse(result);
     result = JdbcExtractor.hasJoinOperation("select a.fromLoc from a ,     b");
     Assert.assertTrue(result);
 
@@ -141,15 +143,18 @@ public class JdbcExtractorTest {
     Assert.assertFalse(result);
     result = JdbcExtractor.hasJoinOperation("select a.fromLoc from a where a.id=\"hello,world\"");
     Assert.assertFalse(result);
+    result = JdbcExtractor.hasJoinOperation("select a.fromLoc from a where a.id=\"hello,world\" limit 100");
+    Assert.assertFalse(result);
 
     // complex query
     result = JdbcExtractor.hasJoinOperation(
         "select a.fromLoc from (Select dest as fromLoc, id from b) as a, c where a.id < c.id");
     Assert.assertTrue(result);
-
-    // complex query with limit
     result = JdbcExtractor.hasJoinOperation(
         "select a.fromLoc from (Select dest as fromLoc, id from b) as a, c where a.id < c.id limit 10");
     Assert.assertTrue(result);
+    result = JdbcExtractor.hasJoinOperation(
+        "select a.fromLoc from (Select dest as fromLoc, id from b) as a limit 10");
+    Assert.assertFalse(result);
   }
 }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-215


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
  Add instanceOf check when parseQuery returns a SqlNode type


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
    Add some test cases where SQL statement has a limit keyword


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

