### PR TITLE
[GOBBLIN-317] Add dynamic configuration injection in the mappers

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -205,6 +205,12 @@ public class ConfigurationKeys {
   public static final String DEFAULT_EVENT_METADATA_GENERATOR_CLASS_KEY = "noop";
 
   /**
+   * Configuration for dynamic configuration generation
+   */
+  public static final String DYNAMIC_CONFIG_GENERATOR_CLASS_KEY = "dynamicConfigGenerator.class";
+  public static final String DEFAULT_DYNAMIC_CONFIG_GENERATOR_CLASS_KEY = "noop";
+
+  /**
    * Configuration properties used internally.
    */
   public static final String JOB_ID_KEY = "job.id";
@@ -734,7 +740,7 @@ public class ConfigurationKeys {
   public static final boolean DEFAULT_KAFKA_SOURCE_SHARE_CONSUMER_CLIENT = false;
   public static final String KAFKA_SOURCE_AVG_FETCH_TIME_CAP = "kakfa.source.avgFetchTimeCap";
   public static final int DEFAULT_KAFKA_SOURCE_AVG_FETCH_TIME_CAP = 100;
-
+  public static final String SHARED_KAFKA_CONFIG_PREFIX = "gobblin.kafka.sharedConfig";
 
   /**
    * Job execution info server and history store configuration properties.

--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/DynamicConfigGenerator.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/DynamicConfigGenerator.java
@@ -26,6 +26,8 @@ import com.typesafe.config.Config;
 public interface DynamicConfigGenerator {
   /**
    * Generate dynamic configuration that should be added to the job configuration.
+   * @param config configuration
+   * @return config object with the dynamic configuration
    */
-  Config generateDynamicConfig();
+  Config generateDynamicConfig(Config config);
 }

--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/DynamicConfigGenerator.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/DynamicConfigGenerator.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gobblin.configuration;
+
+import com.typesafe.config.Config;
+
+/**
+ * For generating dynamic configuration that gets added to the job configuration.
+ * These are configuration values that cannot be determined statically at job specification time.
+ * One example is the SSL certificate location of a certificate that is fetched at runtime.
+ */
+public interface DynamicConfigGenerator {
+  /**
+   * Generate dynamic configuration that should be added to the job configuration.
+   */
+  Config generateDynamicConfig();
+}

--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/NoopDynamicConfigGenerator.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/NoopDynamicConfigGenerator.java
@@ -27,10 +27,10 @@ import org.apache.gobblin.annotation.Alias;
 @Alias("noop")
 public class NoopDynamicConfigGenerator implements DynamicConfigGenerator {
 
-  public NoopDynamicConfigGenerator(Config config) {
+  public NoopDynamicConfigGenerator() {
   }
 
-  public Config generateDynamicConfig() {
+  public Config generateDynamicConfig(Config config) {
     return ConfigFactory.empty();
   }
 }

--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/NoopDynamicConfigGenerator.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/NoopDynamicConfigGenerator.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gobblin.configuration;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.apache.gobblin.annotation.Alias;
+
+
+/**
+ * NoOp dynamic config generator that returns an empty {@link Config}
+ */
+@Alias("noop")
+public class NoopDynamicConfigGenerator implements DynamicConfigGenerator {
+
+  public NoopDynamicConfigGenerator(Config config) {
+  }
+
+  public Config generateDynamicConfig() {
+    return ConfigFactory.empty();
+  }
+}

--- a/gobblin-modules/gobblin-azkaban/src/main/java/org/apache/gobblin/azkaban/AzkabanJobLauncher.java
+++ b/gobblin-modules/gobblin-azkaban/src/main/java/org/apache/gobblin/azkaban/AzkabanJobLauncher.java
@@ -133,9 +133,10 @@ public class AzkabanJobLauncher extends AbstractJob implements ApplicationLaunch
     this.props.putAll(props);
 
     // load dynamic configuration and add them to the job properties
+    Config propsAsConfig = ConfigUtils.propertiesToConfig(props);
     DynamicConfigGenerator dynamicConfigGenerator =
-        DynamicConfigGeneratorFactory.createDynamicConfigGenerator(ConfigUtils.propertiesToConfig(props));
-    Config dynamicConfig = dynamicConfigGenerator.generateDynamicConfig();
+        DynamicConfigGeneratorFactory.createDynamicConfigGenerator(propsAsConfig);
+    Config dynamicConfig = dynamicConfigGenerator.generateDynamicConfig(propsAsConfig);
 
     // add the dynamic config to the job config
     for (Map.Entry<String, ConfigValue> entry : dynamicConfig.entrySet()) {

--- a/gobblin-modules/gobblin-kafka-09/src/main/java/org/apache/gobblin/kafka/client/Kafka09ConsumerClient.java
+++ b/gobblin-modules/gobblin-kafka-09/src/main/java/org/apache/gobblin/kafka/client/Kafka09ConsumerClient.java
@@ -44,6 +44,7 @@ import javax.annotation.Nonnull;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
+import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.source.extractor.extract.kafka.KafkaOffsetRetrievalFailureException;
 import org.apache.gobblin.source.extractor.extract.kafka.KafkaPartition;
 import org.apache.gobblin.source.extractor.extract.kafka.KafkaTopic;
@@ -96,8 +97,10 @@ public class Kafka09ConsumerClient<K, V> extends AbstractBaseKafkaConsumerClient
 
     // grab all the config under "source.kafka" and add the defaults as fallback.
     Config baseConfig = ConfigUtils.getConfigOrEmpty(config, CONFIG_NAMESPACE).withFallback(FALLBACK);
-    // get the "source.kafka.consumerConfig" config for extra config to pass along to Kafka
-    Config specificConfig = ConfigUtils.getConfigOrEmpty(baseConfig, CONSUMER_CONFIG);
+    // get the "source.kafka.consumerConfig" config for extra config to pass along to Kafka with a fallback to the
+    // shared config that start with "gobblin.kafka.sharedConfig"
+    Config specificConfig = ConfigUtils.getConfigOrEmpty(baseConfig, CONSUMER_CONFIG).withFallback(
+        ConfigUtils.getConfigOrEmpty(config, ConfigurationKeys.SHARED_KAFKA_CONFIG_PREFIX));
     // The specific config overrides settings in the base config
     Config scopedConfig = specificConfig.withFallback(baseConfig.withoutPath(CONSUMER_CONFIG));
     props.putAll(ConfigUtils.configToProperties(scopedConfig));

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/metrics/kafka/KafkaAvroReporter.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/metrics/kafka/KafkaAvroReporter.java
@@ -25,13 +25,11 @@ import org.apache.avro.Schema;
 import com.google.common.base.Optional;
 import com.typesafe.config.Config;
 
-import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.metrics.MetricReport;
 import org.apache.gobblin.metrics.reporter.util.AvroBinarySerializer;
 import org.apache.gobblin.metrics.reporter.util.AvroSerializer;
 import org.apache.gobblin.metrics.reporter.util.SchemaRegistryVersionWriter;
 import org.apache.gobblin.metrics.reporter.util.SchemaVersionWriter;
-import org.apache.gobblin.util.ConfigUtils;
 
 
 /**
@@ -99,7 +97,9 @@ public class KafkaAvroReporter extends KafkaReporter {
     public KafkaAvroReporter build(String brokers, String topic, Properties props) throws IOException {
       this.brokers = brokers;
       this.topic = topic;
-      return new KafkaAvroReporter(this, ConfigUtils.propertiesToConfig(props, Optional.of(ConfigurationKeys.METRICS_CONFIGURATIONS_PREFIX)));
+
+      // create a KafkaAvroReporter with metrics.* and gobblin.kafka.sharedConfig.* keys
+      return new KafkaAvroReporter(this, KafkaReporter.getKafkaAndMetricsConfigFromProperties(props));
     }
   }
 }

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/metrics/kafka/KafkaReporterFactory.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/metrics/kafka/KafkaReporterFactory.java
@@ -94,8 +94,13 @@ public class KafkaReporterFactory implements CustomCodahaleReporterFactory {
         KafkaEventReporter.Builder<?> builder = formatEnum.eventReporterBuilder(RootMetricContext.get(),
             properties);
 
-        Config kafkaConfig = ConfigUtils.getConfigOrEmpty(ConfigUtils.propertiesToConfig(properties),
-            PusherUtils.METRICS_REPORTING_KAFKA_CONFIG_PREFIX);
+        Config allConfig = ConfigUtils.propertiesToConfig(properties);
+        // the kafka configuration is composed of the metrics reporting specific keys with a fallback to the shared
+        // kafka config
+        Config kafkaConfig = ConfigUtils.getConfigOrEmpty(allConfig,
+            PusherUtils.METRICS_REPORTING_KAFKA_CONFIG_PREFIX).withFallback(ConfigUtils.getConfigOrEmpty(allConfig,
+            ConfigurationKeys.SHARED_KAFKA_CONFIG_PREFIX));
+
         builder.withConfig(kafkaConfig);
 
         builder.withPusherClassName(properties.getProperty(PusherUtils.KAFKA_PUSHER_CLASS_NAME_KEY,

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/DynamicConfigGeneratorFactory.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/DynamicConfigGeneratorFactory.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gobblin.runtime;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import java.util.Collections;
+
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.configuration.DynamicConfigGenerator;
+import org.apache.gobblin.util.ClassAliasResolver;
+import org.apache.gobblin.util.ConfigUtils;
+import org.apache.gobblin.util.reflection.GobblinConstructorUtils;
+
+
+/**
+ * For getting an instance of a {@link DynamicConfigGenerator}
+ */
+public class DynamicConfigGeneratorFactory {
+  /**
+   * Get an instance of a {@link DynamicConfigGenerator}
+   * @param config {@link Config} to pass to the constructor
+   * @return an instance of {@link DynamicConfigGenerator}
+   */
+  public static DynamicConfigGenerator createDynamicConfigGenerator(Config config) {
+    String dynamicConfigGeneratorClassName =
+        ConfigUtils.getString(config, ConfigurationKeys.DYNAMIC_CONFIG_GENERATOR_CLASS_KEY,
+            ConfigurationKeys.DEFAULT_DYNAMIC_CONFIG_GENERATOR_CLASS_KEY);
+
+    try {
+      ClassAliasResolver<DynamicConfigGenerator> aliasResolver =
+          new ClassAliasResolver<>(DynamicConfigGenerator.class);
+      return GobblinConstructorUtils.invokeFirstConstructor(
+          aliasResolver.resolveClass(dynamicConfigGeneratorClassName),
+          Collections.singletonList(config));
+    } catch (ReflectiveOperationException e) {
+      throw new RuntimeException("Could not construct DynamicConfigGenerator " +
+          dynamicConfigGeneratorClassName, e);
+    }
+  }
+}

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/DynamicConfigGeneratorFactory.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/DynamicConfigGeneratorFactory.java
@@ -44,9 +44,7 @@ public class DynamicConfigGeneratorFactory {
     try {
       ClassAliasResolver<DynamicConfigGenerator> aliasResolver =
           new ClassAliasResolver<>(DynamicConfigGenerator.class);
-      return GobblinConstructorUtils.invokeFirstConstructor(
-          aliasResolver.resolveClass(dynamicConfigGeneratorClassName),
-          Collections.singletonList(config));
+      return aliasResolver.resolveClass(dynamicConfigGeneratorClassName).newInstance();
     } catch (ReflectiveOperationException e) {
       throw new RuntimeException("Could not construct DynamicConfigGenerator " +
           dynamicConfigGeneratorClassName, e);

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/mapreduce/MRJobLauncher.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/mapreduce/MRJobLauncher.java
@@ -633,9 +633,10 @@ public class MRJobLauncher extends AbstractJobLauncher {
 
       // load dynamic configuration to add to the job configuration
       Configuration configuration = context.getConfiguration();
+      Config jobStateAsConfig = ConfigUtils.propertiesToConfig(this.jobState.getProperties());
       DynamicConfigGenerator dynamicConfigGenerator = DynamicConfigGeneratorFactory.createDynamicConfigGenerator(
-          ConfigUtils.propertiesToConfig(this.jobState.getProperties()));
-      Config dynamicConfig = dynamicConfigGenerator.generateDynamicConfig();
+          jobStateAsConfig);
+      Config dynamicConfig = dynamicConfigGenerator.generateDynamicConfig(jobStateAsConfig);
 
       // add the dynamic config to the job config
       for (Map.Entry<String, ConfigValue> entry : dynamicConfig.entrySet()) {

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/JobLauncherTestHelper.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/JobLauncherTestHelper.java
@@ -50,6 +50,8 @@ import org.apache.gobblin.util.JobLauncherUtils;
 public class JobLauncherTestHelper {
 
   public static final String SOURCE_FILE_LIST_KEY = "source.files";
+  public static final String DYNAMIC_KEY1 = "DynamicKey1";
+  public static final String DYNAMIC_VALUE1 = "DynamicValue1";
 
   private final StateStore<JobState.DatasetState> datasetStateStore;
   private final Properties launcherProps;

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/mapreduce/MRJobLauncherTest.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/mapreduce/MRJobLauncherTest.java
@@ -381,11 +381,11 @@ public class MRJobLauncherTest extends BMNGRunner {
   }
 
   public static class TestDynamicConfigGenerator implements DynamicConfigGenerator {
-    public TestDynamicConfigGenerator(Config config) {
+    public TestDynamicConfigGenerator() {
     }
 
     @Override
-    public Config generateDynamicConfig() {
+    public Config generateDynamicConfig(Config config) {
       return ConfigFactory.parseMap(ImmutableMap.of(JobLauncherTestHelper.DYNAMIC_KEY1,
           JobLauncherTestHelper.DYNAMIC_VALUE1));
     }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-317


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
* Adds the ability to plug in the generation of dynamic configuration in the Azkaban executor and mappers. One use case for this is to set the configuration of dynamically loaded SSL certificates.
* Introduce shared kafka config under the gobblin.kafka.sharedConfig prefix.
* Changed the kafka clients to use the shared config as a fallback.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

