### PR TITLE
[GOBBLIN-258] It tried to remove the tmp output path from wrong fs before compaction.

### DIFF
--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/MRCompactorJobRunner.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/MRCompactorJobRunner.java
@@ -443,7 +443,7 @@ public abstract class MRCompactorJobRunner implements Runnable, Comparable<MRCom
     }
 
     //MR output path must not exist when MR job starts, so delete if exists.
-    this.fs.delete(this.dataset.outputTmpPath(), true);
+    this.tmpFs.delete(this.dataset.outputTmpPath(), true);
     FileOutputFormat.setOutputPath(job, this.dataset.outputTmpPath());
   }
 


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-258

### Description
It fixes the issue if someone uses alternate fs for compaction tmp fs then before the compaction Gobblin tried to remove the previously remained tmp files from the wrong fs.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

