### PR TITLE
[GOBBLIN-308] Change boot sequence of gobblin cluster to fix the hanging issue

### DIFF
--- a/gobblin-modules/gobblin-service-kafka/src/main/java/org/apache/gobblin/service/StreamingKafkaSpecConsumer.java
+++ b/gobblin-modules/gobblin-service-kafka/src/main/java/org/apache/gobblin/service/StreamingKafkaSpecConsumer.java
@@ -61,7 +61,7 @@ public class StreamingKafkaSpecConsumer extends AbstractIdleService implements S
   private static final int DEFAULT_SPEC_STREAMING_BLOCKING_QUEUE_SIZE = 100;
   private final AvroJobSpecKafkaJobMonitor _jobMonitor;
   private final BlockingQueue<ImmutablePair<SpecExecutor.Verb, Spec>> _jobSpecQueue;
-
+  private final MutableJobCatalog _jobCatalog;
   public StreamingKafkaSpecConsumer(Config config, MutableJobCatalog jobCatalog, Optional<Logger> log) {
     String topic = config.getString(SPEC_KAFKA_TOPICS_KEY);
     Config defaults = ConfigFactory.parseMap(ImmutableMap.of(AvroJobSpecKafkaJobMonitor.TOPIC_KEY, topic,
@@ -74,11 +74,9 @@ public class StreamingKafkaSpecConsumer extends AbstractIdleService implements S
       throw new RuntimeException("Could not create job monitor", e);
     }
 
+    _jobCatalog = jobCatalog;
     _jobSpecQueue = new LinkedBlockingQueue<>(ConfigUtils.getInt(config, "SPEC_STREAMING_BLOCKING_QUEUE_SIZE",
         DEFAULT_SPEC_STREAMING_BLOCKING_QUEUE_SIZE));
-
-    // listener will add job specs to a blocking queue to send to callers of changedSpecs()
-    jobCatalog.addListener(new JobSpecListener());
   }
 
   public StreamingKafkaSpecConsumer(Config config, MutableJobCatalog jobCatalog, Logger log) {
@@ -116,6 +114,10 @@ public class StreamingKafkaSpecConsumer extends AbstractIdleService implements S
 
   @Override
   protected void startUp() {
+    // listener will add job specs to a blocking queue to send to callers of changedSpecs()
+    // IMPORTANT: This addListener should be invoked after job catalog has been initialized. This is guaranteed because
+    //            StreamingKafkaSpecConsumer is boot after jobCatalog in GobblinClusterManager::startAppLauncherAndServices()
+    this._jobCatalog.addListener(new JobSpecListener());
     _jobMonitor.startAsync().awaitRunning();
   }
 

--- a/gobblin-modules/gobblin-service-kafka/src/main/java/org/apache/gobblin/service/StreamingKafkaSpecConsumer.java
+++ b/gobblin-modules/gobblin-service-kafka/src/main/java/org/apache/gobblin/service/StreamingKafkaSpecConsumer.java
@@ -117,7 +117,7 @@ public class StreamingKafkaSpecConsumer extends AbstractIdleService implements S
     // listener will add job specs to a blocking queue to send to callers of changedSpecs()
     // IMPORTANT: This addListener should be invoked after job catalog has been initialized. This is guaranteed because
     //            StreamingKafkaSpecConsumer is boot after jobCatalog in GobblinClusterManager::startAppLauncherAndServices()
-    this._jobCatalog.addListener(new JobSpecListener());
+    _jobCatalog.addListener(new JobSpecListener());
     _jobMonitor.startAsync().awaitRunning();
   }
 


### PR DESCRIPTION
… hanging issue

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-308


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
         (1) Move jobCatalog.addListener to the specConsumer.startUp(). This will delay the original spec queuing logic (triggered by jobCatalog service startup) to the consumer startup. Earlier this will have an issue because specConsumer doesn't have a chance to run due to jobCatalog service startup pushes job spec to blocking queue and the whole thread was blocked there.
         (2) StreamingJobConfigruationManager::startup() should launch the fetching thread before the consumer thread. This is important because now consumer startup will queuing job specs into a blocking queue. A fetching thread should be present before this queuing starts.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
   Local deployment test is done.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

