### PR TITLE
[GOBBLIN-254] Add config key to update watermark when a partition is empty

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -482,6 +482,10 @@ public class ConfigurationKeys {
       "source.querybased.promoteUnsignedIntToBigInt";
   public static final boolean DEFAULT_SOURCE_QUERYBASED_PROMOTE_UNSIGNED_INT_TO_BIGINT = false;
 
+  public static final String SOURCE_QUERYBASED_RESET_EMPTY_PARTITION_WATERMARK =
+      "source.querybased.resetEmptyPartitionWatermark";
+  public static final boolean DEFAULT_SOURCE_QUERYBASED_RESET_EMPTY_PARTITION_WATERMARK = true;
+
   public static final String ENABLE_DELIMITED_IDENTIFIER = "enable.delimited.identifier";
   public static final boolean DEFAULT_ENABLE_DELIMITED_IDENTIFIER = false;
 

--- a/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/QueryBasedSource.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/QueryBasedSource.java
@@ -437,7 +437,9 @@ public abstract class QueryBasedSource<S, D> extends AbstractSource<S, D> {
       if (tablesWithFailedTasks.contains(entry.getKey())) {
         log.info("Resetting low watermark to {} because previous run failed.", entry.getValue());
         result.put(entry.getKey(), entry.getValue());
-      } else if (tablesWithNoUpdatesOnPreviousRun.contains(entry.getKey())) {
+      } else if (tablesWithNoUpdatesOnPreviousRun.contains(entry.getKey())
+          && state.getPropAsBoolean(ConfigurationKeys.SOURCE_QUERYBASED_RESET_EMPTY_PARTITION_WATERMARK,
+          ConfigurationKeys.DEFAULT_SOURCE_QUERYBASED_RESET_EMPTY_PARTITION_WATERMARK)) {
         log.info("Resetting low watermakr to {} because previous run processed no data.", entry.getValue());
         result.put(entry.getKey(), entry.getValue());
       } else {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-254


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

Add config key to allow watermark to update even if an empty partition exists in `QueryBasedSource`

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Default behaviour is unchanged

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

