### PR TITLE
[GOBBLIN-208] Make the application config the fallback for job configs

### DIFF
--- a/gobblin-aws/src/main/java/org/apache/gobblin/aws/AWSJobConfigurationManager.java
+++ b/gobblin-aws/src/main/java/org/apache/gobblin/aws/AWSJobConfigurationManager.java
@@ -50,6 +50,7 @@ import org.apache.gobblin.cluster.GobblinHelixJobScheduler;
 import org.apache.gobblin.cluster.JobConfigurationManager;
 import org.apache.gobblin.cluster.event.NewJobConfigArrivalEvent;
 import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.util.ConfigUtils;
 import org.apache.gobblin.util.ExecutorsUtils;
 import org.apache.gobblin.util.SchedulerUtils;
 
@@ -151,7 +152,7 @@ public class AWSJobConfigurationManager extends JobConfigurationManager {
       final File jobConfigDir = new File(extractedPullFilesPath);
       if (jobConfigDir.exists()) {
         LOGGER.info("Loading job configurations from " + jobConfigDir);
-        final Properties properties = new Properties();
+        final Properties properties = ConfigUtils.configToProperties(this.config);
         properties.setProperty(ConfigurationKeys.JOB_CONFIG_FILE_GENERAL_PATH_KEY, jobConfigDir.getAbsolutePath());
 
         final List<Properties> jobConfigs = SchedulerUtils.loadGenericJobConfigs(properties);

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterManager.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterManager.java
@@ -184,8 +184,9 @@ public class GobblinClusterManager implements ApplicationLauncher {
 
       this.jobCatalog =
           (MutableJobCatalog) GobblinConstructorUtils.invokeFirstConstructor(Class.forName(jobCatalogClassName),
-          ImmutableList.<Object>of(config.getConfig(
-              StringUtils.removeEnd(GobblinClusterConfigurationKeys.GOBBLIN_CLUSTER_PREFIX, "."))));
+          ImmutableList.<Object>of(config
+              .getConfig(StringUtils.removeEnd(GobblinClusterConfigurationKeys.GOBBLIN_CLUSTER_PREFIX, "."))
+              .withFallback(this.config)));
     } else {
       this.jobCatalog = null;
     }


### PR DESCRIPTION
When `GobblinClusterManager` create the `JobCatalog`, it passes in a copy of the system config, scoped to the `gobblin.cluster.` prefix.  This causes problems later when jobs are being loaded because properties they refer to may not be available.  The config should fall back to the unmodified system config.