### PR TITLE
[GOBBLIN-312] Pass extra kafka configuration to the KafkaConsumer in …

### DIFF
--- a/gobblin-modules/gobblin-kafka-09/src/main/java/org/apache/gobblin/kafka/client/Kafka09ConsumerClient.java
+++ b/gobblin-modules/gobblin-kafka-09/src/main/java/org/apache/gobblin/kafka/client/Kafka09ConsumerClient.java
@@ -94,7 +94,12 @@ public class Kafka09ConsumerClient<K, V> extends AbstractBaseKafkaConsumerClient
     props.put(KAFKA_09_CLIENT_BOOTSTRAP_SERVERS_KEY, Joiner.on(",").join(super.brokers));
     props.put(KAFKA_09_CLIENT_SESSION_TIMEOUT_KEY, super.socketTimeoutMillis);
 
-    Config scopedConfig = config.getConfig(CONFIG_PREFIX_NO_DOT).withFallback(FALLBACK);
+    // grab all the config under "source.kafka" and add the defaults as fallback.
+    Config baseConfig = ConfigUtils.getConfigOrEmpty(config, CONFIG_NAMESPACE).withFallback(FALLBACK);
+    // get the "source.kafka.consumerConfig" config for extra config to pass along to Kafka
+    Config specificConfig = ConfigUtils.getConfigOrEmpty(baseConfig, CONSUMER_CONFIG);
+    // The specific config overrides settings in the base config
+    Config scopedConfig = specificConfig.withFallback(baseConfig.withoutPath(CONSUMER_CONFIG));
     props.putAll(ConfigUtils.configToProperties(scopedConfig));
 
     this.consumer = new KafkaConsumer<>(props);

--- a/gobblin-modules/gobblin-kafka-09/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSimpleStreamingSource.java
+++ b/gobblin-modules/gobblin-kafka-09/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSimpleStreamingSource.java
@@ -46,7 +46,6 @@ import org.apache.gobblin.source.workunit.Extract;
 import org.apache.gobblin.source.workunit.WorkUnit;
 import org.apache.gobblin.util.ConfigUtils;
 
-
 /**
  * A {@link EventBasedSource} implementation for a simple streaming kafka extractor.
  *
@@ -66,6 +65,8 @@ public class KafkaSimpleStreamingSource<S, D> extends EventBasedSource<S, Record
    */
   public static final String TOPIC_KEY_DESERIALIZER = "gobblin.streaming.kafka.topic.key.deserializer";
   public static final String TOPIC_VALUE_DESERIALIZER = "gobblin.streaming.kafka.topic.value.deserializer";
+
+  public static final String KAFKA_CONSUMER_CONFIG_PREFIX = "gobblin.streaming.kafka.consumerConfig";
 
   /**
    * Private config keys used to pass data into work unit state
@@ -103,6 +104,12 @@ public class KafkaSimpleStreamingSource<S, D> extends EventBasedSource<S, Record
     props.put("key.deserializer", config.getString(TOPIC_KEY_DESERIALIZER));
     Preconditions.checkArgument(config.hasPath(TOPIC_VALUE_DESERIALIZER));
     props.put("value.deserializer", config.getString(TOPIC_VALUE_DESERIALIZER));
+
+    // pass along any config scoped under source.kafka.config
+    // one use case of this is to pass SSL configuration
+    Config scopedConfig = ConfigUtils.getConfigOrEmpty(config, KAFKA_CONSUMER_CONFIG_PREFIX);
+    props.putAll(ConfigUtils.configToProperties(scopedConfig));
+
     Consumer consumer = null;
     try {
       consumer = new KafkaConsumer<>(props);

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/kafka/client/AbstractBaseKafkaConsumerClient.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/kafka/client/AbstractBaseKafkaConsumerClient.java
@@ -41,8 +41,9 @@ import javax.annotation.Nullable;
  */
 public abstract class AbstractBaseKafkaConsumerClient implements GobblinKafkaConsumerClient {
 
-  public static final String CONFIG_PREFIX_NO_DOT = "source.kafka";
-  public static final String CONFIG_PREFIX = CONFIG_PREFIX_NO_DOT + ".";
+  public static final String CONFIG_NAMESPACE = "source.kafka";
+  public static final String CONFIG_PREFIX = CONFIG_NAMESPACE + ".";
+  public static final String CONSUMER_CONFIG = "consumerConfig";
   public static final String CONFIG_KAFKA_FETCH_TIMEOUT_VALUE = CONFIG_PREFIX + "fetchTimeoutMillis";
   public static final int CONFIG_KAFKA_FETCH_TIMEOUT_VALUE_DEFAULT = 1000; // 1 second
   public static final String CONFIG_KAFKA_FETCH_REQUEST_MIN_BYTES = CONFIG_PREFIX + "fetchMinBytes";


### PR DESCRIPTION
…KafkaSimpleStreamingSource

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-312


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):


### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
* Adds the `gobblin.streaming.kafka.consumerConfig` configuration prefix for passing extra kafka config to the `KafkaConsumer`.


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

