### PR TITLE
[GOBBLIN-309] Disabled rewrite and enabled retry for adding jar file on HDFS

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -182,6 +182,8 @@ public class ConfigurationKeys {
   public static final String CLEANUP_STAGING_DATA_BY_INITIALIZER = "cleanup.staging.data.by.initializer";
   public static final String CLEANUP_OLD_JOBS_DATA = "cleanup.old.job.data";
   public static final boolean DEFAULT_CLEANUP_OLD_JOBS_DATA = false;
+  public static final String MAXIMUM_JAR_COPY_RETRY_TIMES_KEY = JOB_JAR_FILES_KEY + ".uploading.retry.maximum";
+
 
   public static final String QUEUED_TASK_TIME_MAX_SIZE = "taskexecutor.queued_task_time.history.max_size";
   public static final int DEFAULT_QUEUED_TASK_TIME_MAX_SIZE = 2048;

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/mapreduce/MRJobLauncher.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/mapreduce/MRJobLauncher.java
@@ -412,6 +412,7 @@ public class MRJobLauncher extends AbstractJobLauncher {
           try {
             if (this.fs.exists(destJarFile) && fs.getFileStatus(destJarFile).getLen() != status.getLen()) {
               Thread.sleep(WAITING_TIME_ON_IMCOMPLETE_UPLOAD);
+              throw new IOException("Waiting for file to complete on uploading ... ");
             }
             // Set the first parameter as false for not deleting sourceFile
             // Set the second parameter as false for not overwriting existing file on the target, by default it is true.


### PR DESCRIPTION
This is a rough PR for initial review. 

The approach is to keep the record of unsuccessful copy of jar files, and have busy spin loop to ensure they are added successfully, or drop the attempt if any other job instances have added jar file. 

@htran1  Can you help on this rough review? Just want to make sure it is on the right track. Thanks.

### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-309] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-309


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

