### PR TITLE
[GOBBLIN-241] Allow multiple datasets send different lineage event for kafka

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/lineage/LineageInfo.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/lineage/LineageInfo.java
@@ -17,6 +17,7 @@
 
 package org.apache.gobblin.lineage;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -48,7 +49,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class LineageInfo {
-
+  public static final String LINEAGE_DATASET_URN = "lineage.dataset.urn";
   public static final String LINEAGE_NAME_SPACE = "gobblin.lineage";
   public static final String BRANCH_ID_METADATA_KEY = "branchId";
   private static final String DATASET_PREFIX =  LINEAGE_NAME_SPACE + ".";
@@ -226,6 +227,17 @@ public class LineageInfo {
 
   public static void setBranchLineageAttribute (State state, int branchId, String key, String value) {
     state.setProp(BRANCH_PREFIX + Joiner.on(".").join(branchId, key), value);
+  }
+
+  public static Map<String, Collection<State>> aggregateByDatasetUrn (Collection<? extends State> states) {
+    Map<String, Collection<State>> datasetStates = new HashMap<>();
+    for (State state: states) {
+      String urn = state.getProp(LINEAGE_DATASET_URN, state.getProp(ConfigurationKeys.DATASET_URN_KEY, ConfigurationKeys.DEFAULT_DATASET_URN));
+      datasetStates.putIfAbsent(urn, new ArrayList<>());
+      Collection<State> datasetState = datasetStates.get(urn);
+      datasetState.add(state);
+    }
+    return datasetStates;
   }
 
   public final String getId() {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-241

### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
     (1) Add submitLineageEvent() to DataPublisher class. This allows different publisher create its own submission logic. For example, NoopPublisher can simply return success because no submission is not needed.  The default implementation was added inside BaseDataPublisher. The SafeDatasetCommit will simply invoke DataPublisher::submitLineageEvent without changing existing logic.

     (2) Add submitSingleTaskLineageEvent() to SingleTaskDataPublisher class. This allows different task level publisher to submit lineage event. Default implementation is provided inside BaseDataPublisher.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
    No test needed

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

