### PR TITLE
[GOBBLIN-279] pull file unable to reuse the json property.

### DIFF
--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/PullFileLoader.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/PullFileLoader.java
@@ -72,6 +72,9 @@ public class PullFileLoader {
   public static final Set<String> DEFAULT_JAVA_PROPS_PULL_FILE_EXTENSIONS = Sets.newHashSet("pull", "job");
   public static final Set<String> DEFAULT_HOCON_PULL_FILE_EXTENSIONS = Sets.newHashSet("json", "conf");
 
+  public static final String PROPERTY_DELIMITER_PARSING_ENABLED_KEY = "property.parsing.enablekey";
+  public static final boolean DEFAULT_PROPERTY_DELIMITER_PARSING_ENABLED_KEY = false;
+  
   private final Path rootDirectory;
   private final FileSystem fs;
   private final ExtensionFilter javaPropsPullFileFilter;
@@ -260,6 +263,7 @@ public class PullFileLoader {
     PropertiesConfiguration propertiesConfiguration = new PropertiesConfiguration();
     try (InputStreamReader inputStreamReader = new InputStreamReader(this.fs.open(propertiesPath),
         Charsets.UTF_8)) {
+      propertiesConfiguration.setDelimiterParsingDisabled(ConfigUtils.getBoolean(fallback,PROPERTY_DELIMITER_PARSING_ENABLED_KEY, DEFAULT_PROPERTY_DELIMITER_PARSING_ENABLED_KEY));
       propertiesConfiguration.load(inputStreamReader);
 
       Config configFromProps =

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/PullFileLoader.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/PullFileLoader.java
@@ -263,7 +263,8 @@ public class PullFileLoader {
     PropertiesConfiguration propertiesConfiguration = new PropertiesConfiguration();
     try (InputStreamReader inputStreamReader = new InputStreamReader(this.fs.open(propertiesPath),
         Charsets.UTF_8)) {
-      propertiesConfiguration.setDelimiterParsingDisabled(ConfigUtils.getBoolean(fallback,PROPERTY_DELIMITER_PARSING_ENABLED_KEY, DEFAULT_PROPERTY_DELIMITER_PARSING_ENABLED_KEY));
+      propertiesConfiguration.setDelimiterParsingDisabled(ConfigUtils.getBoolean(fallback,
+    		  PROPERTY_DELIMITER_PARSING_ENABLED_KEY, DEFAULT_PROPERTY_DELIMITER_PARSING_ENABLED_KEY));
       propertiesConfiguration.load(inputStreamReader);
 
       Config configFromProps =

--- a/gobblin-utility/src/test/java/org/apache/gobblin/util/PullFileLoaderTest.java
+++ b/gobblin-utility/src/test/java/org/apache/gobblin/util/PullFileLoaderTest.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.fs.Path;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import com.google.common.collect.ImmutableMap;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
@@ -218,7 +219,20 @@ public class PullFileLoaderTest {
     Assert.assertEquals(pullFile.entrySet().size(), 7);
   }
 
-
+  @Test
+  public void testJsonPropertyReuseJobLoading() throws Exception {
+    Path path;
+    Config pullFile;
+    path = new Path(this.basePath, "bjob.pull");
+    Config cfg = ConfigFactory.parseMap(ImmutableMap.<String, Object>builder()
+            .put(PullFileLoader.PROPERTY_DELIMITER_PARSING_ENABLED_KEY, true)
+            .build());
+    pullFile = loader.loadPullFile(path, cfg, false);
+    System.out.println(pullFile.getString("json.property.key"));
+    System.out.println(pullFile.getString("json.property.key1"));
+    Assert.assertEquals(pullFile.getString("json.property.key"), pullFile.getString("json.property.key1"));
+  }
+  
   private Config pullFileFromPath(Collection<Config> configs, Path path) throws IOException {
     for (Config config : configs) {
       if (config.getString(ConfigurationKeys.JOB_CONFIG_FILE_PATH_KEY).equals(path.toString())) {

--- a/gobblin-utility/src/test/java/org/apache/gobblin/util/PullFileLoaderTest.java
+++ b/gobblin-utility/src/test/java/org/apache/gobblin/util/PullFileLoaderTest.java
@@ -228,8 +228,6 @@ public class PullFileLoaderTest {
             .put(PullFileLoader.PROPERTY_DELIMITER_PARSING_ENABLED_KEY, true)
             .build());
     pullFile = loader.loadPullFile(path, cfg, false);
-    System.out.println(pullFile.getString("json.property.key"));
-    System.out.println(pullFile.getString("json.property.key1"));
     Assert.assertEquals(pullFile.getString("json.property.key"), pullFile.getString("json.property.key1"));
   }
   

--- a/gobblin-utility/src/test/resources/pullFileLoaderTest/bjob.pull
+++ b/gobblin-utility/src/test/resources/pullFileLoaderTest/bjob.pull
@@ -1,0 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+json.property.key={"name":"shankar","country":"bharat"}
+json.property.key1=${json.property.key}
+


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### GOBBLIN-279
- [ ] My PR addresses the following [GOBBLIN-279](https://issues.apache.org/jira/browse/GOBBLIN-279) issues and references them in the PR title. 


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):


### Tests
- [ ] My PR adds the following unit tests org.apache.gobblin.util.PullFileLoaderTest.testJsonPropertyReuseJobLoading


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

