### PR TITLE
[GOBBLIN-280] Added new SpecCompiler compatible constructor to AzkabanSpecExecutor

### DIFF
--- a/gobblin-modules/gobblin-azkaban/src/main/java/org/apache/gobblin/service/modules/orchestration/AzkabanSpecExecutor.java
+++ b/gobblin-modules/gobblin-azkaban/src/main/java/org/apache/gobblin/service/modules/orchestration/AzkabanSpecExecutor.java
@@ -36,6 +36,10 @@ public class AzkabanSpecExecutor extends AbstractSpecExecutor {
 
   private SpecProducer<Spec> azkabanSpecProducer;
 
+  public AzkabanSpecExecutor(Config config) {
+    this(config, Optional.absent());
+  }
+
   public AzkabanSpecExecutor(Config config, Optional<Logger> log) {
     super(config, log);
     Config defaultConfig = ConfigFactory.load(ServiceAzkabanConfigKeys.DEFAULT_AZKABAN_PROJECT_CONFIG_FILE);


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-280

### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
dd new SpecCompiler compatible constructor to AzkabanSpecExecutor since with MultiHop the SpecExecutor is invoked differently via reflection.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Trivial. Tested locally with Azkaban.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

