### PR TITLE
[GOBBLIN-300] Use 1.7.7 form of Schema.createUnion() API that takes i…

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/converter/avro/JsonElementConversionFactory.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/converter/avro/JsonElementConversionFactory.java
@@ -305,7 +305,7 @@ public class JsonElementConversionFactory {
 
     protected Schema buildUnionIfNullable(Schema schema) {
       if (this.isNullable()) {
-        return Schema.createUnion(Schema.create(Schema.Type.NULL), schema);
+        return Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), schema));
       }
       return schema;
     }
@@ -756,7 +756,7 @@ public class JsonElementConversionFactory {
 
     @Override
     protected Schema schema() {
-      return Schema.createUnion(firstSchema, secondSchema);
+      return Schema.createUnion(Arrays.asList(firstSchema, secondSchema));
     }
   }
 }


### PR DESCRIPTION
…n a list

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-300


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
1.8.0 of avro introduced a form of Schema.createUnion() that takes in a variable length arguments. This API does not exist in 1.7.7 and causes problems for users who use the JsonElementConversionFactory with 1.7.7.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

