### PR TITLE
[GOBBLIN-56] Changing statestore checker to work with any state store

### DIFF
--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/util/JobStateToJsonConverterTest.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/util/JobStateToJsonConverterTest.java
@@ -16,16 +16,21 @@
  */
 package org.apache.gobblin.runtime.util;
 
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
-import com.google.gson.stream.JsonReader;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.Properties;
+
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.stream.JsonReader;
+
+import org.apache.gobblin.configuration.ConfigurationKeys;
+
 
 @Test(groups = { "gobblin.runtime" })
 public class JobStateToJsonConverterTest {
@@ -40,8 +45,33 @@ public class JobStateToJsonConverterTest {
   public void testJsonKeepConfig()
       throws IOException {
     String stateStorePath = getClass().getClassLoader().getResource(TEST_STORE).getPath();
+
     boolean keepConfig = true;
+
     JobStateToJsonConverter converter = new JobStateToJsonConverter(new Properties(), stateStorePath, keepConfig);
+
+    StringWriter stringWriter = new StringWriter();
+    converter.convert(TEST_JOB, stringWriter);
+
+    JsonObject json = new JsonParser().parse(new JsonReader(new StringReader(stringWriter.toString()))).getAsJsonObject();
+
+    Assert.assertNotNull(json.get(PROPERTIES));
+    for (JsonElement taskState: json.get(TASK_STATES).getAsJsonArray()) {
+      Assert.assertNotNull(taskState.getAsJsonObject().get(PROPERTIES));
+    }
+  }
+
+  @Test
+  public void testJsonKeepConfigWithoutStoreUrl()
+      throws IOException {
+    String stateStorePath = getClass().getClassLoader().getResource(TEST_STORE).getPath();
+    Properties properties = new Properties();
+
+    properties.setProperty(ConfigurationKeys.STATE_STORE_ROOT_DIR_KEY, stateStorePath);
+
+    boolean keepConfig = true;
+
+    JobStateToJsonConverter converter = new JobStateToJsonConverter(properties, null, keepConfig);
 
     StringWriter stringWriter = new StringWriter();
     converter.convert(TEST_JOB, stringWriter);


### PR DESCRIPTION
- Change statestore checker to work with any state store
- Make non-required the state store url
- Add required text to help for required properties
- Fix issue where it read second parameter as value due to using hasArgs instead of hasArg

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-XXX


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

