### PR TITLE
[GOBBLIN-267] Changed workunit creation policy to compare update time with maxLookBackDays

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/source/HiveSource.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/source/HiveSource.java
@@ -386,10 +386,13 @@ public class HiveSource implements Source {
 
   /**
    * Check if workunit needs to be created. Returns <code>true</code> If the
-   * <code>updateTime</code> is greater than the <code>lowWatermark</code>.
+   * <code>updateTime</code> is greater than the <code>lowWatermark</code> and <code>maxLookBackTime</code>
    * <code>createTime</code> is not used. It exists for backward compatibility
    */
   protected boolean shouldCreateWorkunit(long createTime, long updateTime, LongWatermark lowWatermark) {
+    if (new DateTime(updateTime).isBefore(this.maxLookBackTime)) {
+      return false;
+    }
     return new DateTime(updateTime).isAfter(lowWatermark.getValue());
   }
 


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-267


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
HiveSource#shouldCreateWorkunit() now compares update time with maxLookBackDays


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Very trivial change/fix

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

