### PR TITLE
[GOBBLIN-205]Fix bug in pushmode copyRoute generation

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/replication/CopyRouteGeneratorBase.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/replication/CopyRouteGeneratorBase.java
@@ -45,11 +45,18 @@ public class CopyRouteGeneratorBase implements CopyRouteGenerator {
     List<DataFlowTopology.DataFlowPath> paths = topology.getDataFlowPaths();
 
     for (DataFlowTopology.DataFlowPath p : paths) {
+      /**
+       * Routes are list of pairs that generated from config in the format of topology specification.
+       * For example, source:[holdem, war] will end up with
+       * List<(source, holdem), (source, war)>
+       */
       List<CopyRoute> routes = p.getCopyRoutes();
+
       if (routes.isEmpty()) {
         continue;
       }
 
+      // All the routes should has the same copyFrom but different copyTo.
       if (routes.get(0).getCopyFrom().equals(copyFrom)) {
         return Optional.of(routes);
       }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/replication/DataFlowTopology.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/replication/DataFlowTopology.java
@@ -36,6 +36,16 @@ import lombok.AllArgsConstructor;;
  */
 
 @Data
+/**
+ * Some explanation combined with the example in configStore:
+ *
+ * {@link DataFlowTopology} is the whole block specified in,
+ * say {@link ReplicationConfiguration#DEFAULT_DATA_FLOW_TOPOLOGIES_PULLMODE}, normally call this topology.
+ *
+ * {@link #dataFlowPaths} is representing a line like: tarock:[source,holdem]
+ *
+ * From {@link #dataFlowPaths} we can have a list of {@link CopyRoute}.
+ */
 public class DataFlowTopology {
 
   private List<DataFlowPath> dataFlowPaths = new ArrayList<>();

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/replication/ReplicationConfiguration.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/replication/ReplicationConfiguration.java
@@ -343,6 +343,8 @@ public class ReplicationConfiguration {
       else {
         Set<String> currentCopyTo = new HashSet<>();
         for (final Map.Entry<String, EndPoint> valid : validEndPoints.entrySet()) {
+
+          // Only generate copyRoute from the EndPoint that running this job.
           if (routesConfig.hasPath(valid.getKey())) {
             List<String> copyToStringsRaw = routesConfig.getStringList(valid.getKey());
             List<String> copyToStrings = new ArrayList<>();


### PR DESCRIPTION
Add some docs to help understand and maintain the code

**The major code fix is to change a `return` to `continue` in `generateDatasetInPushMode` to make sure that each end-point of Push Mode will traversed.** 

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-205] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-205


### Description
- [x ] Here are some details about my PR, including screenshots (if applicable):


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

