### PR TITLE
[GOBBLIN-264] Add a SharedResourceFactory for creating shared DataPub…

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/capability/Capability.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/capability/Capability.java
@@ -18,6 +18,8 @@ package org.apache.gobblin.capability;
 
 import org.apache.gobblin.annotation.Alpha;
 
+import lombok.Data;
+
 /**
  * Represents a set of functionality a job-creator can ask for. Examples could include
  * encryption, compression, partitioning...
@@ -26,56 +28,13 @@ import org.apache.gobblin.annotation.Alpha;
  * the encryption algorithm to use.
  */
 @Alpha
+@Data
 public class Capability {
+  /**
+   * Threadsafe capability.
+   */
+  public static final Capability THREADSAFE = new Capability("THREADSAFE", false);
+
   private final String name;
   private final boolean critical;
-
-  /**
-   * Create a new Capability description.
-   * @param name Name of the capability
-   * @param critical If a capability is marked critical and a job is configured with components that can't satisfy
-   *                 the capability, Gobblin will refuse to run the job. If it is not critical then Gobblin will simply
-   *                 issue a warning.
-   */
-  public Capability(String name, boolean critical) {
-    this.name = name;
-    this.critical = critical;
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  public boolean isCritical() {
-    return critical;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-
-    Capability that = (Capability) o;
-
-    if (critical != that.critical) {
-      return false;
-    }
-    return name != null ? name.equals(that.name) : that.name == null;
-  }
-
-  @Override
-  public int hashCode() {
-    int result = name != null ? name.hashCode() : 0;
-    result = 31 * result + (critical ? 1 : 0);
-    return result;
-  }
-
-  @Override
-  public String toString() {
-    return "Capability{" + "name='" + name + '\'' + ", critical=" + critical + '}';
-  }
 }

--- a/gobblin-api/src/main/java/org/apache/gobblin/capability/Capability.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/capability/Capability.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gobblin.capability;
+
+import org.apache.gobblin.annotation.Alpha;
+
+/**
+ * Represents a set of functionality a job-creator can ask for. Examples could include
+ * encryption, compression, partitioning...
+ *
+ * Each Capability has a name and then a set of associated configuration properties. An example is
+ * the encryption algorithm to use.
+ */
+@Alpha
+public class Capability {
+  private final String name;
+  private final boolean critical;
+
+  /**
+   * Create a new Capability description.
+   * @param name Name of the capability
+   * @param critical If a capability is marked critical and a job is configured with components that can't satisfy
+   *                 the capability, Gobblin will refuse to run the job. If it is not critical then Gobblin will simply
+   *                 issue a warning.
+   */
+  public Capability(String name, boolean critical) {
+    this.name = name;
+    this.critical = critical;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public boolean isCritical() {
+    return critical;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    Capability that = (Capability) o;
+
+    if (critical != that.critical) {
+      return false;
+    }
+    return name != null ? name.equals(that.name) : that.name == null;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = name != null ? name.hashCode() : 0;
+    result = 31 * result + (critical ? 1 : 0);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "Capability{" + "name='" + name + '\'' + ", critical=" + critical + '}';
+  }
+}

--- a/gobblin-api/src/main/java/org/apache/gobblin/capability/CapabilityAware.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/capability/CapabilityAware.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gobblin.capability;
+
+import java.util.Map;
+
+import org.apache.gobblin.annotation.Alpha;
+
+/**
+ * Describes an object that is aware of the capabilities it supports.
+ */
+@Alpha
+public interface CapabilityAware {
+  /**
+   * Checks if this object supports the given Capability with the given properties.
+   *
+   * Implementers of this should always check if their super-class may happen to support a capability
+   * before returning false!
+   * @param c Capability being queried
+   * @param properties Properties specific to the capability. Properties are capability specific.
+   * @return True if this object supports the given capability + property settings, false if not
+   */
+  boolean supportsCapability(Capability c, Map<String, Object> properties);
+}

--- a/gobblin-api/src/main/java/org/apache/gobblin/publisher/DataPublisher.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/publisher/DataPublisher.java
@@ -21,7 +21,10 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.util.Collection;
+import java.util.Map;
 
+import org.apache.gobblin.capability.Capability;
+import org.apache.gobblin.capability.CapabilityAware;
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.configuration.WorkUnitState;
@@ -30,7 +33,16 @@ import org.apache.gobblin.configuration.WorkUnitState;
 /**
  * Defines how to publish data and its corresponding metadata. Can be used for either task level or job level publishing.
  */
-public abstract class DataPublisher implements Closeable {
+public abstract class DataPublisher implements Closeable, CapabilityAware {
+  /**
+   * Threadsafe capability.
+   */
+  public static final Capability THREADSAFE = new Capability("THREADSAFE", false);
+
+  /**
+   * Reusable capability.
+   */
+  public static final Capability REUSABLE = new Capability("REUSABLE", false);
 
   protected final State state;
 
@@ -124,5 +136,10 @@ public abstract class DataPublisher implements Closeable {
    */
   protected boolean shouldPublishMetadataFirst() {
     return true;
+  }
+
+  @Override
+  public boolean supportsCapability(Capability c, Map<String, Object> properties) {
+    return false;
   }
 }

--- a/gobblin-api/src/main/java/org/apache/gobblin/publisher/DataPublisher.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/publisher/DataPublisher.java
@@ -35,11 +35,6 @@ import org.apache.gobblin.configuration.WorkUnitState;
  */
 public abstract class DataPublisher implements Closeable, CapabilityAware {
   /**
-   * Threadsafe capability.
-   */
-  public static final Capability THREADSAFE = new Capability("THREADSAFE", false);
-
-  /**
    * Reusable capability.
    */
   public static final Capability REUSABLE = new Capability("REUSABLE", false);

--- a/gobblin-core/src/main/java/org/apache/gobblin/publisher/DataPublisherFactory.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/publisher/DataPublisherFactory.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.publisher;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import org.apache.gobblin.broker.ImmediatelyInvalidResourceEntry;
+import org.apache.gobblin.broker.ResourceInstance;
+import org.apache.gobblin.broker.iface.ConfigView;
+import org.apache.gobblin.broker.iface.NotConfiguredException;
+import org.apache.gobblin.broker.iface.ScopeType;
+import org.apache.gobblin.broker.iface.ScopedConfigView;
+import org.apache.gobblin.broker.iface.SharedResourceFactory;
+import org.apache.gobblin.broker.iface.SharedResourceFactoryResponse;
+import org.apache.gobblin.broker.iface.SharedResourcesBroker;
+import org.apache.gobblin.configuration.State;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * A {@link SharedResourceFactory} for creating {@link DataPublisher}s.
+ *
+ * The factory creates a {@link DataPublisher} with the publisher class name and state.
+ */
+@Slf4j
+public class DataPublisherFactory<S extends ScopeType<S>>
+    implements SharedResourceFactory<DataPublisher, DataPublisherKey, S> {
+
+  public static final String FACTORY_NAME = "dataPublisher";
+
+  public static <S extends ScopeType<S>> DataPublisher get(String publisherClassName, State state,
+      SharedResourcesBroker<S> broker) throws IOException {
+    try {
+      return broker.getSharedResource(new DataPublisherFactory<S>(), new DataPublisherKey(publisherClassName, state));
+    } catch (NotConfiguredException nce) {
+      throw new IOException(nce);
+    }
+  }
+
+  @Override
+  public String getName() {
+    return FACTORY_NAME;
+  }
+
+  @Override
+  public SharedResourceFactoryResponse<DataPublisher> createResource(SharedResourcesBroker<S> broker,
+      ScopedConfigView<S, DataPublisherKey> config) throws NotConfiguredException {
+    try {
+      DataPublisherKey key = config.getKey();
+      String publisherClassName = key.getPublisherClassName();
+      State state = key.getState();
+      Class<? extends DataPublisher> dataPublisherClass =  (Class<? extends DataPublisher>) Class
+          .forName(publisherClassName);
+
+      DataPublisher publisher = DataPublisher.getInstance(dataPublisherClass, state);
+
+      // If the publisher is threadsafe then it is shareable, so return it as a resource instance that may be cached
+      // by the broker.
+      // Otherwise, it is not shareable, so return it as an immediately invalidated resource that will only be returned
+      // once from the broker.
+      if (publisher.supportsCapability(DataPublisher.THREADSAFE, Collections.EMPTY_MAP)) {
+        return new ResourceInstance<>(publisher);
+      } else {
+        return new ImmediatelyInvalidResourceEntry<>(publisher);
+      }
+    } catch (ReflectiveOperationException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public S getAutoScope(SharedResourcesBroker<S> broker, ConfigView<S, DataPublisherKey> config) {
+    return broker.selfScope().getType().rootScope();
+  }
+}

--- a/gobblin-core/src/main/java/org/apache/gobblin/publisher/DataPublisherFactory.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/publisher/DataPublisherFactory.java
@@ -29,6 +29,7 @@ import org.apache.gobblin.broker.iface.ScopedConfigView;
 import org.apache.gobblin.broker.iface.SharedResourceFactory;
 import org.apache.gobblin.broker.iface.SharedResourceFactoryResponse;
 import org.apache.gobblin.broker.iface.SharedResourcesBroker;
+import org.apache.gobblin.capability.Capability;
 import org.apache.gobblin.configuration.State;
 
 import lombok.extern.slf4j.Slf4j;
@@ -74,7 +75,7 @@ public class DataPublisherFactory<S extends ScopeType<S>>
       // by the broker.
       // Otherwise, it is not shareable, so return it as an immediately invalidated resource that will only be returned
       // once from the broker.
-      if (publisher.supportsCapability(DataPublisher.THREADSAFE, Collections.EMPTY_MAP)) {
+      if (publisher.supportsCapability(Capability.THREADSAFE, Collections.EMPTY_MAP)) {
         return new ResourceInstance<>(publisher);
       } else {
         return new ImmediatelyInvalidResourceEntry<>(publisher);

--- a/gobblin-core/src/main/java/org/apache/gobblin/publisher/DataPublisherKey.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/publisher/DataPublisherKey.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.publisher;
+
+import org.apache.gobblin.broker.iface.SharedResourceKey;
+import org.apache.gobblin.configuration.State;
+
+import lombok.Getter;
+
+
+/**
+ * {@link SharedResourceKey} for requesting {@link DataPublisher}s from a
+ * {@link org.apache.gobblin.broker.iface.SharedResourceFactory
+ */
+@Getter
+public class DataPublisherKey implements SharedResourceKey {
+  private final String publisherClassName;
+  private final State state;
+
+  public DataPublisherKey(String publisherClassName, State state) {
+    this.publisherClassName = publisherClassName;
+    this.state = state;
+  }
+
+  @Override
+  public String toConfigurationKey() {
+    return this.publisherClassName;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    DataPublisherKey that = (DataPublisherKey) o;
+
+    return publisherClassName == null ?
+        that.publisherClassName == null : publisherClassName.equals(that.publisherClassName);
+  }
+
+  @Override
+  public int hashCode() {
+    return publisherClassName != null ? publisherClassName.hashCode() : 0;
+  }
+}

--- a/gobblin-core/src/test/java/org/apache/gobblin/publisher/DataPublisherFactoryTest.java
+++ b/gobblin-core/src/test/java/org/apache/gobblin/publisher/DataPublisherFactoryTest.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gobblin.publisher;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.typesafe.config.ConfigFactory;
+
+import org.apache.gobblin.broker.SharedResourcesBrokerFactory;
+import org.apache.gobblin.broker.SimpleScope;
+import org.apache.gobblin.broker.SimpleScopeType;
+import org.apache.gobblin.broker.iface.NoSuchScopeException;
+import org.apache.gobblin.broker.iface.NotConfiguredException;
+import org.apache.gobblin.broker.iface.SharedResourcesBroker;
+import org.apache.gobblin.capability.Capability;
+import org.apache.gobblin.configuration.State;
+import org.apache.gobblin.configuration.WorkUnitState;
+
+/**
+ * Tests for DataPublisherFactory
+ */
+public class DataPublisherFactoryTest {
+
+  @Test
+  public void testGetNonThreadSafePublisher()
+      throws IOException {
+    SharedResourcesBroker broker =
+        SharedResourcesBrokerFactory.<SimpleScopeType>createDefaultTopLevelBroker(ConfigFactory.empty(),
+            SimpleScopeType.GLOBAL.defaultScopeInstance());
+
+    DataPublisher publisher1 = DataPublisherFactory.get(TestNonThreadsafeDataPublisher.class.getName(), null, broker);
+    DataPublisher publisher2 = DataPublisherFactory.get(TestNonThreadsafeDataPublisher.class.getName(), null, broker);
+
+    // should get different publishers
+    Assert.assertNotEquals(publisher1, publisher2);
+
+    // Check capabilities
+    Assert.assertTrue(publisher1.supportsCapability(DataPublisher.REUSABLE, Collections.EMPTY_MAP));
+    Assert.assertFalse(publisher1.supportsCapability(DataPublisher.THREADSAFE, Collections.EMPTY_MAP));
+  }
+
+  @Test
+  public void testGetThreadSafePublisher()
+      throws IOException, NotConfiguredException, NoSuchScopeException {
+    SharedResourcesBroker<SimpleScopeType> broker =
+        SharedResourcesBrokerFactory.<SimpleScopeType>createDefaultTopLevelBroker(ConfigFactory.empty(),
+            SimpleScopeType.GLOBAL.defaultScopeInstance());
+
+    SharedResourcesBroker<SimpleScopeType> localBroker1 =
+        broker.newSubscopedBuilder(new SimpleScope<>(SimpleScopeType.LOCAL, "local1")).build();
+
+    DataPublisher publisher1 = DataPublisherFactory.get(TestThreadsafeDataPublisher.class.getName(), null, broker);
+    DataPublisher publisher2 = DataPublisherFactory.get(TestThreadsafeDataPublisher.class.getName(), null, broker);
+
+    // should get the same publisher
+    Assert.assertEquals(publisher1, publisher2);
+
+    DataPublisher publisher3 =
+        localBroker1.getSharedResource(new DataPublisherFactory<>(),
+            new DataPublisherKey(TestThreadsafeDataPublisher.class.getName(), null));
+
+    // should get the same publisher
+    Assert.assertEquals(publisher2, publisher3);
+
+    DataPublisher publisher4 =
+        localBroker1.getSharedResourceAtScope(new DataPublisherFactory<>(),
+            new DataPublisherKey(TestThreadsafeDataPublisher.class.getName(), null), SimpleScopeType.LOCAL);
+
+    // should get a different publisher
+    Assert.assertNotEquals(publisher3, publisher4);
+
+    // Check capabilities
+    Assert.assertTrue(publisher1.supportsCapability(DataPublisher.REUSABLE, Collections.EMPTY_MAP));
+    Assert.assertTrue(publisher1.supportsCapability(DataPublisher.THREADSAFE, Collections.EMPTY_MAP));
+  }
+
+  private static class TestNonThreadsafeDataPublisher extends DataPublisher {
+    public TestNonThreadsafeDataPublisher(State state) {
+      super(state);
+    }
+
+    @Override
+    public void initialize() throws IOException {
+    }
+
+    @Override
+    public void publishData(Collection<? extends WorkUnitState> states) throws IOException {
+    }
+
+    @Override
+    public void publishMetadata(Collection<? extends WorkUnitState> states) throws IOException {
+    }
+
+    @Override
+    public void close() throws IOException {
+    }
+
+    @Override
+    public boolean supportsCapability(Capability c, Map<String, Object> properties) {
+      return c == DataPublisher.REUSABLE;
+    }
+  }
+
+  private static class TestThreadsafeDataPublisher extends TestNonThreadsafeDataPublisher {
+    public TestThreadsafeDataPublisher(State state) {
+      super(state);
+    }
+
+    @Override
+    public boolean supportsCapability(Capability c, Map<String, Object> properties) {
+      return (c == DataPublisher.THREADSAFE || c == DataPublisher.REUSABLE);
+    }
+  }
+}

--- a/gobblin-core/src/test/java/org/apache/gobblin/publisher/DataPublisherFactoryTest.java
+++ b/gobblin-core/src/test/java/org/apache/gobblin/publisher/DataPublisherFactoryTest.java
@@ -56,7 +56,7 @@ public class DataPublisherFactoryTest {
 
     // Check capabilities
     Assert.assertTrue(publisher1.supportsCapability(DataPublisher.REUSABLE, Collections.EMPTY_MAP));
-    Assert.assertFalse(publisher1.supportsCapability(DataPublisher.THREADSAFE, Collections.EMPTY_MAP));
+    Assert.assertFalse(publisher1.supportsCapability(Capability.THREADSAFE, Collections.EMPTY_MAP));
   }
 
   @Test
@@ -91,7 +91,7 @@ public class DataPublisherFactoryTest {
 
     // Check capabilities
     Assert.assertTrue(publisher1.supportsCapability(DataPublisher.REUSABLE, Collections.EMPTY_MAP));
-    Assert.assertTrue(publisher1.supportsCapability(DataPublisher.THREADSAFE, Collections.EMPTY_MAP));
+    Assert.assertTrue(publisher1.supportsCapability(Capability.THREADSAFE, Collections.EMPTY_MAP));
   }
 
   private static class TestNonThreadsafeDataPublisher extends DataPublisher {
@@ -128,7 +128,7 @@ public class DataPublisherFactoryTest {
 
     @Override
     public boolean supportsCapability(Capability c, Map<String, Object> properties) {
-      return (c == DataPublisher.THREADSAFE || c == DataPublisher.REUSABLE);
+      return (c == Capability.THREADSAFE || c == DataPublisher.REUSABLE);
     }
   }
 }

--- a/gobblin-utility/src/main/java/org/apache/gobblin/broker/ImmediatelyInvalidResourceEntry.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/broker/ImmediatelyInvalidResourceEntry.java
@@ -17,38 +17,40 @@
 
 package org.apache.gobblin.broker;
 
-import org.apache.gobblin.broker.iface.SharedResourceFactoryResponse;
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.extern.slf4j.Slf4j;
 
 
 /**
- * A {@link SharedResourceFactoryResponse} that returns a newly created resource instance.
+ * A {@link ResourceEntry} that expires immediately. The resource is not closed on invalidation since the lifetime of
+ * the object cannot be determined by the cache, so the recipient of the resource needs to close it.
  */
-@Data
-public class ResourceInstance<T> implements ResourceEntry<T> {
-  // Note: the name here is theResource instead of resource since to avoid a collision of the lombok generated getter
-  // and the getResource() method defined in {@link ResourceEntry}. The collision results in unintended side effects
-  // when getResource() is overridden since it may have additional logic that should not be executed when the value of
-  // this field is fetched using the getter, such as in the Lombok generated toString().
-  private final T theResource;
+@Slf4j
+@EqualsAndHashCode(callSuper = true)
+public class ImmediatelyInvalidResourceEntry<T> extends ResourceInstance<T> {
+  private boolean valid;
 
-  /**
-   * This method returns the resource, but may have logic before the return.
-   * @return the resource
-   */
+  public ImmediatelyInvalidResourceEntry(T resource) {
+    super(resource);
+    this.valid = true;
+  }
+
   @Override
   public T getResource() {
+    // mark the object as invalid before returning so that a new one will be created on the next
+    // request from the factory
+    this.valid = false;
+
     return getTheResource();
   }
 
   @Override
   public boolean isValid() {
-    return true;
+    return this.valid;
   }
 
   @Override
   public void onInvalidate() {
-    // this should never happen
-    throw new RuntimeException();
+    // these type of resource cannot be closed on invalidation since the lifetime can't be determined
   }
 }

--- a/gobblin-utility/src/main/java/org/apache/gobblin/broker/ImmediatelyInvalidResourceEntry.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/broker/ImmediatelyInvalidResourceEntry.java
@@ -41,7 +41,7 @@ public class ImmediatelyInvalidResourceEntry<T> extends ResourceInstance<T> {
     // request from the factory
     this.valid = false;
 
-    return getTheResource();
+    return super.getResource();
   }
 
   @Override


### PR DESCRIPTION
…lishers

A DataPublisher can indicate whether it has the THREADSAFE capability.
If the DataPublisher is threadsafe then the DataPublisherFactory will return a shareable ResourceInstance.
If the DataPublisher is not threadsafe then an ImmediatelyInvalidResourceEntry is returned to ensure
that the broker won't return the same publisher for a second request.

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-264


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
Adds the following.
* `ImmediatelyInvalidResourceEntry `- a ResourceInstance that is invalidated when getResource() is called. Immediate invalidation means it won't be returned as a response to a future get call.
* `Capabilities` - a construct can implement the `CapabilityAware` interface to support queries on the capabilities it supports.
* `Threadsafe` - this capability indicates that the `DataPublisher` is can be called concurrently in multiple threads.
* `Reusable` - this capability indicates that the `DataPublisher` publish APIs can be invoked multiple times.
* The `ParallelRunner` is made reusable by adding a method to change the FileSystem and a method to wait for submitted tasks to complete.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

