### PR TITLE
[GOBBLIN-287] Adding a service name to the resource name for multiple throttling quotas

### DIFF
--- a/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-server/src/main/webapp/WEB-INF/web.xml
+++ b/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-server/src/main/webapp/WEB-INF/web.xml
@@ -30,7 +30,7 @@
   </filter-mapping>
 
   <listener>
-    <listener-class>gobblin.restli.throttling.ThrottlingGuiceServletConfig</listener-class>
+    <listener-class>org.apache.gobblin.restli.throttling.ThrottlingGuiceServletConfig</listener-class>
   </listener>
 
   <context-param>
@@ -41,6 +41,21 @@
   <context-param>
     <param-name>gobblin.broker.limiter.streamCopierBandwidth.localhost.localhost.qps</param-name>
     <param-value>100000000</param-value>
+  </context-param>
+
+  <context-param>
+    <param-name>gobblin.broker.limiter.filesystem.ltx1-holdem.grid.linkedin.com.presto.qps</param-name>
+    <param-value>10</param-value>
+  </context-param>
+
+  <context-param>
+    <param-name>gobblin.broker.limiter.filesystem.ltx1-holdem.grid.linkedin.com.etl.qps</param-name>
+    <param-value>5</param-value>
+  </context-param>
+
+  <context-param>
+    <param-name>gobblin.broker.limiter.serviceName</param-name>
+    <param-value>presto</param-value>
   </context-param>
 
 </web-app>

--- a/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-server/src/main/webapp/WEB-INF/web.xml
+++ b/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-server/src/main/webapp/WEB-INF/web.xml
@@ -44,18 +44,13 @@
   </context-param>
 
   <context-param>
-    <param-name>gobblin.broker.limiter.filesystem.ltx1-holdem.grid.linkedin.com.presto.qps</param-name>
+    <param-name>gobblin.broker.limiter.filesystem.localhost.localhost.other.qps</param-name>
     <param-value>10</param-value>
   </context-param>
 
   <context-param>
-    <param-name>gobblin.broker.limiter.filesystem.ltx1-holdem.grid.linkedin.com.etl.qps</param-name>
+    <param-name>gobblin.broker.limiter.filesystem.localhost.localhost.etl.qps</param-name>
     <param-value>5</param-value>
-  </context-param>
-
-  <context-param>
-    <param-name>gobblin.broker.limiter.serviceName</param-name>
-    <param-value>presto</param-value>
   </context-param>
 
 </web-app>

--- a/gobblin-restli/server.gradle
+++ b/gobblin-restli/server.gradle
@@ -78,5 +78,4 @@ artifacts {
 }
 
 war {
-  classifier "war"
 }

--- a/gobblin-restli/server.gradle
+++ b/gobblin-restli/server.gradle
@@ -78,4 +78,5 @@ artifacts {
 }
 
 war {
+  classifier "war"
 }

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/RateControlledFileSystem.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/RateControlledFileSystem.java
@@ -78,7 +78,7 @@ public class RateControlledFileSystem extends ThrottledFileSystem {
   }
 
   public RateControlledFileSystem(FileSystem fs, final long limitPerSecond) {
-    super(fs, null);
+    super(fs, null, null);
     this.limitPerSecond = limitPerSecond;
     this.callableLimiter = new Callable<RateBasedLimiter>() {
       @Override

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/filesystem/FileSystemLimiterKey.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/filesystem/FileSystemLimiterKey.java
@@ -30,10 +30,18 @@ public class FileSystemLimiterKey extends SharedLimiterKey {
 
   public static final String RESOURCE_LIMITED_PREFIX = "filesystem";
   private final URI uri;
+  public final String serviceName;
 
   public FileSystemLimiterKey(URI uri) {
     super(RESOURCE_LIMITED_PREFIX + "/" + getFSIdentifier(uri));
     this.uri = uri;
+    this.serviceName = null;
+  }
+
+  public FileSystemLimiterKey(URI uri, String serviceName) {
+    super(RESOURCE_LIMITED_PREFIX + "/" + getFSIdentifier(uri) + "/" + serviceName);
+    this.uri = uri;
+    this.serviceName = serviceName;
   }
 
   private static String getFSIdentifier(URI uri) {

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/filesystem/FileSystemLimiterKey.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/filesystem/FileSystemLimiterKey.java
@@ -19,9 +19,10 @@ package org.apache.gobblin.util.filesystem;
 
 import java.net.URI;
 
+import com.google.common.base.Strings;
 import org.apache.gobblin.util.ClustersNames;
 import org.apache.gobblin.util.limiter.broker.SharedLimiterKey;
-
+import org.apache.hadoop.util.StringUtils;
 
 /**
  * {@link SharedLimiterKey} used for NameNode throttling.
@@ -37,7 +38,7 @@ public class FileSystemLimiterKey extends SharedLimiterKey {
   }
 
   public FileSystemLimiterKey(URI uri, String serviceName) {
-    super(RESOURCE_LIMITED_PREFIX + "/" + getFSIdentifier(uri) + serviceName == null ? "" : "/" + serviceName);
+    super(RESOURCE_LIMITED_PREFIX + "/" + getFSIdentifier(uri) + (Strings.isNullOrEmpty(serviceName) ? "" : "/" + serviceName));
     this.uri = uri;
     this.serviceName = serviceName;
   }

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/filesystem/FileSystemLimiterKey.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/filesystem/FileSystemLimiterKey.java
@@ -33,9 +33,7 @@ public class FileSystemLimiterKey extends SharedLimiterKey {
   public final String serviceName;
 
   public FileSystemLimiterKey(URI uri) {
-    super(RESOURCE_LIMITED_PREFIX + "/" + getFSIdentifier(uri));
-    this.uri = uri;
-    this.serviceName = null;
+    this(uri, null);
   }
 
   public FileSystemLimiterKey(URI uri, String serviceName) {

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/filesystem/FileSystemLimiterKey.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/filesystem/FileSystemLimiterKey.java
@@ -37,7 +37,7 @@ public class FileSystemLimiterKey extends SharedLimiterKey {
   }
 
   public FileSystemLimiterKey(URI uri, String serviceName) {
-    super(RESOURCE_LIMITED_PREFIX + "/" + getFSIdentifier(uri) + "/" + serviceName);
+    super(RESOURCE_LIMITED_PREFIX + "/" + getFSIdentifier(uri) + serviceName == null ? "" : "/" + serviceName);
     this.uri = uri;
     this.serviceName = serviceName;
   }

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/filesystem/FileSystemLimiterKey.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/filesystem/FileSystemLimiterKey.java
@@ -22,7 +22,6 @@ import java.net.URI;
 import com.google.common.base.Strings;
 import org.apache.gobblin.util.ClustersNames;
 import org.apache.gobblin.util.limiter.broker.SharedLimiterKey;
-import org.apache.hadoop.util.StringUtils;
 
 /**
  * {@link SharedLimiterKey} used for NameNode throttling.

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/filesystem/ThrottledFileSystem.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/filesystem/ThrottledFileSystem.java
@@ -53,17 +53,13 @@ public class ThrottledFileSystem extends FileSystemInstrumentation {
    * Factory for {@link ThrottledFileSystem}.
    */
   public static class Factory<S extends ScopeType<S>> extends FileSystemInstrumentationFactory<S> {
-    private final String SERVICE_NAME_CONF_KEY = "gobblin.broker.limiter.serviceName";
+    private final String SERVICE_NAME_CONF_KEY = "gobblin.broker.filesystem.limiterServiceName";
     @Override
     public FileSystem instrumentFileSystem(FileSystem fs, SharedResourcesBroker<S> broker,
         ConfigView<S, FileSystemKey> config) {
       try {
         String serviceName = config.getConfig().getString(SERVICE_NAME_CONF_KEY);
-        Limiter limiter;
-        if (serviceName == null)
-          limiter = broker.getSharedResource(new SharedLimiterFactory<S>(), new FileSystemLimiterKey(config.getKey().getUri()));
-        else
-          limiter = broker.getSharedResource(new SharedLimiterFactory<S>(), new FileSystemLimiterKey(config.getKey().getUri(), serviceName));
+        Limiter limiter = broker.getSharedResource(new SharedLimiterFactory<S>(), new FileSystemLimiterKey(config.getKey().getUri()));
         return new ThrottledFileSystem(fs, limiter, serviceName);
       } catch (NotConfiguredException nce) {
         throw new RuntimeException(nce);

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/filesystem/ThrottledFileSystem.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/filesystem/ThrottledFileSystem.java
@@ -53,7 +53,7 @@ public class ThrottledFileSystem extends FileSystemInstrumentation {
    * Factory for {@link ThrottledFileSystem}.
    */
   public static class Factory<S extends ScopeType<S>> extends FileSystemInstrumentationFactory<S> {
-    private final String SERVICE_NAME_CONF_KEY = "gobblin.broker.filesystem.limiterServiceName";
+    private static final String SERVICE_NAME_CONF_KEY = "gobblin.broker.filesystem.limiterServiceName";
     @Override
     public FileSystem instrumentFileSystem(FileSystem fs, SharedResourcesBroker<S> broker,
         ConfigView<S, FileSystemKey> config) {

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/filesystem/ThrottledFileSystem.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/filesystem/ThrottledFileSystem.java
@@ -189,6 +189,10 @@ public class ThrottledFileSystem extends FileSystemInstrumentation {
     return this.limiter;
   }
 
+  public String getServiceName() {
+    return this.serviceName;
+  }
+
   @Override
   public void close() throws IOException {
     getRateLimiter().stop();

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/filesystem/ThrottledFileSystem.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/filesystem/ThrottledFileSystem.java
@@ -21,6 +21,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.apache.gobblin.util.ConfigUtils;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
@@ -58,7 +59,7 @@ public class ThrottledFileSystem extends FileSystemInstrumentation {
     public FileSystem instrumentFileSystem(FileSystem fs, SharedResourcesBroker<S> broker,
         ConfigView<S, FileSystemKey> config) {
       try {
-        String serviceName = config.getConfig().getString(SERVICE_NAME_CONF_KEY);
+        String serviceName = ConfigUtils.getString(config.getConfig(), SERVICE_NAME_CONF_KEY, "");
         Limiter limiter = broker.getSharedResource(new SharedLimiterFactory<S>(), new FileSystemLimiterKey(config.getKey().getUri()));
         return new ThrottledFileSystem(fs, limiter, serviceName);
       } catch (NotConfiguredException nce) {

--- a/gobblin-utility/src/test/java/org/apache/gobblin/util/filesystem/ThrottledFileSystemTest.java
+++ b/gobblin-utility/src/test/java/org/apache/gobblin/util/filesystem/ThrottledFileSystemTest.java
@@ -40,7 +40,7 @@ public class ThrottledFileSystemTest {
 
     Limiter limiter = new CountBasedLimiter(2);
 
-    ThrottledFileSystem throttledFileSystem = new ThrottledFileSystem(fs, limiter);
+    ThrottledFileSystem throttledFileSystem = new ThrottledFileSystem(fs, limiter, "testService");
 
     Assert.assertNotNull(throttledFileSystem.getFileStatus(new Path("/myFile")));
     Assert.assertNotNull(throttledFileSystem.getFileStatus(new Path("/myFile")));
@@ -74,7 +74,8 @@ public class ThrottledFileSystemTest {
 
     Limiter limiter = new CountBasedLimiter(5);
 
-    ThrottledFileSystem throttledFileSystem = new ThrottledFileSystem(fs, limiter);
+    ThrottledFileSystem throttledFileSystem = new ThrottledFileSystem(fs, limiter, "testService");
+    Assert.assertEquals(throttledFileSystem.getName(), "testService");
 
     Assert.assertNotNull(throttledFileSystem.listStatus(new Path("/files/99"))); // use 1 permit
     Assert.assertNotNull(throttledFileSystem.listStatus(new Path("/files/250"))); // use 3 permits

--- a/gobblin-utility/src/test/java/org/apache/gobblin/util/filesystem/ThrottledFileSystemTest.java
+++ b/gobblin-utility/src/test/java/org/apache/gobblin/util/filesystem/ThrottledFileSystemTest.java
@@ -75,7 +75,7 @@ public class ThrottledFileSystemTest {
     Limiter limiter = new CountBasedLimiter(5);
 
     ThrottledFileSystem throttledFileSystem = new ThrottledFileSystem(fs, limiter, "testService");
-    Assert.assertEquals(throttledFileSystem.getName(), "testService");
+    Assert.assertEquals(throttledFileSystem.getServiceName(), "testService");
 
     Assert.assertNotNull(throttledFileSystem.listStatus(new Path("/files/99"))); // use 1 permit
     Assert.assertNotNull(throttledFileSystem.listStatus(new Path("/files/250"))); // use 3 permits


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-287

### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
This appends a service name to a ThrottledFileSystem's resource key so that multiple throttling quotas can be applied instead of a single global quota. It also updates a test to validate that this effect takes place.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
It modifies an existing test to get coverage of this new code.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

