### PR TITLE
[GOBBLIN-177] Added error limit for records failed during conversion in batch execution

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/TaskConfigurationKeys.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/TaskConfigurationKeys.java
@@ -37,4 +37,7 @@ public class TaskConfigurationKeys {
   public static final String TASK_IS_SINGLE_BRANCH_SYNCHRONOUS = "gobblin.task.is.single.branch.synchronous";
   public static final String DEFAULT_TASK_IS_SINGLE_BRANCH_SYNCHRONOUS = Boolean.toString(false);
 
+
+  public static final String TASK_SKIP_ERROR_RECORDS = "task.skip.error.records";
+  public static final long DEFAULT_TASK_SKIP_ERROR_RECORDS = 0;
 }

--- a/gobblin-test-harness/src/test/java/org/apache/gobblin/TaskSkipErrRecordsIntegrationTest.java
+++ b/gobblin-test-harness/src/test/java/org/apache/gobblin/TaskSkipErrRecordsIntegrationTest.java
@@ -1,0 +1,63 @@
+package org.apache.gobblin;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Properties;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.runtime.JobException;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+
+@Test
+public class TaskSkipErrRecordsIntegrationTest {
+  private static final String SAMPLE_FILE = "test.avro";
+  public static final String TASK_SKIP_ERROR_RECORDS = "task.skip.error.records";
+  public static final String ONE = "1";
+  public static final String ZERO = "0";
+
+  @BeforeTest
+  @AfterTest
+  public void cleanDir()
+      throws IOException {
+    GobblinLocalJobLauncherUtils.cleanDir();
+  }
+
+  /**
+   * Converter will throw DataConversionException while trying to convert
+   * first record. Since task.skip.error.records is set to 0, this job should fail.
+   */
+  @Test(expectedExceptions = JobException.class)
+  public void skipZeroErrorRecordTest()
+      throws Exception {
+    Properties jobProperties = getProperties();
+    jobProperties.setProperty(TASK_SKIP_ERROR_RECORDS, ZERO);
+    GobblinLocalJobLauncherUtils.invokeLocalJobLauncher(jobProperties);
+  }
+
+  /**
+   * Converter will throw DataConversionException while trying to convert
+   * first record. Since task.skip.error.records is set to 1, this job should succeed
+   */
+  @Test
+  public void skipOneErrorRecordTest()
+      throws Exception {
+    Properties jobProperties = getProperties();
+    jobProperties.setProperty(TASK_SKIP_ERROR_RECORDS, ONE);
+    GobblinLocalJobLauncherUtils.invokeLocalJobLauncher(jobProperties);
+  }
+
+  private Properties getProperties()
+      throws IOException {
+    Properties jobProperties =
+        GobblinLocalJobLauncherUtils.getJobProperties("runtime_test/task_skip_err_records.properties");
+    FileUtils.copyFile(new File(GobblinLocalJobLauncherUtils.RESOURCE_DIR + SAMPLE_FILE),
+        new File(GobblinLocalJobLauncherUtils.RESOURCE_DIR + GobblinLocalJobLauncherUtils.SAMPLE_DIR + SAMPLE_FILE));
+    jobProperties.setProperty(ConfigurationKeys.SOURCE_FILEBASED_FILES_TO_PULL,
+        GobblinLocalJobLauncherUtils.RESOURCE_DIR + GobblinLocalJobLauncherUtils.SAMPLE_DIR + SAMPLE_FILE);
+    return jobProperties;
+  }
+}

--- a/gobblin-test-harness/src/test/java/org/apache/gobblin/TestAvroConverter.java
+++ b/gobblin-test-harness/src/test/java/org/apache/gobblin/TestAvroConverter.java
@@ -1,0 +1,33 @@
+package org.apache.gobblin;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.gobblin.configuration.WorkUnitState;
+import org.apache.gobblin.converter.Converter;
+import org.apache.gobblin.converter.DataConversionException;
+import org.apache.gobblin.converter.SchemaConversionException;
+import org.apache.gobblin.converter.SingleRecordIterable;
+
+
+/**
+ * Test converter which throws DataConversionException while converting first record
+ */
+public class TestAvroConverter extends Converter<Schema, Schema, GenericRecord, GenericRecord> {
+  private long recordCount = 0;
+
+  @Override
+  public Schema convertSchema(Schema inputSchema, WorkUnitState workUnit)
+      throws SchemaConversionException {
+    return inputSchema;
+  }
+
+  @Override
+  public Iterable<GenericRecord> convertRecord(Schema outputSchema, GenericRecord inputRecord, WorkUnitState workUnit)
+      throws DataConversionException {
+    recordCount++;
+    if (recordCount == 1) {
+      throw new DataConversionException("Unable to convert record");
+    }
+    return new SingleRecordIterable<GenericRecord>(inputRecord);
+  }
+}

--- a/gobblin-test-harness/src/test/resources/runtime_test/task_skip_err_records.properties
+++ b/gobblin-test-harness/src/test/resources/runtime_test/task_skip_err_records.properties
@@ -1,0 +1,42 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+job.name=task_skip_err_records.job
+job.commit.policy=full
+
+job.lock.enabled=false
+
+extract.namespace=data.writerOutput
+extract.table.type=snapshot_append
+
+writer.destination.type=HDFS
+writer.eager.initialization=true
+writer.file.path=output
+writer.output.format=AVRO
+
+state.store.dir=./gobblin-test-harness/src/test/resources/runtime_test/state_store
+writer.staging.dir=./gobblin-test-harness/src/test/resources/runtime_test/writer_staging
+writer.output.dir=./gobblin-test-harness/src/test/resources/runtime_test/writer_output
+data.publisher.final.dir=./gobblin-test-harness/src/test/resources/runtime_test/final_dir
+
+
+source.class=org.apache.gobblin.TestAvroSource
+task.skip.error.records=1
+converter.classes=org.apache.gobblin.TestAvroConverter
+publish.data.at.job.level=true
+pubisher.class=org.apache.gobblin.publisher.BaseDataPublisher
+task.maxretries=0


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-177


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Modified task.java to have a configurable error limit for DataConversionExceptions
Also added a Integration test to verify the same


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Added test TaskSkipErrRecordsIntegrationTest


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

