### PR TITLE
[GOBBLIN-228] Add config property to ignore fields in JsonRecordAvroSchemaToAvroConverter

### DIFF
--- a/gobblin-core/src/test/java/org/apache/gobblin/converter/avro/JsonRecordAvroSchemaToAvroConverterTest.java
+++ b/gobblin-core/src/test/java/org/apache/gobblin/converter/avro/JsonRecordAvroSchemaToAvroConverterTest.java
@@ -53,12 +53,13 @@ public class JsonRecordAvroSchemaToAvroConverterTest {
     this.state = new WorkUnitState(
         source.createWorkUnit(source.createExtract(TableType.SNAPSHOT_ONLY, "test_table", "test_namespace")));
     this.state.setProp(JsonRecordAvroSchemaToAvroConverter.AVRO_SCHEMA_KEY, avroSchemaString);
+    this.state.setProp(JsonRecordAvroSchemaToAvroConverter.IGNORE_FIELDS, "fieldToIgnore");
   }
 
   @Test
   public void testConverter()
       throws Exception {
-    JsonRecordAvroSchemaToAvroConverter<String> converter = new JsonRecordAvroSchemaToAvroConverter();
+    JsonRecordAvroSchemaToAvroConverter<String> converter = new JsonRecordAvroSchemaToAvroConverter<>();
 
     converter.init(this.state);
 
@@ -66,6 +67,7 @@ public class JsonRecordAvroSchemaToAvroConverterTest {
 
     GenericRecord record = converter.convertRecord(avroSchema, this.jsonRecord, this.state).iterator().next();
 
+    Assert.assertEquals(record.get("fieldToIgnore"), null);
     Assert.assertEquals(record.get("nullableField"), null);
     Assert.assertEquals(record.get("longField"), 1234L);
 

--- a/gobblin-core/src/test/resources/converter/jsonToAvroSchema.avsc
+++ b/gobblin-core/src/test/resources/converter/jsonToAvroSchema.avsc
@@ -4,6 +4,10 @@
   "namespace": "org.apache.gobblin.test",
   "fields": [
     {
+      "name": "fieldToIgnore",
+      "type": "string"
+    },
+    {
       "name": "nullableField",
       "type": ["string", "null"]
     },


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-228


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

Allow fields in the Avro schema to be skipped (set to null in the resulting record) if specified in config property

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Update unit test

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

