### PR TITLE
Fix the filtering doesn't work issue when listing files from a given …

### DIFF
--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/FileListUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/FileListUtils.java
@@ -132,7 +132,7 @@ public class FileListUtils {
             files.add(status);
           }
         } else {
-          files.add(status);
+          listFilesRecursivelyHelper(fs, files, status, fileFilter, applyFilterToDirectories, includeEmptyDirectories);
         }
       }
     } else if (fileFilter.accept(fileStatus.getPath())) {

--- a/gobblin-utility/src/test/java/org/apache/gobblin/util/FileListUtilsTest.java
+++ b/gobblin-utility/src/test/java/org/apache/gobblin/util/FileListUtilsTest.java
@@ -146,6 +146,63 @@ public class FileListUtilsTest {
     }
   }
 
+  public void testListAllFiles () throws IOException {
+    FileSystem localFs = FileSystem.getLocal(new Configuration());
+    Path baseDir = new Path(FILE_UTILS_TEST_DIR, "listAllFiles");
+    System.out.println (baseDir);
+    try {
+      if (localFs.exists(baseDir)) {
+        localFs.delete(baseDir, true);
+      }
+      localFs.mkdirs(baseDir);
+
+      // Empty root directory
+      List<FileStatus> testFiles = FileListUtils.listFilesRecursively(localFs, baseDir, FileListUtils.NO_OP_PATH_FILTER);
+      Assert.assertTrue(testFiles.size() == 0);
+
+      // With two avro files (1.avro, 2.avro)
+      Path file1 = new Path(baseDir, "1.avro");
+      localFs.create(file1);
+      Path file2 = new Path(baseDir, "2.avro");
+      localFs.create(file2);
+      testFiles = FileListUtils.listFilesRecursively(localFs, baseDir, FileListUtils.NO_OP_PATH_FILTER);
+      Assert.assertTrue(testFiles.size() == 2);
+
+      // With an avro schema file (part.avsc)
+      Path avsc = new Path(baseDir, "part.avsc");
+      localFs.create(avsc);
+      testFiles = FileListUtils.listFilesRecursively(localFs, baseDir, FileListUtils.NO_OP_PATH_FILTER);
+      Assert.assertTrue(testFiles.size() == 3);
+      testFiles = FileListUtils.listFilesRecursively(localFs, baseDir, (path)->path.getName().endsWith(".avro"));
+      Assert.assertTrue(testFiles.size() == 2);
+
+      // A complicated hierarchy
+      // baseDir ____ 1.avro
+      //        |____ 2.avro
+      //        |____ part.avsc
+      //        |____ subDir ____ 3.avro
+      //                    |____ subDir2 ____ 4.avro
+      //                                 |____ part2.avsc
+      Path subDir = new Path(baseDir, "subDir");
+      localFs.mkdirs(subDir);
+      Path file3 = new Path(subDir, "3.avro");
+      localFs.create(file3);
+      Path subDir2 = new Path(subDir, "subDir2");
+      localFs.mkdirs(subDir2);
+      Path file4 = new Path(subDir2, "4.avro");
+      localFs.create(file4);
+      Path avsc2 = new Path(subDir2, "part2.avsc");
+      localFs.create(avsc2);
+
+      testFiles = FileListUtils.listFilesRecursively(localFs, baseDir, (path)->path.getName().endsWith(".avro"));
+      Assert.assertTrue(testFiles.size() == 4);
+      testFiles = FileListUtils.listFilesRecursively(localFs, baseDir, FileListUtils.NO_OP_PATH_FILTER);
+      Assert.assertTrue(testFiles.size() == 6);
+    } finally {
+      localFs.delete(baseDir, true);
+    }
+  }
+
   public void testListFilesToCopyAtPath() throws IOException {
     FileSystem localFs = FileSystem.getLocal(new Configuration());
     Path baseDir = new Path(FILE_UTILS_TEST_DIR, "fileListTestDir4");


### PR DESCRIPTION
…path

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-214


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
  The listFilesRecursively from FileListUtils does not apply the pathFilter to all the individual files. Add listAllFiles to fix the filtering issue and simplify the listing procedure. 


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
   testListAllFiles was added in FileListUtilsTest

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

