### PR TITLE
[GOBBLIN-220] FileAwareInputStreamDataWriter: Add a log statement whe…

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
@@ -226,6 +226,8 @@ public class FileAwareInputStreamDataWriter extends InstrumentedDataWriter<FileA
             .targetURI(this.fs.makeQualified(writeAt).toUri()).build();
         StreamCopier copier = new StreamCopier(throttledInputStream, os).withBufferSize(this.bufferSize);
 
+        log.info("File {}: Starting copy", copyableFile.getOrigin().getPath());
+
         if (isInstrumentationEnabled()) {
           copier.withCopySpeedMeter(this.copySpeedMeter);
         }


### PR DESCRIPTION
…n we begin file copies so if an exception is thrown it is easy to tie that back to the filename.

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-220


### Description
- [x ] Here are some details about my PR, including screenshots (if applicable):
See title above

### Tests
- [x ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

New log statement; no new unit tests needed

### Commits
- [x ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

