### PR TITLE
[GOBBLIN-229] Cleanup job.state file upon job completion in cluster mode

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobLauncher.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobLauncher.java
@@ -221,7 +221,7 @@ public class GobblinHelixJobLauncher extends AbstractJobLauncher {
     } finally {
       // The last iteration of output TaskState collecting will run when the collector service gets stopped
       this.taskStateCollectorService.stopAsync().awaitTerminated();
-      deletePersistedWorkUnitsForJob();
+      cleanupWorkingDirectory();
     }
   }
 
@@ -352,11 +352,14 @@ public class GobblinHelixJobLauncher extends AbstractJobLauncher {
   }
 
   /**
-   * Delete persisted {@link WorkUnit}s upon job completion.
+   * Delete persisted {@link WorkUnit}s and {@link JobState} upon job completion.
    */
-  private void deletePersistedWorkUnitsForJob() throws IOException {
+  private void cleanupWorkingDirectory() throws IOException {
     LOGGER.info("Deleting persisted work units for job " + this.jobContext.getJobId());
     stateStores.wuStateStore.delete(this.jobContext.getJobId());
+    LOGGER.info("Deleting job state file for job " + this.jobContext.getJobId());
+    Path jobStateFilePath = new Path(this.appWorkDir, this.jobContext.getJobId() + "." + JOB_STATE_FILE_NAME);
+    this.fs.delete(jobStateFilePath, false);
   }
 
   /**


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-229


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
   Add a job.state cleanup step which was previously missing for gobblin cluster running model.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
    GobblinHelixJobLauncherTest was run

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

