### PR TITLE
[GOBBLIN-87] Fix runOnce not working correctly

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/scheduler/JobScheduler.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/scheduler/JobScheduler.java
@@ -274,8 +274,6 @@ public class JobScheduler extends AbstractIdleService {
     }
 
     if (!jobProps.containsKey(ConfigurationKeys.JOB_SCHEDULE_KEY)) {
-      // A job without a cron schedule is considered a one-time job
-      jobProps.setProperty(ConfigurationKeys.JOB_RUN_ONCE_KEY, "true");
       // Submit the job to run
       this.jobExecutor.execute(new NonScheduledJobRunner(jobProps, jobListener));
       return;
@@ -410,6 +408,12 @@ public class JobScheduler extends AbstractIdleService {
       throws ConfigurationException, JobException, IOException {
     LOG.info("Scheduling configured jobs");
     for (Properties jobProps : loadGeneralJobConfigs()) {
+
+      if (!jobProps.containsKey(ConfigurationKeys.JOB_SCHEDULE_KEY)) {
+        // A job without a cron schedule is considered a one-time job
+        jobProps.setProperty(ConfigurationKeys.JOB_RUN_ONCE_KEY, "true");
+      }
+
       boolean runOnce = Boolean.valueOf(jobProps.getProperty(ConfigurationKeys.JOB_RUN_ONCE_KEY, "false"));
       scheduleJob(jobProps, runOnce ? new RunOnceJobListener() : new EmailNotificationJobListener());
       this.listener.addToJobNameMap(jobProps);


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/GOBBLIN-87


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Fix a job without a schedule didn't run once

### Tests
- [x] My PR does not need testing for this extremely good reason:
Currently, `JobScheduler` doesn't have any test. We need a separate task to make `JobScheduler` unit testable.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

