### PR TITLE
[GOBBLIN-275] Use listStatus instead of globStatus for finding persisted files

### DIFF
--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/recovery/RecoveryHelperTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/recovery/RecoveryHelperTest.java
@@ -103,7 +103,7 @@ public class RecoveryHelperTest {
     Assert.assertEquals(stagingDir.listFiles().length, 0);
     Assert.assertEquals(recoveryDir.listFiles().length, 1);
 
-    File fileInRecovery = recoveryDir.listFiles()[0];
+    File fileInRecovery = recoveryDir.listFiles()[0].listFiles()[0];
     Assert.assertEquals(IOUtils.readLines(new FileInputStream(fileInRecovery)).get(0), content);
 
     Optional<FileStatus> fileToRecover =


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-275


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

Persist files at `recoveryfolder/guid/filename` instead of `recoveryfolder/guid_filename` to allow finding with listStatus instead of globStatus

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

`org.apache.gobblin.data.management.copy.recovery.RecoveryHelperTest`

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

