### PR TITLE
[GOBBLIN-236] Add a ControlMessage injector as a RecordStreamProcessor

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -147,6 +147,7 @@ public class ConfigurationKeys {
   public static final String TASK_DATA_ROOT_DIR_KEY = "task.data.root.dir";
   public static final String SOURCE_CLASS_KEY = "source.class";
   public static final String CONVERTER_CLASSES_KEY = "converter.classes";
+  public static final String RECORD_STREAM_PROCESSOR_CLASSES_KEY = "recordStreamProcessor.classes";
   public static final String FORK_OPERATOR_CLASS_KEY = "fork.operator.class";
   public static final String DEFAULT_FORK_OPERATOR_CLASS = "org.apache.gobblin.fork.IdentityForkOperator";
   public static final String JOB_COMMIT_POLICY_KEY = "job.commit.policy";

--- a/gobblin-api/src/main/java/org/apache/gobblin/converter/Converter.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/converter/Converter.java
@@ -25,10 +25,12 @@ import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.configuration.WorkUnitState;
 import org.apache.gobblin.converter.initializer.ConverterInitializer;
 import org.apache.gobblin.converter.initializer.NoopConverterInitializer;
+import org.apache.gobblin.metadata.GlobalMetadata;
 import org.apache.gobblin.stream.ControlMessage;
 import org.apache.gobblin.records.ControlMessageHandler;
 import org.apache.gobblin.records.RecordStreamProcessor;
 import org.apache.gobblin.records.RecordStreamWithMetadata;
+import org.apache.gobblin.stream.MetadataUpdateControlMessage;
 import org.apache.gobblin.stream.RecordEnvelope;
 import org.apache.gobblin.source.workunit.WorkUnitStream;
 import org.apache.gobblin.stream.StreamEntity;
@@ -55,6 +57,9 @@ import io.reactivex.Flowable;
  * @param <DO> output data type
  */
 public abstract class Converter<SI, SO, DI, DO> implements Closeable, FinalState, RecordStreamProcessor<SI, SO, DI, DO> {
+  // Metadata containing the output schema. This may be changed when a MetadataUpdateControlMessage is received.
+  private GlobalMetadata<SO> outputGlobalMetadata;
+
   /**
    * Initialize this {@link Converter}.
    *
@@ -120,16 +125,27 @@ public abstract class Converter<SI, SO, DI, DO> implements Closeable, FinalState
   public RecordStreamWithMetadata<DO, SO> processStream(RecordStreamWithMetadata<DI, SI> inputStream,
       WorkUnitState workUnitState) throws SchemaConversionException {
     init(workUnitState);
-    SO outputSchema = convertSchema(inputStream.getSchema(), workUnitState);
+    this.outputGlobalMetadata =
+        new GlobalMetadata<SO>(convertSchema(inputStream.getGlobalMetadata().getSchema(), workUnitState));
     Flowable<StreamEntity<DO>> outputStream =
         inputStream.getRecordStream()
             .flatMap(in -> {
               if (in instanceof ControlMessage) {
+                ControlMessage out = (ControlMessage) in;
+                // update the output schema with the new input schema from the MetadataUpdateControlMessage
+                if (in instanceof MetadataUpdateControlMessage) {
+                  this.outputGlobalMetadata =
+                      new GlobalMetadata<SO>(convertSchema((SI)((MetadataUpdateControlMessage) in).getGlobalMetadata()
+                                      .getSchema(), workUnitState));
+                  out = new MetadataUpdateControlMessage<SO, DO>(this.outputGlobalMetadata);
+                }
+
                 getMessageHandler().handleMessage((ControlMessage) in);
-                return Flowable.just(((ControlMessage<DO>) in));
+                return Flowable.just(((ControlMessage<DO>) out));
               } else if (in instanceof RecordEnvelope) {
                 RecordEnvelope<DI> recordEnvelope = (RecordEnvelope<DI>) in;
-                Iterator<DO> convertedIterable = convertRecord(outputSchema, recordEnvelope.getRecord(), workUnitState).iterator();
+                Iterator<DO> convertedIterable = convertRecord(this.outputGlobalMetadata.getSchema(),
+                    recordEnvelope.getRecord(), workUnitState).iterator();
 
                 if (!convertedIterable.hasNext()) {
                   // if the iterable is empty, ack the record, return an empty flowable
@@ -153,7 +169,7 @@ public abstract class Converter<SI, SO, DI, DO> implements Closeable, FinalState
               }
             }, 1);
     outputStream = outputStream.doOnComplete(this::close);
-    return inputStream.withRecordStream(outputStream, outputSchema);
+    return inputStream.withRecordStream(outputStream, this.outputGlobalMetadata);
   }
 
   /**

--- a/gobblin-api/src/main/java/org/apache/gobblin/converter/Converter.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/converter/Converter.java
@@ -139,7 +139,8 @@ public abstract class Converter<SI, SO, DI, DO> implements Closeable, FinalState
 
                 // update the output schema with the new input schema from the MetadataUpdateControlMessage
                 if (in instanceof MetadataUpdateControlMessage) {
-                  this.outputGlobalMetadata = GlobalMetadata.<SI, SO>builderWithInput(inputStream.getGlobalMetadata(),
+                  this.outputGlobalMetadata = GlobalMetadata.<SI, SO>builderWithInput(
+                      ((MetadataUpdateControlMessage) in).getGlobalMetadata(),
                       Optional.of(convertSchema((SI)((MetadataUpdateControlMessage) in).getGlobalMetadata()
                           .getSchema(), workUnitState))).build();
                   out = new MetadataUpdateControlMessage<SO, DO>(this.outputGlobalMetadata);

--- a/gobblin-api/src/main/java/org/apache/gobblin/fork/Forker.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/fork/Forker.java
@@ -24,6 +24,7 @@ import com.google.common.collect.Lists;
 
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.WorkUnitState;
+import org.apache.gobblin.metadata.GlobalMetadata;
 import org.apache.gobblin.records.RecordStreamWithMetadata;
 import org.apache.gobblin.stream.ControlMessage;
 import org.apache.gobblin.stream.RecordEnvelope;
@@ -59,7 +60,7 @@ public class Forker {
     workUnitState.setProp(ConfigurationKeys.FORK_BRANCHES_KEY, branches);
 
     forkOperator.init(workUnitState);
-    List<Boolean> forkedSchemas = forkOperator.forkSchema(workUnitState, inputStream.getSchema());
+    List<Boolean> forkedSchemas = forkOperator.forkSchema(workUnitState, inputStream.getGlobalMetadata().getSchema());
     int activeForks = (int) forkedSchemas.stream().filter(b -> b).count();
 
     Preconditions.checkState(forkedSchemas.size() == branches, String
@@ -90,7 +91,8 @@ public class Forker {
         Flowable<StreamEntity<D>> thisStream =
             forkedStream.filter(new ForkFilter<>(idx)).map(RecordWithForkMap::getRecordCopyIfNecessary);
         forkStreams.add(inputStream.withRecordStream(thisStream,
-            mustCopy ? (S) CopyHelper.copy(inputStream.getSchema()) : inputStream.getSchema()));
+            mustCopy ? (GlobalMetadata<S>) CopyHelper.copy(inputStream.getGlobalMetadata()) :
+                inputStream.getGlobalMetadata()));
       } else {
         forkStreams.add(null);
       }

--- a/gobblin-api/src/main/java/org/apache/gobblin/metadata/GlobalMetadata.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/metadata/GlobalMetadata.java
@@ -20,7 +20,11 @@ import org.apache.gobblin.fork.CopyHelper;
 import org.apache.gobblin.fork.CopyNotSupportedException;
 import org.apache.gobblin.fork.Copyable;
 
+import com.google.common.base.Optional;
+
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
@@ -29,8 +33,9 @@ import lombok.Getter;
  * Global metadata
  * @param <S> schema type
  */
-@AllArgsConstructor
+@AllArgsConstructor(access=AccessLevel.PRIVATE)
 @EqualsAndHashCode
+@Builder
 public class GlobalMetadata<S> implements Copyable<GlobalMetadata<S>> {
   @Getter
   private S schema;
@@ -42,5 +47,23 @@ public class GlobalMetadata<S> implements Copyable<GlobalMetadata<S>> {
     }
 
     throw new CopyNotSupportedException("Type is not copyable: " + schema.getClass().getName());
+  }
+
+  /**
+   * Builder that takes in an input {@GlobalMetadata} to use as a base.
+   * @param inputMetadata input metadata
+   * @param outputSchema output schema to set in the builder
+   * @param <SI> input schema type
+   * @param <SO> output schema type
+   * @return builder
+   */
+  public static <SI, SO> GlobalMetadataBuilder<SO> builderWithInput(GlobalMetadata<SI> inputMetadata, Optional<SO> outputSchema) {
+    GlobalMetadataBuilder<SO> builder = (GlobalMetadataBuilder<SO>) builder();
+
+    if (outputSchema.isPresent()) {
+      builder.schema(outputSchema.get());
+    }
+
+    return builder;
   }
 }

--- a/gobblin-api/src/main/java/org/apache/gobblin/metadata/GlobalMetadata.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/metadata/GlobalMetadata.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gobblin.metadata;
+
+import org.apache.gobblin.fork.CopyHelper;
+import org.apache.gobblin.fork.CopyNotSupportedException;
+import org.apache.gobblin.fork.Copyable;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+
+/**
+ * Global metadata
+ * @param <S> schema type
+ */
+@AllArgsConstructor
+@EqualsAndHashCode
+public class GlobalMetadata<S> implements Copyable<GlobalMetadata<S>> {
+  @Getter
+  private S schema;
+
+  @Override
+  public GlobalMetadata<S> copy() throws CopyNotSupportedException {
+    if (CopyHelper.isCopyable(schema)) {
+      return new GlobalMetadata((S)CopyHelper.copy(schema));
+    }
+
+    throw new CopyNotSupportedException("Type is not copyable: " + schema.getClass().getName());
+  }
+}

--- a/gobblin-api/src/main/java/org/apache/gobblin/records/RecordStreamWithMetadata.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/records/RecordStreamWithMetadata.java
@@ -49,7 +49,7 @@ public class RecordStreamWithMetadata<D, S> {
    */
   @Deprecated
   public <DO, SO> RecordStreamWithMetadata<DO, SO> withRecordStream(Flowable<StreamEntity<DO>> newRecordStream, SO newSchema) {
-    return new RecordStreamWithMetadata<>(newRecordStream, new GlobalMetadata<SO>(newSchema));
+    return new RecordStreamWithMetadata<>(newRecordStream, GlobalMetadata.<SO>builder().schema(newSchema).build());
   }
 
   /**

--- a/gobblin-api/src/main/java/org/apache/gobblin/records/RecordStreamWithMetadata.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/records/RecordStreamWithMetadata.java
@@ -19,6 +19,7 @@ package org.apache.gobblin.records;
 
 import java.util.function.Function;
 
+import org.apache.gobblin.metadata.GlobalMetadata;
 import org.apache.gobblin.stream.RecordEnvelope;
 import org.apache.gobblin.stream.StreamEntity;
 
@@ -34,20 +35,29 @@ import lombok.Data;
 @Data
 public class RecordStreamWithMetadata<D, S> {
   private final Flowable<StreamEntity<D>> recordStream;
-  private final S schema;
+  private final GlobalMetadata<S> globalMetadata;
 
   /**
    * @return a new {@link RecordStreamWithMetadata} with a different {@link #recordStream} but same schema.
    */
   public <DO> RecordStreamWithMetadata<DO, S> withRecordStream(Flowable<StreamEntity<DO>> newRecordStream) {
-    return withRecordStream(newRecordStream, this.schema);
+    return withRecordStream(newRecordStream, this.globalMetadata);
   }
 
   /**
-   * @return a new {@link RecordStreamWithMetadata} with a different {@link #recordStream} and {@link #schema}.
+   * @return a new {@link RecordStreamWithMetadata} with a different {@link #recordStream} and {@link #globalMetadata}.
    */
+  @Deprecated
   public <DO, SO> RecordStreamWithMetadata<DO, SO> withRecordStream(Flowable<StreamEntity<DO>> newRecordStream, SO newSchema) {
-    return new RecordStreamWithMetadata<>(newRecordStream, newSchema);
+    return new RecordStreamWithMetadata<>(newRecordStream, new GlobalMetadata<SO>(newSchema));
+  }
+
+  /**
+   * @return a new {@link RecordStreamWithMetadata} with a different {@link #recordStream} and {@link #globalMetadata}.
+   */
+  public <DO, SO> RecordStreamWithMetadata<DO, SO> withRecordStream(Flowable<StreamEntity<DO>> newRecordStream,
+      GlobalMetadata<SO> newGlobalMetadata) {
+    return new RecordStreamWithMetadata<>(newRecordStream, newGlobalMetadata);
   }
 
   /**
@@ -56,7 +66,7 @@ public class RecordStreamWithMetadata<D, S> {
    */
   public <DO> RecordStreamWithMetadata<DO, S>
       mapStream(Function<? super Flowable<StreamEntity<D>>, ? extends Flowable<StreamEntity<DO>>> transform) {
-    return new RecordStreamWithMetadata<>(transform.apply(this.recordStream), this.schema);
+    return new RecordStreamWithMetadata<>(transform.apply(this.recordStream), this.globalMetadata);
   }
 
   /**

--- a/gobblin-api/src/main/java/org/apache/gobblin/source/extractor/Extractor.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/source/extractor/Extractor.java
@@ -21,6 +21,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.apache.gobblin.metadata.GlobalMetadata;
 import org.apache.gobblin.records.RecordStreamWithMetadata;
 import org.apache.gobblin.stream.RecordEnvelope;
 import org.apache.gobblin.stream.StreamEntity;
@@ -128,7 +129,7 @@ public interface Extractor<S, D> extends Closeable {
       }
     });
     recordStream = recordStream.doFinally(this::close);
-    return new RecordStreamWithMetadata<>(recordStream, schema);
+    return new RecordStreamWithMetadata<>(recordStream, new GlobalMetadata<>(schema));
   }
 
 }

--- a/gobblin-api/src/main/java/org/apache/gobblin/source/extractor/Extractor.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/source/extractor/Extractor.java
@@ -129,7 +129,7 @@ public interface Extractor<S, D> extends Closeable {
       }
     });
     recordStream = recordStream.doFinally(this::close);
-    return new RecordStreamWithMetadata<>(recordStream, new GlobalMetadata<>(schema));
+    return new RecordStreamWithMetadata<>(recordStream, GlobalMetadata.<S>builder().schema(schema).build());
   }
 
 }

--- a/gobblin-api/src/main/java/org/apache/gobblin/stream/ControlMessageInjector.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/stream/ControlMessageInjector.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.stream;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+import org.apache.gobblin.configuration.WorkUnitState;
+import org.apache.gobblin.metadata.GlobalMetadata;
+import org.apache.gobblin.records.ControlMessageHandler;
+import org.apache.gobblin.records.RecordStreamProcessor;
+import org.apache.gobblin.records.RecordStreamWithMetadata;
+
+import io.reactivex.Flowable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * A {@link RecordStreamProcessor} that inspects an input record and outputs control messages before, after, or around
+ * the input record
+ * @param <SI>
+ * @param <DI>
+ */
+public abstract class ControlMessageInjector<SI, DI> implements Closeable,
+        RecordStreamProcessor<SI, SI, DI, DI> {
+
+  @Setter(AccessLevel.PROTECTED)
+  @Getter(AccessLevel.PROTECTED)
+  private GlobalMetadata<SI> inputGlobalMetadata;
+
+  /**
+   * Initialize this {@link ControlMessageInjector}.
+   *
+   * @param workUnitState a {@link WorkUnitState} object carrying configuration properties
+   * @return an initialized {@link ControlMessageInjector} instance
+   */
+  public ControlMessageInjector<SI, DI> init(WorkUnitState workUnitState) {
+    return this;
+  }
+
+  @Override
+  public void close() throws IOException {
+  }
+
+  /**
+   * Set the global metadata of the input messages
+   * @param inputGlobalMetadata the global metadata for input messages
+   * @param workUnitState
+   */
+  public void setInputGlobalMetadata(GlobalMetadata<SI> inputGlobalMetadata, WorkUnitState workUnitState) {
+    this.inputGlobalMetadata = inputGlobalMetadata;
+  }
+
+  /**
+   * Inject {@link ControlMessage}s before the record
+   * @param inputRecordEnvelope
+   * @param workUnitState
+   * @return The {@link ControlMessage}s to inject before the record
+   */
+  public abstract Iterable<ControlMessage<DI>> injectControlMessagesBefore(RecordEnvelope<DI> inputRecordEnvelope,
+      WorkUnitState workUnitState);
+
+  /**
+   * Inject {@link ControlMessage}s after the record
+   * @param inputRecordEnvelope
+   * @param workUnitState
+   * @return The {@link ControlMessage}s to inject after the record
+   */
+  public abstract Iterable<ControlMessage<DI>> injectControlMessagesAfter(RecordEnvelope<DI> inputRecordEnvelope,
+      WorkUnitState workUnitState);
+
+  /**
+   * Apply injections to the input {@link RecordStreamWithMetadata}.
+   * {@link ControlMessage}s may be injected before, after, or around the input record.
+   * A {@link MetadataUpdateControlMessage} will update the current input {@link GlobalMetadata} and pass the
+   * updated input {@link GlobalMetadata} to the next processor to propagate the metadata update down the pipeline.
+   */
+  @Override
+  public RecordStreamWithMetadata<DI, SI> processStream(RecordStreamWithMetadata<DI, SI> inputStream,
+      WorkUnitState workUnitState) throws StreamProcessingException {
+    init(workUnitState);
+
+    setInputGlobalMetadata(inputStream.getGlobalMetadata(), workUnitState);
+
+    Flowable<StreamEntity<DI>> outputStream =
+        inputStream.getRecordStream()
+            .flatMap(in -> {
+              if (in instanceof ControlMessage) {
+                ControlMessage out = (ControlMessage) in;
+                if (in instanceof MetadataUpdateControlMessage) {
+                  setInputGlobalMetadata(((MetadataUpdateControlMessage) in).getGlobalMetadata(),
+                      workUnitState);
+                  out = new MetadataUpdateControlMessage<SI, DI>(this.inputGlobalMetadata);
+                }
+
+                getMessageHandler().handleMessage((ControlMessage) in);
+                return Flowable.just(((ControlMessage<DI>) out));
+
+              } else if (in instanceof RecordEnvelope) {
+                RecordEnvelope<DI> recordEnvelope = (RecordEnvelope<DI>) in;
+                Iterable<ControlMessage<DI>> injectedBeforeIterable =
+                    injectControlMessagesBefore(recordEnvelope, workUnitState);
+                Iterable<ControlMessage<DI>> injectedAfterIterable =
+                    injectControlMessagesAfter(recordEnvelope, workUnitState);
+
+                if (injectedBeforeIterable == null && injectedAfterIterable == null) {
+                  // nothing injected so return the record envelope
+                  return Flowable.just(recordEnvelope);
+                } else {
+                  Flowable<StreamEntity<DI>> flowable;
+
+                  if (injectedBeforeIterable != null) {
+                    flowable = Flowable.<StreamEntity<DI>>fromIterable(injectedBeforeIterable)
+                        .concatWith(Flowable.just(recordEnvelope));
+                  } else {
+                    flowable = Flowable.just(recordEnvelope);
+                  }
+
+                  if (injectedAfterIterable != null) {
+                    flowable.concatWith(Flowable.fromIterable(injectedAfterIterable));
+                  }
+                  return flowable;
+                }
+              } else {
+                throw new UnsupportedOperationException();
+              }
+            }, 1);
+    outputStream = outputStream.doOnComplete(this::close);
+    return inputStream.withRecordStream(outputStream, this.inputGlobalMetadata);
+  }
+
+  /**
+   * @return {@link ControlMessageHandler} to call for each {@link ControlMessage} received.
+   */
+  public ControlMessageHandler getMessageHandler() {
+    return ControlMessageHandler.NOOP;
+  }
+}

--- a/gobblin-api/src/main/java/org/apache/gobblin/stream/ControlMessageInjector.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/stream/ControlMessageInjector.java
@@ -27,9 +27,6 @@ import org.apache.gobblin.records.RecordStreamProcessor;
 import org.apache.gobblin.records.RecordStreamWithMetadata;
 
 import io.reactivex.Flowable;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.Setter;
 
 /**
  * A {@link RecordStreamProcessor} that inspects an input record and outputs control messages before, after, or around

--- a/gobblin-api/src/main/java/org/apache/gobblin/stream/ControlMessageInjector.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/stream/ControlMessageInjector.java
@@ -50,7 +50,7 @@ public abstract class ControlMessageInjector<SI, DI> implements Closeable,
    * @param workUnitState a {@link WorkUnitState} object carrying configuration properties
    * @return an initialized {@link ControlMessageInjector} instance
    */
-  public ControlMessageInjector<SI, DI> init(WorkUnitState workUnitState) {
+  protected ControlMessageInjector<SI, DI> init(WorkUnitState workUnitState) {
     return this;
   }
 
@@ -63,7 +63,7 @@ public abstract class ControlMessageInjector<SI, DI> implements Closeable,
    * @param inputGlobalMetadata the global metadata for input messages
    * @param workUnitState
    */
-  public void setInputGlobalMetadata(GlobalMetadata<SI> inputGlobalMetadata, WorkUnitState workUnitState) {
+  protected void setInputGlobalMetadata(GlobalMetadata<SI> inputGlobalMetadata, WorkUnitState workUnitState) {
     this.inputGlobalMetadata = inputGlobalMetadata;
   }
 
@@ -73,7 +73,7 @@ public abstract class ControlMessageInjector<SI, DI> implements Closeable,
    * @param workUnitState
    * @return The {@link ControlMessage}s to inject before the record
    */
-  public abstract Iterable<ControlMessage<DI>> injectControlMessagesBefore(RecordEnvelope<DI> inputRecordEnvelope,
+  protected abstract Iterable<ControlMessage<DI>> injectControlMessagesBefore(RecordEnvelope<DI> inputRecordEnvelope,
       WorkUnitState workUnitState);
 
   /**
@@ -82,7 +82,7 @@ public abstract class ControlMessageInjector<SI, DI> implements Closeable,
    * @param workUnitState
    * @return The {@link ControlMessage}s to inject after the record
    */
-  public abstract Iterable<ControlMessage<DI>> injectControlMessagesAfter(RecordEnvelope<DI> inputRecordEnvelope,
+  protected abstract Iterable<ControlMessage<DI>> injectControlMessagesAfter(RecordEnvelope<DI> inputRecordEnvelope,
       WorkUnitState workUnitState);
 
   /**
@@ -148,7 +148,7 @@ public abstract class ControlMessageInjector<SI, DI> implements Closeable,
   /**
    * @return {@link ControlMessageHandler} to call for each {@link ControlMessage} received.
    */
-  public ControlMessageHandler getMessageHandler() {
+  protected ControlMessageHandler getMessageHandler() {
     return ControlMessageHandler.NOOP;
   }
 }

--- a/gobblin-api/src/main/java/org/apache/gobblin/stream/MetadataUpdateControlMessage.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/stream/MetadataUpdateControlMessage.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gobblin.stream;
+
+import org.apache.gobblin.metadata.GlobalMetadata;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+
+/**
+ * Control message for updating the {@link GlobalMetadata} used for processing records
+ * @param <S> schema type
+ * @param <D> data type
+ */
+@AllArgsConstructor
+@EqualsAndHashCode
+public class MetadataUpdateControlMessage<S, D> extends ControlMessage<D> {
+  @Getter
+  private GlobalMetadata<S> globalMetadata;
+
+  @Override
+  protected StreamEntity<D> buildClone() {
+    return new MetadataUpdateControlMessage(this.globalMetadata);
+  }
+}

--- a/gobblin-api/src/test/java/org/apache/gobblin/converter/ConverterTest.java
+++ b/gobblin-api/src/test/java/org/apache/gobblin/converter/ConverterTest.java
@@ -44,7 +44,7 @@ public class ConverterTest {
 
     RecordStreamWithMetadata<Integer, String> stream =
         new RecordStreamWithMetadata<>(Flowable.just(new RecordEnvelope<>(0)),
-            new GlobalMetadata<>("schema")).mapRecords(r -> {
+            GlobalMetadata.<String>builder().schema("schema").build()).mapRecords(r -> {
           r.addCallBack(ackable);
           return r;
         });
@@ -63,7 +63,7 @@ public class ConverterTest {
 
     RecordStreamWithMetadata<Integer, String> stream =
         new RecordStreamWithMetadata<>(Flowable.just(new RecordEnvelope<>(1)),
-            new GlobalMetadata<>("schema")).mapRecords(r -> {
+            GlobalMetadata.<String>builder().schema("schema").build()).mapRecords(r -> {
           r.addCallBack(ackable);
           return r;
         });
@@ -85,7 +85,7 @@ public class ConverterTest {
 
     RecordStreamWithMetadata<Integer, String> stream =
         new RecordStreamWithMetadata<>(Flowable.just(new RecordEnvelope<>(2)),
-            new GlobalMetadata<>("schema")).mapRecords(r -> {
+            GlobalMetadata.<String>builder().schema("schema").build()).mapRecords(r -> {
           r.addCallBack(ackable);
           return r;
         });
@@ -110,7 +110,7 @@ public class ConverterTest {
 
     RecordStreamWithMetadata<Integer, String> stream =
         new RecordStreamWithMetadata<>(Flowable.just(new RecordEnvelope<>(1), new MyControlMessage<>()),
-            new GlobalMetadata<>("schema")).mapRecords(r -> {
+            GlobalMetadata.<String>builder().schema("schema").build()).mapRecords(r -> {
           r.addCallBack(ackable);
           return r;
         });

--- a/gobblin-api/src/test/java/org/apache/gobblin/converter/ConverterTest.java
+++ b/gobblin-api/src/test/java/org/apache/gobblin/converter/ConverterTest.java
@@ -26,6 +26,7 @@ import com.google.common.collect.Lists;
 
 import org.apache.gobblin.ack.BasicAckableForTesting;
 import org.apache.gobblin.configuration.WorkUnitState;
+import org.apache.gobblin.metadata.GlobalMetadata;
 import org.apache.gobblin.records.RecordStreamWithMetadata;
 import org.apache.gobblin.stream.ControlMessage;
 import org.apache.gobblin.stream.RecordEnvelope;
@@ -42,7 +43,8 @@ public class ConverterTest {
     BasicAckableForTesting ackable = new BasicAckableForTesting();
 
     RecordStreamWithMetadata<Integer, String> stream =
-        new RecordStreamWithMetadata<>(Flowable.just(new RecordEnvelope<>(0)), "schema").mapRecords(r -> {
+        new RecordStreamWithMetadata<>(Flowable.just(new RecordEnvelope<>(0)),
+            new GlobalMetadata<>("schema")).mapRecords(r -> {
           r.addCallBack(ackable);
           return r;
         });
@@ -60,7 +62,8 @@ public class ConverterTest {
     BasicAckableForTesting ackable = new BasicAckableForTesting();
 
     RecordStreamWithMetadata<Integer, String> stream =
-        new RecordStreamWithMetadata<>(Flowable.just(new RecordEnvelope<>(1)), "schema").mapRecords(r -> {
+        new RecordStreamWithMetadata<>(Flowable.just(new RecordEnvelope<>(1)),
+            new GlobalMetadata<>("schema")).mapRecords(r -> {
           r.addCallBack(ackable);
           return r;
         });
@@ -81,7 +84,8 @@ public class ConverterTest {
     BasicAckableForTesting ackable = new BasicAckableForTesting();
 
     RecordStreamWithMetadata<Integer, String> stream =
-        new RecordStreamWithMetadata<>(Flowable.just(new RecordEnvelope<>(2)), "schema").mapRecords(r -> {
+        new RecordStreamWithMetadata<>(Flowable.just(new RecordEnvelope<>(2)),
+            new GlobalMetadata<>("schema")).mapRecords(r -> {
           r.addCallBack(ackable);
           return r;
         });
@@ -105,7 +109,8 @@ public class ConverterTest {
     BasicAckableForTesting ackable = new BasicAckableForTesting();
 
     RecordStreamWithMetadata<Integer, String> stream =
-        new RecordStreamWithMetadata<>(Flowable.just(new RecordEnvelope<>(1), new MyControlMessage<>()), "schema").mapRecords(r -> {
+        new RecordStreamWithMetadata<>(Flowable.just(new RecordEnvelope<>(1), new MyControlMessage<>()),
+            new GlobalMetadata<>("schema")).mapRecords(r -> {
           r.addCallBack(ackable);
           return r;
         });

--- a/gobblin-api/src/test/java/org/apache/gobblin/fork/ForkerTest.java
+++ b/gobblin-api/src/test/java/org/apache/gobblin/fork/ForkerTest.java
@@ -32,6 +32,7 @@ import com.google.common.collect.Lists;
 
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.WorkUnitState;
+import org.apache.gobblin.metadata.GlobalMetadata;
 import org.apache.gobblin.records.RecordStreamWithMetadata;
 import org.apache.gobblin.runtime.BasicTestControlMessage;
 import org.apache.gobblin.stream.RecordEnvelope;
@@ -48,7 +49,8 @@ public class ForkerTest {
     Forker forker = new Forker();
     MyFlowable<StreamEntity<byte[]>> flowable = new MyFlowable<>();
 
-    RecordStreamWithMetadata<byte[], String> stream = new RecordStreamWithMetadata<>(flowable, "schema");
+    RecordStreamWithMetadata<byte[], String> stream =
+        new RecordStreamWithMetadata<>(flowable, new GlobalMetadata<>("schema"));
 
     WorkUnitState workUnitState = new WorkUnitState();
     workUnitState.setProp(ConfigurationKeys.FORK_BRANCHES_KEY, "3");

--- a/gobblin-api/src/test/java/org/apache/gobblin/fork/ForkerTest.java
+++ b/gobblin-api/src/test/java/org/apache/gobblin/fork/ForkerTest.java
@@ -50,7 +50,7 @@ public class ForkerTest {
     MyFlowable<StreamEntity<byte[]>> flowable = new MyFlowable<>();
 
     RecordStreamWithMetadata<byte[], String> stream =
-        new RecordStreamWithMetadata<>(flowable, new GlobalMetadata<>("schema"));
+        new RecordStreamWithMetadata<>(flowable, GlobalMetadata.<String>builder().schema("schema").build());
 
     WorkUnitState workUnitState = new WorkUnitState();
     workUnitState.setProp(ConfigurationKeys.FORK_BRANCHES_KEY, "3");

--- a/gobblin-core-base/src/main/java/org/apache/gobblin/converter/AsyncConverter1to1.java
+++ b/gobblin-core-base/src/main/java/org/apache/gobblin/converter/AsyncConverter1to1.java
@@ -19,6 +19,8 @@ package org.apache.gobblin.converter;
 
 import java.util.concurrent.CompletableFuture;
 
+import com.google.common.base.Optional;
+
 import org.apache.gobblin.annotation.Alpha;
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.WorkUnitState;
@@ -92,7 +94,8 @@ public abstract class AsyncConverter1to1<SI, SO, DI, DO> extends Converter<SI, S
                 throw new IllegalStateException("Expected ControlMessage or RecordEnvelope.");
               }
             }, false, maxConcurrentAsyncConversions);
-    return inputStream.withRecordStream(outputStream, new GlobalMetadata<SO>(outputSchema));
+    return inputStream.withRecordStream(outputStream, GlobalMetadata.<SI, SO>builderWithInput(inputStream.getGlobalMetadata(),
+        Optional.of(outputSchema)).build());
   }
 
   @RequiredArgsConstructor

--- a/gobblin-core-base/src/main/java/org/apache/gobblin/converter/AsyncConverter1to1.java
+++ b/gobblin-core-base/src/main/java/org/apache/gobblin/converter/AsyncConverter1to1.java
@@ -22,6 +22,7 @@ import java.util.concurrent.CompletableFuture;
 import org.apache.gobblin.annotation.Alpha;
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.WorkUnitState;
+import org.apache.gobblin.metadata.GlobalMetadata;
 import org.apache.gobblin.stream.ControlMessage;
 import org.apache.gobblin.records.RecordStreamWithMetadata;
 import org.apache.gobblin.stream.RecordEnvelope;
@@ -64,12 +65,20 @@ public abstract class AsyncConverter1to1<SI, SO, DI, DO> extends Converter<SI, S
   protected abstract CompletableFuture<DO> convertRecordAsync(SO outputSchema, DI inputRecord, WorkUnitState workUnit)
       throws DataConversionException;
 
+  /**
+   * Return a {@link RecordStreamWithMetadata} with the appropriate modifications.
+   * @param inputStream
+   * @param workUnitState
+   * @return
+   * @throws SchemaConversionException
+   * @implNote this processStream does not handle {@link org.apache.gobblin.stream.MetadataUpdateControlMessage}s
+   */
   @Override
   public RecordStreamWithMetadata<DO, SO> processStream(RecordStreamWithMetadata<DI, SI> inputStream,
       WorkUnitState workUnitState) throws SchemaConversionException {
     int maxConcurrentAsyncConversions = workUnitState.getPropAsInt(MAX_CONCURRENT_ASYNC_CONVERSIONS_KEY,
         DEFAULT_MAX_CONCURRENT_ASYNC_CONVERSIONS);
-    SO outputSchema = convertSchema(inputStream.getSchema(), workUnitState);
+    SO outputSchema = convertSchema(inputStream.getGlobalMetadata().getSchema(), workUnitState);
     Flowable<StreamEntity<DO>> outputStream =
         inputStream.getRecordStream()
             .flatMapSingle(in -> {
@@ -83,7 +92,7 @@ public abstract class AsyncConverter1to1<SI, SO, DI, DO> extends Converter<SI, S
                 throw new IllegalStateException("Expected ControlMessage or RecordEnvelope.");
               }
             }, false, maxConcurrentAsyncConversions);
-    return inputStream.withRecordStream(outputStream, outputSchema);
+    return inputStream.withRecordStream(outputStream, new GlobalMetadata<SO>(outputSchema));
   }
 
   @RequiredArgsConstructor

--- a/gobblin-core-base/src/main/java/org/apache/gobblin/instrumented/extractor/InstrumentedExtractorBase.java
+++ b/gobblin-core-base/src/main/java/org/apache/gobblin/instrumented/extractor/InstrumentedExtractorBase.java
@@ -191,7 +191,8 @@ public abstract class InstrumentedExtractorBase<S, D>
       }
     });
     recordStream = recordStream.doFinally(this::close);
-    return new RecordStreamWithMetadata<>(recordStream, new GlobalMetadata<S>(schema));
+    return new RecordStreamWithMetadata<>(recordStream, GlobalMetadata.<S>builder().schema(schema).build());
+
   }
 
   /**

--- a/gobblin-core-base/src/main/java/org/apache/gobblin/instrumented/extractor/InstrumentedExtractorBase.java
+++ b/gobblin-core-base/src/main/java/org/apache/gobblin/instrumented/extractor/InstrumentedExtractorBase.java
@@ -34,6 +34,7 @@ import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.configuration.WorkUnitState;
 import org.apache.gobblin.instrumented.Instrumentable;
 import org.apache.gobblin.instrumented.Instrumented;
+import org.apache.gobblin.metadata.GlobalMetadata;
 import org.apache.gobblin.metrics.GobblinMetrics;
 import org.apache.gobblin.metrics.MetricContext;
 import org.apache.gobblin.metrics.MetricNames;
@@ -190,7 +191,7 @@ public abstract class InstrumentedExtractorBase<S, D>
       }
     });
     recordStream = recordStream.doFinally(this::close);
-    return new RecordStreamWithMetadata<>(recordStream, schema);
+    return new RecordStreamWithMetadata<>(recordStream, new GlobalMetadata<S>(schema));
   }
 
   /**

--- a/gobblin-core-base/src/test/java/org/apache/gobblin/converter/AsyncConverter1to1Test.java
+++ b/gobblin-core-base/src/test/java/org/apache/gobblin/converter/AsyncConverter1to1Test.java
@@ -31,6 +31,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
 import org.apache.gobblin.configuration.WorkUnitState;
+import org.apache.gobblin.metadata.GlobalMetadata;
 import org.apache.gobblin.records.RecordStreamWithMetadata;
 import org.apache.gobblin.stream.RecordEnvelope;
 import org.apache.gobblin.util.ExponentialBackoff;
@@ -52,7 +53,8 @@ public class AsyncConverter1to1Test {
     workUnitState.setProp(AsyncConverter1to1.MAX_CONCURRENT_ASYNC_CONVERSIONS_KEY, 3);
 
     RecordStreamWithMetadata<String, String> stream =
-        new RecordStreamWithMetadata<>(Flowable.range(0, 5).map(i -> i.toString()).map(RecordEnvelope::new), "schema");
+        new RecordStreamWithMetadata<>(Flowable.range(0, 5).map(i -> i.toString()).map(RecordEnvelope::new),
+            new GlobalMetadata<>("schema"));
 
     Set<String> outputRecords = Sets.newConcurrentHashSet();
 
@@ -106,7 +108,8 @@ public class AsyncConverter1to1Test {
     workUnitState.setProp(AsyncConverter1to1.MAX_CONCURRENT_ASYNC_CONVERSIONS_KEY, 3);
 
     RecordStreamWithMetadata<String, String> stream =
-        new RecordStreamWithMetadata<>(Flowable.just("0", MyAsyncConverter1to1.FAIL, "1").map(RecordEnvelope::new), "schema");
+        new RecordStreamWithMetadata<>(Flowable.just("0", MyAsyncConverter1to1.FAIL, "1").map(RecordEnvelope::new),
+            new GlobalMetadata<>("schema"));
 
     Set<String> outputRecords = Sets.newConcurrentHashSet();
 

--- a/gobblin-core-base/src/test/java/org/apache/gobblin/converter/AsyncConverter1to1Test.java
+++ b/gobblin-core-base/src/test/java/org/apache/gobblin/converter/AsyncConverter1to1Test.java
@@ -54,7 +54,7 @@ public class AsyncConverter1to1Test {
 
     RecordStreamWithMetadata<String, String> stream =
         new RecordStreamWithMetadata<>(Flowable.range(0, 5).map(i -> i.toString()).map(RecordEnvelope::new),
-            new GlobalMetadata<>("schema"));
+            GlobalMetadata.<String>builder().schema("schema").build());
 
     Set<String> outputRecords = Sets.newConcurrentHashSet();
 
@@ -109,7 +109,7 @@ public class AsyncConverter1to1Test {
 
     RecordStreamWithMetadata<String, String> stream =
         new RecordStreamWithMetadata<>(Flowable.just("0", MyAsyncConverter1to1.FAIL, "1").map(RecordEnvelope::new),
-            new GlobalMetadata<>("schema"));
+            GlobalMetadata.<String>builder().schema("schema").build());
 
     Set<String> outputRecords = Sets.newConcurrentHashSet();
 

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/Task.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/Task.java
@@ -17,6 +17,7 @@
 
 package org.apache.gobblin.runtime;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -29,7 +30,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.commons.lang3.BooleanUtils;
-import org.apache.gobblin.converter.DataConversionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -43,14 +43,13 @@ import com.google.common.io.Closer;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
-import lombok.NoArgsConstructor;
-
 import org.apache.gobblin.Constructs;
 import org.apache.gobblin.commit.SpeculativeAttemptAwareConstruct;
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.configuration.WorkUnitState;
 import org.apache.gobblin.converter.Converter;
+import org.apache.gobblin.converter.DataConversionException;
 import org.apache.gobblin.fork.CopyHelper;
 import org.apache.gobblin.fork.CopyNotSupportedException;
 import org.apache.gobblin.fork.Copyable;
@@ -64,6 +63,7 @@ import org.apache.gobblin.publisher.DataPublisher;
 import org.apache.gobblin.publisher.SingleTaskDataPublisher;
 import org.apache.gobblin.qualitychecker.row.RowLevelPolicyCheckResults;
 import org.apache.gobblin.qualitychecker.row.RowLevelPolicyChecker;
+import org.apache.gobblin.records.RecordStreamProcessor;
 import org.apache.gobblin.runtime.fork.AsynchronousFork;
 import org.apache.gobblin.runtime.fork.Fork;
 import org.apache.gobblin.runtime.fork.SynchronousFork;
@@ -71,18 +71,13 @@ import org.apache.gobblin.runtime.task.TaskIFace;
 import org.apache.gobblin.runtime.util.TaskMetrics;
 import org.apache.gobblin.source.extractor.Extractor;
 import org.apache.gobblin.source.extractor.JobCommitPolicy;
-import org.apache.gobblin.stream.RecordEnvelope;
 import org.apache.gobblin.source.extractor.StreamingExtractor;
 import org.apache.gobblin.state.ConstructState;
+import org.apache.gobblin.stream.RecordEnvelope;
 import org.apache.gobblin.util.ConfigUtils;
-import org.apache.gobblin.writer.AcknowledgableWatermark;
-import org.apache.gobblin.writer.DataWriter;
-import org.apache.gobblin.writer.FineGrainedWatermarkTracker;
-import org.apache.gobblin.writer.MultiWriterWatermarkManager;
-import org.apache.gobblin.writer.TrackerBasedWatermarkManager;
-import org.apache.gobblin.writer.WatermarkAwareWriter;
-import org.apache.gobblin.writer.WatermarkManager;
-import org.apache.gobblin.writer.WatermarkStorage;
+import org.apache.gobblin.writer.*;
+
+import lombok.NoArgsConstructor;
 
 
 /**
@@ -139,6 +134,7 @@ public class Task implements TaskIFace {
   private final Optional<WatermarkManager> watermarkManager;
   private final Optional<FineGrainedWatermarkTracker> watermarkTracker;
   private final Optional<WatermarkStorage> watermarkStorage;
+  private final List<RecordStreamProcessor<?,?,?,?>> recordStreamProcessors;
 
   private final Closer closer;
 
@@ -173,7 +169,30 @@ public class Task implements TaskIFace {
     this.extractor =
         closer.register(new InstrumentedExtractorDecorator<>(this.taskState, this.taskContext.getExtractor()));
 
-    this.converter = closer.register(new MultiConverter(this.taskContext.getConverters()));
+    this.recordStreamProcessors = this.taskContext.getRecordStreamProcessors();
+
+    // add record stream processors to closer if they are closeable
+    for (RecordStreamProcessor r: recordStreamProcessors) {
+      if (r instanceof Closeable) {
+        this.closer.register((Closeable)r);
+      }
+    }
+
+    List<Converter<?,?,?,?>> converters = this.taskContext.getConverters();
+
+    this.converter = closer.register(new MultiConverter(converters));
+
+    // can't have both record stream processors and converter lists configured
+    if (!this.recordStreamProcessors.isEmpty() && !converters.isEmpty()) {
+      try {
+        closer.close();
+      } catch (Throwable t) {
+        LOG.error("Failed to close all open resources", t);
+      }
+
+      throw new TaskInstantiationException("Converters cannot be specified when RecordStreamProcessors are specified");
+    }
+
     try {
       this.rowChecker = closer.register(this.taskContext.getRowLevelPolicyChecker());
     } catch (Exception e) {
@@ -314,7 +333,7 @@ public class Task implements TaskIFace {
         runSynchronousModel();
       } else {
         new StreamModelTaskRunner(this, this.taskState, this.closer, this.taskContext, this.extractor,
-            this.converter, this.rowChecker, this.taskExecutor, this.taskMode, this.shutdownRequested,
+            this.converter, this.recordStreamProcessors, this.rowChecker, this.taskExecutor, this.taskMode, this.shutdownRequested,
             this.watermarkTracker, this.watermarkManager, this.watermarkStorage, this.forks, this.watermarkingStrategy).run();
       }
 

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/TestRecordStream.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/TestRecordStream.java
@@ -19,6 +19,7 @@ package org.apache.gobblin.runtime;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
@@ -38,27 +39,33 @@ import org.apache.gobblin.configuration.WorkUnitState;
 import org.apache.gobblin.converter.Converter;
 import org.apache.gobblin.converter.DataConversionException;
 import org.apache.gobblin.converter.SchemaConversionException;
+import org.apache.gobblin.converter.SingleRecordIterable;
 import org.apache.gobblin.fork.IdentityForkOperator;
+import org.apache.gobblin.metadata.GlobalMetadata;
 import org.apache.gobblin.publisher.TaskPublisher;
 import org.apache.gobblin.qualitychecker.row.RowLevelPolicyChecker;
 import org.apache.gobblin.qualitychecker.task.TaskLevelPolicyCheckResults;
 import org.apache.gobblin.qualitychecker.task.TaskLevelPolicyChecker;
 import org.apache.gobblin.records.ControlMessageHandler;
+import org.apache.gobblin.records.RecordStreamProcessor;
 import org.apache.gobblin.records.RecordStreamWithMetadata;
 import org.apache.gobblin.source.extractor.Extractor;
 import org.apache.gobblin.source.workunit.Extract;
 import org.apache.gobblin.source.workunit.WorkUnit;
 import org.apache.gobblin.stream.ControlMessage;
+import org.apache.gobblin.stream.ControlMessageInjector;
 import org.apache.gobblin.stream.FlushControlMessage;
+import org.apache.gobblin.stream.MetadataUpdateControlMessage;
 import org.apache.gobblin.stream.RecordEnvelope;
 import org.apache.gobblin.stream.StreamEntity;
 import org.apache.gobblin.writer.DataWriter;
 import org.apache.gobblin.writer.DataWriterBuilder;
 
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.*;
 import io.reactivex.Flowable;
 import lombok.AllArgsConstructor;
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
 
 
 /**
@@ -107,6 +114,94 @@ public class TestRecordStream {
 
     Assert.assertEquals(writer.records, Lists.newArrayList("a", "b"));
     Assert.assertEquals(writer.messages, Lists.newArrayList("flush called", "flush called"));
+  }
+
+  /**
+   * Test of metadata update control messages that signal the converters to change schemas
+   * @throws Exception
+   */
+  @Test
+  public void testMetadataUpdateControlMessages() throws Exception {
+
+    MyExtractor extractor = new MyExtractor(new StreamEntity[]{new RecordEnvelope<>("a"),
+        new MetadataUpdateControlMessage<>(new GlobalMetadata<>("Schema1")), new RecordEnvelope<>("b"),
+            new MetadataUpdateControlMessage(new GlobalMetadata<>("Schema2"))});
+    SchemaAppendConverter converter = new SchemaAppendConverter();
+    MyDataWriter writer = new MyDataWriter();
+
+    Task task = setupTask(extractor, writer, converter);
+
+    task.run();
+    task.commit();
+    Assert.assertEquals(task.getTaskState().getWorkingState(), WorkUnitState.WorkingState.SUCCESSFUL);
+
+    Assert.assertEquals(converter.records, Lists.newArrayList("a:schema", "b:Schema1"));
+    Assert.assertEquals(converter.messages,
+        Lists.newArrayList(new MetadataUpdateControlMessage<>(new GlobalMetadata<>("Schema1")),
+            new MetadataUpdateControlMessage<>(new GlobalMetadata<>("Schema2"))));
+
+    Assert.assertEquals(writer.records, Lists.newArrayList("a:schema", "b:Schema1"));
+    Assert.assertEquals(writer.messages, Lists.newArrayList(new MetadataUpdateControlMessage<>(new GlobalMetadata<>("Schema1")),
+        new MetadataUpdateControlMessage<>(new GlobalMetadata<>("Schema2"))));
+  }
+
+  /**
+   * Test with the converter configured in the list of {@link RecordStreamProcessor}s.
+   * @throws Exception
+   */
+  @Test
+  public void testMetadataUpdateWithStreamProcessors() throws Exception {
+
+    MyExtractor extractor = new MyExtractor(new StreamEntity[]{new RecordEnvelope<>("a"),
+        new MetadataUpdateControlMessage<>(new GlobalMetadata<>("Schema1")), new RecordEnvelope<>("b"),
+        new MetadataUpdateControlMessage(new GlobalMetadata<>("Schema2"))});
+    SchemaAppendConverter converter = new SchemaAppendConverter();
+    MyDataWriter writer = new MyDataWriter();
+
+    Task task = setupTask(extractor, writer, Collections.EMPTY_LIST, Lists.newArrayList(converter));
+
+    task.run();
+    task.commit();
+    Assert.assertEquals(task.getTaskState().getWorkingState(), WorkUnitState.WorkingState.SUCCESSFUL);
+
+    Assert.assertEquals(converter.records, Lists.newArrayList("a:schema", "b:Schema1"));
+    Assert.assertEquals(converter.messages,
+        Lists.newArrayList(new MetadataUpdateControlMessage<>(new GlobalMetadata<>("Schema1")),
+            new MetadataUpdateControlMessage<>(new GlobalMetadata<>("Schema2"))));
+
+    Assert.assertEquals(writer.records, Lists.newArrayList("a:schema", "b:Schema1"));
+    Assert.assertEquals(writer.messages, Lists.newArrayList(new MetadataUpdateControlMessage<>(new GlobalMetadata<>("Schema1")),
+        new MetadataUpdateControlMessage<>(new GlobalMetadata<>("Schema2"))));
+  }
+
+  /**
+   * Test the injection of {@link ControlMessage}s
+   * @throws Exception
+   */
+  @Test
+  public void testInjectedControlMessages() throws Exception {
+
+    MyExtractor extractor = new MyExtractor(new StreamEntity[]{new RecordEnvelope<>("schema:a"),
+        new RecordEnvelope<>("schema:b"), new RecordEnvelope<>("schema1:c"), new RecordEnvelope<>("schema2:d")});
+    SchemaChangeDetectionInjector injector = new SchemaChangeDetectionInjector();
+    SchemaAppendConverter converter = new SchemaAppendConverter();
+    MyDataWriter writer = new MyDataWriter();
+
+    Task task = setupTask(extractor, writer, Collections.EMPTY_LIST,
+        Lists.newArrayList(injector, converter));
+
+    task.run();
+    task.commit();
+    Assert.assertEquals(task.getTaskState().getWorkingState(), WorkUnitState.WorkingState.SUCCESSFUL);
+
+    Assert.assertEquals(converter.records, Lists.newArrayList("a:schema", "b:schema", "c:schema1", "d:schema2"));
+    Assert.assertEquals(converter.messages,
+        Lists.newArrayList(new MetadataUpdateControlMessage<>(new GlobalMetadata<>("schema1")),
+            new MetadataUpdateControlMessage<>(new GlobalMetadata<>("schema2"))));
+
+    Assert.assertEquals(writer.records, Lists.newArrayList("a:schema", "b:schema", "c:schema1", "d:schema2"));
+    Assert.assertEquals(writer.messages, Lists.newArrayList(new MetadataUpdateControlMessage<>(new GlobalMetadata<>("schema1")),
+        new MetadataUpdateControlMessage<>(new GlobalMetadata<>("schema2"))));
   }
 
   @Test
@@ -178,6 +273,11 @@ public class TestRecordStream {
   }
 
   private Task setupTask(Extractor extractor, DataWriterBuilder writer, Converter converter) throws Exception {
+    return setupTask(extractor, writer, Lists.newArrayList(converter), Collections.EMPTY_LIST);
+  }
+
+  private Task setupTask(Extractor extractor, DataWriterBuilder writer, List<Converter<?,?,?,?>> converters,
+      List<RecordStreamProcessor<?,?,?,?>> recordStreamProcessors) throws Exception {
     // Create a TaskState
     TaskState taskState = getEmptyTestTaskState("testRetryTaskId");
     taskState.setProp(ConfigurationKeys.TASK_SYNCHRONOUS_EXECUTION_MODEL_KEY, false);
@@ -186,7 +286,8 @@ public class TestRecordStream {
     when(mockTaskContext.getExtractor()).thenReturn(extractor);
     when(mockTaskContext.getForkOperator()).thenReturn(new IdentityForkOperator());
     when(mockTaskContext.getTaskState()).thenReturn(taskState);
-    when(mockTaskContext.getConverters()).thenReturn(Lists.newArrayList(converter));
+    when(mockTaskContext.getConverters()).thenReturn(converters);
+    when(mockTaskContext.getRecordStreamProcessors()).thenReturn(recordStreamProcessors);
     when(mockTaskContext.getTaskLevelPolicyChecker(any(TaskState.class), anyInt()))
         .thenReturn(mock(TaskLevelPolicyChecker.class));
     when(mockTaskContext.getRowLevelPolicyChecker()).
@@ -241,7 +342,7 @@ public class TestRecordStream {
 
     @Override
     public RecordStreamWithMetadata<String, String> recordStream(AtomicBoolean shutdownRequest) throws IOException {
-      return new RecordStreamWithMetadata<>(Flowable.fromArray(this.stream), "schema");
+      return new RecordStreamWithMetadata<>(Flowable.fromArray(this.stream), new GlobalMetadata<>("schema"));
     }
   }
 
@@ -298,6 +399,74 @@ public class TestRecordStream {
         throws DataConversionException {
       records.add(inputRecord);
       return Lists.newArrayList(inputRecord);
+    }
+
+    @Override
+    public ControlMessageHandler getMessageHandler() {
+      return messages::add;
+    }
+  }
+
+
+  /**
+   * Converter that appends the output schema string to the record string
+   */
+  static class SchemaAppendConverter extends Converter<String, String, String, String> {
+    private List<String> records = new ArrayList<>();
+    private List<ControlMessage<String>> messages = new ArrayList<>();
+
+    @Override
+    public String convertSchema(String inputSchema, WorkUnitState workUnit) throws SchemaConversionException {
+      return inputSchema;
+    }
+
+    @Override
+    public Iterable<String> convertRecord(String outputSchema, String inputRecord, WorkUnitState workUnit)
+        throws DataConversionException {
+      String inputWithoutSchema = inputRecord.substring(inputRecord.indexOf(":") + 1);
+      String outputRecord = inputWithoutSchema + ":" + outputSchema;
+      records.add(outputRecord);
+      return Lists.newArrayList(outputRecord);
+    }
+
+    @Override
+    public ControlMessageHandler getMessageHandler() {
+      return messages::add;
+    }
+  }
+
+  /**
+   * Input to this {@link RecordStreamProcessor} is a string of the form "schema:value".
+   * It will inject a {@link MetadataUpdateControlMessage} when a schema change is detected.
+   */
+  static class SchemaChangeDetectionInjector extends ControlMessageInjector<String, String> {
+    private List<String> records = new ArrayList<>();
+    private List<ControlMessage<String>> messages = new ArrayList<>();
+
+    public Iterable<String> convertRecord(String outputSchema, String inputRecord, WorkUnitState workUnitState)
+        throws DataConversionException {
+
+      String outputRecord = inputRecord.split(":")[1];
+      records.add(outputRecord);
+      return Lists.newArrayList(outputRecord);
+    }
+
+    @Override
+    public Iterable<ControlMessage<String>> injectControlMessagesBefore(RecordEnvelope<String> inputRecordEnvelope,
+        WorkUnitState workUnitState) {
+      String recordSchema = inputRecordEnvelope.getRecord().split(":")[0];
+
+      if (!recordSchema.equals(getInputGlobalMetadata().getSchema())) {
+        return new SingleRecordIterable<>(new MetadataUpdateControlMessage<>(new GlobalMetadata<>(recordSchema)));
+      }
+
+      return null;
+    }
+
+    @Override
+    public Iterable<ControlMessage<String>> injectControlMessagesAfter(RecordEnvelope<String> inputRecordEnvelope,
+        WorkUnitState workUnitState) {
+      return null;
     }
 
     @Override

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/TestRecordStream.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/TestRecordStream.java
@@ -446,6 +446,7 @@ public class TestRecordStream {
   static class SchemaChangeDetectionInjector extends ControlMessageInjector<String, String> {
     private List<String> records = new ArrayList<>();
     private List<ControlMessage<String>> messages = new ArrayList<>();
+    private GlobalMetadata<String> globalMetadata;
 
     public Iterable<String> convertRecord(String outputSchema, String inputRecord, WorkUnitState workUnitState)
         throws DataConversionException {
@@ -456,11 +457,16 @@ public class TestRecordStream {
     }
 
     @Override
+    protected void setInputGlobalMetadata(GlobalMetadata<String> inputGlobalMetadata, WorkUnitState workUnitState) {
+      this.globalMetadata = inputGlobalMetadata;
+    }
+
+    @Override
     public Iterable<ControlMessage<String>> injectControlMessagesBefore(RecordEnvelope<String> inputRecordEnvelope,
         WorkUnitState workUnitState) {
       String recordSchema = inputRecordEnvelope.getRecord().split(":")[0];
 
-      if (!recordSchema.equals(getInputGlobalMetadata().getSchema())) {
+      if (!recordSchema.equals(this.globalMetadata.getSchema())) {
         return new SingleRecordIterable<>(new MetadataUpdateControlMessage<>(
             GlobalMetadata.<String>builder().schema(recordSchema).build()));
       }

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/TestRecordStream.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/TestRecordStream.java
@@ -124,8 +124,8 @@ public class TestRecordStream {
   public void testMetadataUpdateControlMessages() throws Exception {
 
     MyExtractor extractor = new MyExtractor(new StreamEntity[]{new RecordEnvelope<>("a"),
-        new MetadataUpdateControlMessage<>(new GlobalMetadata<>("Schema1")), new RecordEnvelope<>("b"),
-            new MetadataUpdateControlMessage(new GlobalMetadata<>("Schema2"))});
+        new MetadataUpdateControlMessage<>(GlobalMetadata.<String>builder().schema("Schema1").build()), new RecordEnvelope<>("b"),
+            new MetadataUpdateControlMessage(GlobalMetadata.<String>builder().schema("Schema2").build())});
     SchemaAppendConverter converter = new SchemaAppendConverter();
     MyDataWriter writer = new MyDataWriter();
 
@@ -137,12 +137,13 @@ public class TestRecordStream {
 
     Assert.assertEquals(converter.records, Lists.newArrayList("a:schema", "b:Schema1"));
     Assert.assertEquals(converter.messages,
-        Lists.newArrayList(new MetadataUpdateControlMessage<>(new GlobalMetadata<>("Schema1")),
-            new MetadataUpdateControlMessage<>(new GlobalMetadata<>("Schema2"))));
+        Lists.newArrayList(new MetadataUpdateControlMessage<>(GlobalMetadata.<String>builder().schema("Schema1").build()),
+            new MetadataUpdateControlMessage<>(GlobalMetadata.<String>builder().schema("Schema2").build())));
 
     Assert.assertEquals(writer.records, Lists.newArrayList("a:schema", "b:Schema1"));
-    Assert.assertEquals(writer.messages, Lists.newArrayList(new MetadataUpdateControlMessage<>(new GlobalMetadata<>("Schema1")),
-        new MetadataUpdateControlMessage<>(new GlobalMetadata<>("Schema2"))));
+    Assert.assertEquals(writer.messages, Lists.newArrayList(new MetadataUpdateControlMessage<>(
+        GlobalMetadata.<String>builder().schema("Schema1").build()),
+        new MetadataUpdateControlMessage<>(GlobalMetadata.<String>builder().schema("Schema2").build())));
   }
 
   /**
@@ -153,8 +154,8 @@ public class TestRecordStream {
   public void testMetadataUpdateWithStreamProcessors() throws Exception {
 
     MyExtractor extractor = new MyExtractor(new StreamEntity[]{new RecordEnvelope<>("a"),
-        new MetadataUpdateControlMessage<>(new GlobalMetadata<>("Schema1")), new RecordEnvelope<>("b"),
-        new MetadataUpdateControlMessage(new GlobalMetadata<>("Schema2"))});
+        new MetadataUpdateControlMessage<>(GlobalMetadata.<String>builder().schema("Schema1").build()), new RecordEnvelope<>("b"),
+        new MetadataUpdateControlMessage(GlobalMetadata.<String>builder().schema("Schema2").build())});
     SchemaAppendConverter converter = new SchemaAppendConverter();
     MyDataWriter writer = new MyDataWriter();
 
@@ -166,12 +167,13 @@ public class TestRecordStream {
 
     Assert.assertEquals(converter.records, Lists.newArrayList("a:schema", "b:Schema1"));
     Assert.assertEquals(converter.messages,
-        Lists.newArrayList(new MetadataUpdateControlMessage<>(new GlobalMetadata<>("Schema1")),
-            new MetadataUpdateControlMessage<>(new GlobalMetadata<>("Schema2"))));
+        Lists.newArrayList(new MetadataUpdateControlMessage<>(GlobalMetadata.<String>builder().schema("Schema1").build()),
+            new MetadataUpdateControlMessage<>(GlobalMetadata.<String>builder().schema("Schema2").build())));
 
     Assert.assertEquals(writer.records, Lists.newArrayList("a:schema", "b:Schema1"));
-    Assert.assertEquals(writer.messages, Lists.newArrayList(new MetadataUpdateControlMessage<>(new GlobalMetadata<>("Schema1")),
-        new MetadataUpdateControlMessage<>(new GlobalMetadata<>("Schema2"))));
+    Assert.assertEquals(writer.messages, Lists.newArrayList(new MetadataUpdateControlMessage<>(
+        GlobalMetadata.<String>builder().schema("Schema1").build()),
+        new MetadataUpdateControlMessage<>(GlobalMetadata.<String>builder().schema("Schema2").build())));
   }
 
   /**
@@ -196,12 +198,13 @@ public class TestRecordStream {
 
     Assert.assertEquals(converter.records, Lists.newArrayList("a:schema", "b:schema", "c:schema1", "d:schema2"));
     Assert.assertEquals(converter.messages,
-        Lists.newArrayList(new MetadataUpdateControlMessage<>(new GlobalMetadata<>("schema1")),
-            new MetadataUpdateControlMessage<>(new GlobalMetadata<>("schema2"))));
+        Lists.newArrayList(new MetadataUpdateControlMessage<>(GlobalMetadata.<String>builder().schema("schema1").build()),
+            new MetadataUpdateControlMessage<>(GlobalMetadata.<String>builder().schema("schema2").build())));
 
     Assert.assertEquals(writer.records, Lists.newArrayList("a:schema", "b:schema", "c:schema1", "d:schema2"));
-    Assert.assertEquals(writer.messages, Lists.newArrayList(new MetadataUpdateControlMessage<>(new GlobalMetadata<>("schema1")),
-        new MetadataUpdateControlMessage<>(new GlobalMetadata<>("schema2"))));
+    Assert.assertEquals(writer.messages, Lists.newArrayList(new MetadataUpdateControlMessage<>(
+        GlobalMetadata.<String>builder().schema("schema1").build()),
+        new MetadataUpdateControlMessage<>(GlobalMetadata.<String>builder().schema("schema2").build())));
   }
 
   @Test
@@ -342,7 +345,8 @@ public class TestRecordStream {
 
     @Override
     public RecordStreamWithMetadata<String, String> recordStream(AtomicBoolean shutdownRequest) throws IOException {
-      return new RecordStreamWithMetadata<>(Flowable.fromArray(this.stream), new GlobalMetadata<>("schema"));
+      return new RecordStreamWithMetadata<>(Flowable.fromArray(this.stream),
+          GlobalMetadata.<String>builder().schema("schema").build());
     }
   }
 
@@ -457,7 +461,8 @@ public class TestRecordStream {
       String recordSchema = inputRecordEnvelope.getRecord().split(":")[0];
 
       if (!recordSchema.equals(getInputGlobalMetadata().getSchema())) {
-        return new SingleRecordIterable<>(new MetadataUpdateControlMessage<>(new GlobalMetadata<>(recordSchema)));
+        return new SingleRecordIterable<>(new MetadataUpdateControlMessage<>(
+            GlobalMetadata.<String>builder().schema(recordSchema).build()));
       }
 
       return null;


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-236


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Add a ControlMessage injector as a RecordStreamProcessor.
A `ControlMessageInjector` inspects an incoming record and can inject `ControlMessages` based on the content of the incoming record.

One use case for this is the injection of `MetadataUpdateControlMessages` when the latest schema has been updated to trigger the update of the schema used by other constructs downstream from the `ControlMessageInjector`.

Long running jobs are more likely to encounter issues due to the schema being updated after the start of the job.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

