### PR TITLE
[GOBBLIN-257] Remove jobs' previous run data

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -180,6 +180,8 @@ public class ConfigurationKeys {
   public static final String CLEANUP_STAGING_DATA_PER_TASK = "cleanup.staging.data.per.task";
   public static final boolean DEFAULT_CLEANUP_STAGING_DATA_PER_TASK = true;
   public static final String CLEANUP_STAGING_DATA_BY_INITIALIZER = "cleanup.staging.data.by.initializer";
+  public static final String CLEANUP_OLD_JOBS_DATA = "cleanup.old.job.data";
+  public static final boolean DEFAULT_CLEANUP_OLD_JOBS_DATA = false;
 
   public static final String QUEUED_TASK_TIME_MAX_SIZE = "taskexecutor.queued_task_time.history.max_size";
   public static final int DEFAULT_QUEUED_TASK_TIME_MAX_SIZE = 2048;

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/AbstractJobLauncher.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/AbstractJobLauncher.java
@@ -18,6 +18,8 @@
 package org.apache.gobblin.runtime;
 
 import java.io.IOException;
+import java.net.URI;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -26,6 +28,10 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.gobblin.util.HadoopUtils;
+import org.apache.gobblin.util.WriterUtils;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -48,7 +54,6 @@ import org.apache.gobblin.source.workunit.BasicWorkUnitStream;
 import org.apache.gobblin.source.workunit.WorkUnitStream;
 import org.apache.gobblin.broker.gobblin_scopes.GobblinScopeTypes;
 import org.apache.gobblin.broker.SharedResourcesBrokerFactory;
-import org.apache.gobblin.broker.gobblin_scopes.GobblinScopeTypes;
 import org.apache.gobblin.broker.iface.SharedResourcesBroker;
 import org.apache.gobblin.commit.CommitSequence;
 import org.apache.gobblin.commit.CommitSequenceStore;
@@ -830,6 +835,7 @@ public abstract class AbstractJobLauncher implements JobLauncher {
           throw new RuntimeException("Work unit streams do not support cleaning staging data per task.");
         }
       } else {
+        cleanUpOldJobData(jobState, jobProps, jobContext);
         JobLauncherUtils.cleanJobStagingData(jobState, LOG);
       }
     } catch (Throwable t) {
@@ -838,6 +844,38 @@ public abstract class AbstractJobLauncher implements JobLauncher {
     }
   }
 
+  protected static void cleanUpOldJobData(JobState state, Properties jobProps, JobContext jobContext) throws IOException {
+    if (jobContext.getJobIdSet()) {
+      LOG.warn("Skipping cleaning old jobs' data. \"{}\" is set to {}; old job's path cannot be determined.", ConfigurationKeys.JOB_ID_KEY, jobProps.getProperty(ConfigurationKeys.JOB_ID_KEY));
+      return;
+    }
+    Set<Path> rootPaths = new HashSet<>();
+    String writerFsUri = state.getProp(ConfigurationKeys.WRITER_FILE_SYSTEM_URI, ConfigurationKeys.LOCAL_FS_URI);
+    FileSystem fs = FileSystem.get(URI.create(writerFsUri), WriterUtils.getFsConfiguration(state));
+
+    if (state.getPropAsBoolean(ConfigurationKeys.CLEANUP_OLD_JOBS_DATA, ConfigurationKeys.DEFAULT_CLEANUP_OLD_JOBS_DATA)) {
+      Path taskDataRootDir;
+      if (jobContext.getWriterStagingDirSet()) {
+        taskDataRootDir = new Path(state.getProp(ConfigurationKeys.WRITER_STAGING_DIR)).getParent();
+      } else {
+        taskDataRootDir = new Path(state.getProp(ConfigurationKeys.WRITER_STAGING_DIR)).getParent().getParent();
+      }
+      rootPaths.add(taskDataRootDir);
+      if (jobContext.getWriterOutputDirSet()) {
+        taskDataRootDir = new Path(state.getProp(ConfigurationKeys.WRITER_OUTPUT_DIR)).getParent();
+      } else {
+        taskDataRootDir = new Path(state.getProp(ConfigurationKeys.WRITER_OUTPUT_DIR)).getParent().getParent();
+      }
+      rootPaths.add(taskDataRootDir);
+    }
+    for (Path rootPath : rootPaths) {
+      HadoopUtils.deletePathByRegex(fs, rootPath, getJobIdPrefix(jobContext.getJobId()) + ".*");
+    }
+  }
+
+  private static String getJobIdPrefix(String jobId) {
+    return jobId.substring(0, jobId.lastIndexOf(Id.Job.SEPARATOR) + 1);
+  }
   /**
    * Cleanup the job's task staging data. This is not doing anything in case job succeeds
    * and data is successfully committed because the staging data has already been moved

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/JobContext.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/JobContext.java
@@ -109,6 +109,14 @@ public class JobContext implements Closeable {
   private final boolean parallelizeCommit;
   private final int parallelCommits;
 
+  // Were WRITER_STAGING_DIR and WRITER_OUTPUT_DIR provided
+  @Getter
+  protected final Boolean writerStagingDirSet;
+  @Getter
+  protected final Boolean writerOutputDirSet;
+  @Getter
+  protected final Boolean jobIdSet;
+
   @Getter
   private final DeliverySemantics semantics;
 
@@ -131,6 +139,7 @@ public class JobContext implements Closeable {
     this.jobName = JobState.getJobNameFromProps(jobProps);
     this.jobId = jobProps.containsKey(ConfigurationKeys.JOB_ID_KEY) ? jobProps.getProperty(ConfigurationKeys.JOB_ID_KEY)
         : JobLauncherUtils.newJobId(this.jobName);
+    jobIdSet = jobProps.containsKey(ConfigurationKeys.JOB_ID_KEY);
     this.jobSequence = Long.toString(Id.Job.parse(this.jobId).getSequence());
     jobProps.setProperty(ConfigurationKeys.JOB_ID_KEY, this.jobId);
 
@@ -146,6 +155,9 @@ public class JobContext implements Closeable {
     this.jobState =
         new JobState(jobPropsState, this.datasetStateStore.getLatestDatasetStatesByUrns(this.jobName), this.jobName,
             this.jobId);
+
+    writerStagingDirSet = this.jobState.contains(ConfigurationKeys.WRITER_STAGING_DIR);
+    writerOutputDirSet = this.jobState.contains(ConfigurationKeys.WRITER_OUTPUT_DIR);
 
     setTaskStagingAndOutputDirs();
 

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/JobContext.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/JobContext.java
@@ -296,8 +296,14 @@ public class JobContext implements Closeable {
     return this.source;
   }
 
-  protected static Path getJobDir(String dir, String jobDir) {
-    return new Path(dir, jobDir);
+  /**
+   * Appends two paths
+   * @param dir1
+   * @param dir2
+   * @return appended path
+   */
+  protected static Path getJobDir(String dir1, String dir2) {
+    return new Path(dir1, dir2);
   }
 
   protected void setTaskStagingAndOutputDirs() {

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/JobContextTest.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/JobContextTest.java
@@ -29,18 +29,26 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import org.slf4j.Logger;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Queues;
+import com.google.common.io.Files;
 
 import org.apache.gobblin.commit.DeliverySemantics;
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.util.Either;
+import org.apache.gobblin.util.Id;
 
 import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
@@ -212,6 +220,48 @@ public class JobContextTest {
     }
     // job failed
     Assert.assertEquals(jobContext.getJobState().getState(), JobState.RunningState.FAILED);
+  }
+
+  @Test
+  public void testCleanUpOldJobData() throws Exception {
+    Path rootPath = new Path(Files.createTempDir().getAbsolutePath(), "TestDir");
+    System.out.println(rootPath);
+    final String JOB_PREFIX = Id.Job.PREFIX;
+    final String JOB_NAME1 = "GobblinKafka";
+    final String JOB_NAME2 = "GobblinBrooklin";
+    final long timestamp1 = 1505774129247L;
+    final long timestamp2 = 1505774129248L;
+    final Joiner JOINER = Joiner.on(Id.SEPARATOR).skipNulls();
+    Object[] oldJob1 = new Object[]{JOB_PREFIX, JOB_NAME1, timestamp1};
+    Object[] oldJob2 = new Object[]{JOB_PREFIX, JOB_NAME2, timestamp1};
+    Object[] currentJob = new Object[]{JOB_PREFIX, JOB_NAME1, timestamp2};
+
+    Path currentJobPath = new Path(rootPath, JOINER.join(currentJob));
+    Path oldJobPath1 = new Path(rootPath, JOINER.join(oldJob1));
+    Path oldJobPath2 = new Path(rootPath, JOINER.join(oldJob2));
+    Path stagingPath = new Path(currentJobPath, "task-staging");
+    Path outputPath = new Path(currentJobPath, "task-output");
+
+    FileSystem fs = FileSystem.getLocal(new Configuration());
+    fs.mkdirs(currentJobPath);
+    fs.mkdirs(oldJobPath1);
+    fs.mkdirs(oldJobPath2);
+
+    gobblin.runtime.JobState jobState = new gobblin.runtime.JobState();
+    jobState.setProp(ConfigurationKeys.CLEANUP_OLD_JOBS_DATA, true);
+    jobState.setProp(ConfigurationKeys.WRITER_STAGING_DIR, stagingPath.toString());
+    jobState.setProp(ConfigurationKeys.WRITER_OUTPUT_DIR, outputPath.toString());
+
+    JobContext jobContext = mock(JobContext.class);
+    when(jobContext.getWriterStagingDirSet()).thenReturn(false);
+    when(jobContext.getWriterOutputDirSet()).thenReturn(false);
+    when(jobContext.getJobId()).thenReturn(currentJobPath.getName().toString());
+
+    AbstractJobLauncher.cleanUpOldJobData(jobState, new Properties(), jobContext);
+
+    Assert.assertFalse(fs.exists(oldJobPath1));
+    Assert.assertTrue(fs.exists(oldJobPath2));
+    Assert.assertFalse(fs.exists(currentJobPath));
   }
 
   /**

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/HadoopUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/HadoopUtils.java
@@ -45,6 +45,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.fs.LocalFileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathFilter;
 import org.apache.hadoop.fs.RawLocalFileSystem;
 import org.apache.hadoop.fs.Trash;
 import org.apache.hadoop.fs.permission.FsPermission;
@@ -181,6 +182,21 @@ public class HadoopUtils {
       } else {
         break;
       }
+    }
+  }
+
+  /**
+   * Delete files according to the regular expression provided
+   * @param fs Filesystem object
+   * @param path base path
+   * @param regex regular expression to select files to delete
+   * @throws IOException
+   */
+  public static void deletePathByRegex(FileSystem fs, final Path path, final String regex) throws IOException {
+    FileStatus[] statusList = fs.listStatus(path, path1 -> path1.getName().matches(regex));
+
+    for (final FileStatus oldJobFile : statusList) {
+      HadoopUtils.deletePath(fs, oldJobFile.getPath(), true);
     }
   }
 


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!
@abti Please review


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-XXX


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
At times, gobblin job can leave staging and output directories undeleted, especially if the job is killed. This PR will add a cleanup step for previous job runs.


### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
PR adds required unit test cases to check deletion of old job run directories.


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

