### PR TITLE
Changed access modifier to protected for HiveSource and Watermarkers

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/source/HiveSource.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/source/HiveSource.java
@@ -137,19 +137,19 @@ public class HiveSource implements Source {
   public static final Gson GENERICS_AWARE_GSON = GsonInterfaceAdapter.getGson(Object.class);
   public static final Splitter COMMA_BASED_SPLITTER = Splitter.on(",").omitEmptyStrings().trimResults();
 
-  private MetricContext metricContext;
-  private EventSubmitter eventSubmitter;
-  private AvroSchemaManager avroSchemaManager;
+  protected MetricContext metricContext;
+  protected EventSubmitter eventSubmitter;
+  protected AvroSchemaManager avroSchemaManager;
 
-  private HiveUnitUpdateProvider updateProvider;
-  private HiveSourceWatermarker watermarker;
-  private IterableDatasetFinder<HiveDataset> datasetFinder;
-  private List<WorkUnit> workunits;
-  private long maxLookBackTime;
-  private long beginGetWorkunitsTime;
-  private List<String> ignoreDataPathIdentifierList;
+  protected HiveUnitUpdateProvider updateProvider;
+  protected HiveSourceWatermarker watermarker;
+  protected IterableDatasetFinder<HiveDataset> datasetFinder;
+  protected List<WorkUnit> workunits;
+  protected long maxLookBackTime;
+  protected long beginGetWorkunitsTime;
+  protected List<String> ignoreDataPathIdentifierList;
 
-  private final ClassAliasResolver<HiveBaseExtractorFactory> classAliasResolver =
+  protected final ClassAliasResolver<HiveBaseExtractorFactory> classAliasResolver =
       new ClassAliasResolver<>(HiveBaseExtractorFactory.class);
 
   @Override
@@ -219,7 +219,7 @@ public class HiveSource implements Source {
   }
 
 
-  private void createWorkunitForNonPartitionedTable(HiveDataset hiveDataset) throws IOException {
+  protected void createWorkunitForNonPartitionedTable(HiveDataset hiveDataset) throws IOException {
     // Create workunits for tables
     try {
 
@@ -280,7 +280,7 @@ public class HiveSource implements Source {
     return hiveWorkUnit;
   }
 
-  private void createWorkunitsForPartitionedTable(HiveDataset hiveDataset, AutoReturnableObject<IMetaStoreClient> client) throws IOException {
+  protected void createWorkunitsForPartitionedTable(HiveDataset hiveDataset, AutoReturnableObject<IMetaStoreClient> client) throws IOException {
 
     long tableProcessTime = new DateTime().getMillis();
     this.watermarker.onTableProcessBegin(hiveDataset.getTable(), tableProcessTime);
@@ -425,7 +425,7 @@ public class HiveSource implements Source {
   }
 
   // Convert createTime from seconds to milliseconds
-  private static long getCreateTime(Table table) {
+  protected static long getCreateTime(Table table) {
     return TimeUnit.MILLISECONDS.convert(table.getTTable().getCreateTime(), TimeUnit.SECONDS);
   }
 

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/watermarker/PartitionLevelWatermarker.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/watermarker/PartitionLevelWatermarker.java
@@ -112,31 +112,31 @@ public class PartitionLevelWatermarker implements HiveSourceWatermarker {
 
   @Setter(AccessLevel.PACKAGE)
   @VisibleForTesting
-  private long leastWatermarkToPersistInState;
+  protected long leastWatermarkToPersistInState;
   // Keep an additional 2 days of updates
-  private static final int BUFFER_WATERMARK_DAYS_TO_PERSIST = 2;
+  protected static final int BUFFER_WATERMARK_DAYS_TO_PERSIST = 2;
 
   /**
    * Watermarks from previous state
    */
   @Getter(AccessLevel.PACKAGE)
   @VisibleForTesting
-  private final TableWatermarks previousWatermarks;
+  protected final TableWatermarks previousWatermarks;
 
   /**
    * Current expected watermarks
    */
   @Getter(AccessLevel.PACKAGE)
   @VisibleForTesting
-  private final TableWatermarks expectedHighWatermarks;
+  protected final TableWatermarks expectedHighWatermarks;
 
-  private final HiveMetastoreClientPool pool;
+  protected final HiveMetastoreClientPool pool;
   /**
    * Delegates watermarking logic to {@link TableLevelWatermarker} for Non partitioned tables
    */
-  private final TableLevelWatermarker tableLevelWatermarker;
+  protected final TableLevelWatermarker tableLevelWatermarker;
 
-  private final HiveUnitUpdateProvider updateProvider;
+  protected final HiveUnitUpdateProvider updateProvider;
 
   /**
    * Reads and initialized the previous high watermarks from {@link SourceState#getPreviousDatasetStatesByUrns()}

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/watermarker/TableLevelWatermarker.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/watermarker/TableLevelWatermarker.java
@@ -53,7 +53,7 @@ public class TableLevelWatermarker implements HiveSourceWatermarker {
   public static final Gson GSON = new Gson();
 
   // Table complete name db@tb - list of previous workunitState
-  private Map<String, LongWatermark> tableWatermarks;
+  protected Map<String, LongWatermark> tableWatermarks;
 
   public TableLevelWatermarker(State state) {
     this.tableWatermarks = Maps.newHashMap();


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-297


### Description
- [x] Changed access modifier to protected from private so that extending classes can easily override the required methods.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Only access modifier is changed. Hence testing is not required.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

