### PR TITLE
[GOBBLIN-259] Support writing Kafka messages to db/table file path

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/source/workunit/WorkUnit.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/source/workunit/WorkUnit.java
@@ -82,7 +82,6 @@ public class WorkUnit extends State {
 
     if (extract != null) {
       this.extract = extract;
-      super.addAll(extract);
     } else {
       this.extract = new Extract(null, null, null, null);
     }
@@ -303,6 +302,20 @@ public class WorkUnit extends State {
   @Deprecated
   public long getLowWaterMark() {
     return getPropAsLong(ConfigurationKeys.WORK_UNIT_LOW_WATER_MARK_KEY);
+  }
+
+  @Override
+  public boolean contains(String key) {
+    return super.contains(key) || this.extract.contains(key);
+  }
+
+  @Override
+  public String getProp(String key) {
+    String value = super.getProp(key);
+    if (value == null) {
+      value = this.extract.getProp(key);
+    }
+    return value;
   }
 
   /**

--- a/gobblin-api/src/main/java/org/apache/gobblin/source/workunit/WorkUnit.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/source/workunit/WorkUnit.java
@@ -82,6 +82,7 @@ public class WorkUnit extends State {
 
     if (extract != null) {
       this.extract = extract;
+      super.addAll(extract);
     } else {
       this.extract = new Extract(null, null, null, null);
     }

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSource.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSource.java
@@ -518,6 +518,7 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
     // Default to job level configurations
     Extract.TableType currentTableType = tableType;
     String currentExtractNamespace = extractNamespace;
+    String currentExtractTableName = partition.getTopicName();
     boolean isCurrentFullExtract = isFullExtract;
     // Update to topic specific configurations if any
     if (topicSpecificState.isPresent()) {
@@ -526,10 +527,12 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
         currentTableType = Extract.TableType.valueOf(topicState.getProp(ConfigurationKeys.EXTRACT_TABLE_TYPE_KEY));
       }
       currentExtractNamespace = topicState.getProp(ConfigurationKeys.EXTRACT_NAMESPACE_NAME_KEY, extractNamespace);
+      currentExtractTableName =
+          topicState.getProp(ConfigurationKeys.EXTRACT_TABLE_NAME_KEY, partition.getTopicName());
       isCurrentFullExtract = topicState.getPropAsBoolean(ConfigurationKeys.EXTRACT_IS_FULL_KEY, isFullExtract);
     }
 
-    Extract extract = this.createExtract(currentTableType, currentExtractNamespace, partition.getTopicName());
+    Extract extract = this.createExtract(currentTableType, currentExtractNamespace, currentExtractTableName);
     if (isCurrentFullExtract) {
       extract.setProp(ConfigurationKeys.EXTRACT_IS_FULL_KEY, true);
     }
@@ -538,9 +541,9 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
     if (topicSpecificState.isPresent()) {
       workUnit.addAll(topicSpecificState.get());
     }
+
     workUnit.setProp(TOPIC_NAME, partition.getTopicName());
     addDatasetUrnOptionally(workUnit);
-    workUnit.setProp(ConfigurationKeys.EXTRACT_TABLE_NAME_KEY, partition.getTopicName());
     workUnit.setProp(PARTITION_ID, partition.getId());
     workUnit.setProp(LEADER_ID, partition.getLeader().getId());
     workUnit.setProp(LEADER_HOSTANDPORT, partition.getLeader().getHostAndPort().toString());

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/WriterUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/WriterUtils.java
@@ -58,8 +58,12 @@ public class WriterUtils {
   public static final Config NO_RETRY_CONFIG = ConfigFactory.empty();
 
   public enum WriterFilePathType {
-    /** Write records into db/table folders */
-    DB_TABLE,
+    /**
+     * Write records into namespace/table folder. If namespace has multiple components, each component will be
+     * a folder in the path. For example: the write file path for namespace 'org.apache.gobblin' and table 'tableName'
+     * will be 'org/apache/gobblin/tableName'
+     */
+    NAMESPACE_TABLE,
     /**
      * TABLENAME should be used for jobs that pull from multiple tables/topics and intend to write the records
      * in each table/topic to a separate folder.
@@ -159,8 +163,8 @@ public class WriterUtils {
     }
 
     switch (getWriterFilePathType(state)) {
-      case DB_TABLE:
-        return getDbTableWriterFilePath(state);
+      case NAMESPACE_TABLE:
+        return getNamespaceTableWriterFilePath(state);
       case TABLENAME:
         return WriterUtils.getTableNameWriterFilePath(state);
       default:
@@ -175,16 +179,17 @@ public class WriterUtils {
   }
 
   /**
-   * Creates {@link Path} for case {@link WriterFilePathType#DB_TABLE} with configurations
+   * Creates {@link Path} for case {@link WriterFilePathType#NAMESPACE_TABLE} with configurations
    * {@link ConfigurationKeys#EXTRACT_NAMESPACE_NAME_KEY} and {@link ConfigurationKeys#EXTRACT_TABLE_NAME_KEY}
    * @param state
    * @return a path
    */
-  public static Path getDbTableWriterFilePath(State state) {
+  public static Path getNamespaceTableWriterFilePath(State state) {
     Preconditions.checkArgument(state.contains(ConfigurationKeys.EXTRACT_NAMESPACE_NAME_KEY));
     Preconditions.checkArgument(state.contains(ConfigurationKeys.EXTRACT_TABLE_NAME_KEY));
-    return new Path(state.getProp(ConfigurationKeys.EXTRACT_NAMESPACE_NAME_KEY) + Path.SEPARATOR + state
-        .getProp(ConfigurationKeys.EXTRACT_TABLE_NAME_KEY));
+
+    String namespace = state.getProp(ConfigurationKeys.EXTRACT_NAMESPACE_NAME_KEY).replaceAll("\\.", Path.SEPARATOR);
+    return new Path( namespace + Path.SEPARATOR + state.getProp(ConfigurationKeys.EXTRACT_TABLE_NAME_KEY));
   }
 
   /**

--- a/gobblin-utility/src/test/java/org/apache/gobblin/util/WriterUtilsTest.java
+++ b/gobblin-utility/src/test/java/org/apache/gobblin/util/WriterUtilsTest.java
@@ -93,13 +93,24 @@ public class WriterUtilsTest {
 
   @Test
   public void testGetWriterFilePath() {
-    WorkUnit state = WorkUnit.createEmpty();
+    final String namespace = "dbNamespace";
+    final String table = "tableName";
+    Extract extract = new Extract(TableType.SNAPSHOT_ONLY, namespace, table);
+    WorkUnit state = WorkUnit.create(extract);
 
     state.setProp(ConfigurationKeys.WRITER_FILE_PATH, TEST_WRITER_FILE_PATH);
     Assert.assertEquals(WriterUtils.getWriterFilePath(state, 0, 0), TEST_WRITER_FILE_PATH);
 
     state.setProp(ConfigurationKeys.WRITER_FILE_PATH + ".0", TEST_WRITER_FILE_PATH);
     Assert.assertEquals(WriterUtils.getWriterFilePath(state, 1, 1), TEST_WRITER_FILE_PATH);
+
+    state.removeProp(ConfigurationKeys.WRITER_FILE_PATH);
+
+    state.setProp(ConfigurationKeys.WRITER_FILE_PATH_TYPE, "tablename");
+    Assert.assertEquals(WriterUtils.getWriterFilePath(state, 0, 0), new Path(table));
+
+    state.setProp(ConfigurationKeys.WRITER_FILE_PATH_TYPE, "db_table");
+    Assert.assertEquals(WriterUtils.getWriterFilePath(state, 0, 0), new Path(namespace + "/" + table));
   }
 
   @Test

--- a/gobblin-utility/src/test/java/org/apache/gobblin/util/WriterUtilsTest.java
+++ b/gobblin-utility/src/test/java/org/apache/gobblin/util/WriterUtilsTest.java
@@ -93,9 +93,7 @@ public class WriterUtilsTest {
 
   @Test
   public void testGetWriterFilePath() {
-    final String namespace = "dbNamespace";
-    final String table = "tableName";
-    Extract extract = new Extract(TableType.SNAPSHOT_ONLY, namespace, table);
+    Extract extract = new Extract(TableType.SNAPSHOT_ONLY, "org.apache.gobblin.dbNamespace", "tableName");
     WorkUnit state = WorkUnit.create(extract);
 
     state.setProp(ConfigurationKeys.WRITER_FILE_PATH, TEST_WRITER_FILE_PATH);
@@ -107,10 +105,11 @@ public class WriterUtilsTest {
     state.removeProp(ConfigurationKeys.WRITER_FILE_PATH);
 
     state.setProp(ConfigurationKeys.WRITER_FILE_PATH_TYPE, "tablename");
-    Assert.assertEquals(WriterUtils.getWriterFilePath(state, 0, 0), new Path(table));
+    Assert.assertEquals(WriterUtils.getWriterFilePath(state, 0, 0), new Path("tableName"));
 
-    state.setProp(ConfigurationKeys.WRITER_FILE_PATH_TYPE, "db_table");
-    Assert.assertEquals(WriterUtils.getWriterFilePath(state, 0, 0), new Path(namespace + "/" + table));
+    state.setProp(ConfigurationKeys.WRITER_FILE_PATH_TYPE, "namespace_table");
+    Assert.assertEquals(WriterUtils.getWriterFilePath(state, 0, 0),
+        new Path("org/apache/gobblin/dbNamespace/tableName"));
   }
 
   @Test


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/GOBBLIN-259

### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
- Add a new write file path type `DB_TABLE`, which writes records from an `Extract` to folder '<namespace>/<table>'. 
- A gobblin job which uses the `KafkSource` and `AvroHdfsDataWriter` will write records to 'dbName/tableName' with the following configurations
```
extract.namespace=dbName
extract.table.name=tableName
writer.file.path.type=db_table
```

### Tests
- [x] My PR adds the following unit tests
- `WriterUtilsTest#testGetWriterFilePath`

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

