### PR TITLE
[GOBBLIN-286]  fix bug where non hive dataset publishing gives NPE

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/CopyEntity.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/CopyEntity.java
@@ -118,7 +118,7 @@ public class CopyEntity implements HasGuid {
    */
   public static String getSerializedWithNewPackage(String serialized) {
     serialized = serialized.replace("\"gobblin.data.management.", "\"org.apache.gobblin.data.management.");
-    log.info("Serialized updated copy entity: " + serialized);
+    log.debug("Serialized updated copy entity: " + serialized);
     return serialized;
   }
 

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/CopyableDatasetMetadata.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/CopyableDatasetMetadata.java
@@ -69,7 +69,7 @@ public class CopyableDatasetMetadata {
    */
   private static String getSerializedWithNewPackage(String serialized) {
     serialized = serialized.replace("\"gobblin.data.management.", "\"org.apache.gobblin.data.management.");
-    log.info("Serialized updated copy entity: " + serialized);
+    log.debug("Serialized updated copy entity: " + serialized);
     return serialized;
   }
 }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/publisher/CopyDataPublisher.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/publisher/CopyDataPublisher.java
@@ -209,7 +209,9 @@ public class CopyDataPublisher extends DataPublisher implements UnpublishedHandl
           // Dataset Output path is injected in each copyableFile.
           // This can be optimized by having a dataset level equivalent class for copyable entities
           // and storing dataset related information, e.g. dataset output path, there.
-          if (!fileSetRoot.isPresent()) {
+
+          // Currently datasetOutputPath is only present for hive datasets.
+          if (!fileSetRoot.isPresent() && copyableFile.getDatasetOutputPath() != null) {
             fileSetRoot = Optional.of(copyableFile.getDatasetOutputPath());
           }
         }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below! @htran1  please review


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-XXX


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Currently non hive dataset do not have datasetOutputPath populated in copyableFile, ths throwing NPE while trying to access it. This PR will fix this bug where non hive dataset throw NPE during publish.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
It is not a new feature, just a minor fix. So not adding any test case.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

