### PR TITLE
[GOBBLIN-322] The cluster mode failed to find a log4j config file

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterManager.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterManager.java
@@ -725,10 +725,6 @@ public class GobblinClusterManager implements ApplicationLauncher {
         isStandaloneClusterManager = Boolean.parseBoolean(cmd.getOptionValue(GobblinClusterConfigurationKeys.STANDALONE_CLUSTER_MODE, "false"));
       }
 
-      Log4jConfigurationHelper.updateLog4jConfiguration(GobblinClusterManager.class,
-          GobblinClusterConfigurationKeys.GOBBLIN_CLUSTER_LOG4J_CONFIGURATION_FILE,
-          GobblinClusterConfigurationKeys.GOBBLIN_CLUSTER_LOG4J_CONFIGURATION_FILE);
-
       LOGGER.info(JvmUtils.getJvmInputArguments());
       Config config = ConfigFactory.load();
 

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinTaskRunner.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinTaskRunner.java
@@ -480,10 +480,6 @@ public class GobblinTaskRunner {
         System.exit(1);
       }
 
-      Log4jConfigurationHelper.updateLog4jConfiguration(GobblinTaskRunner.class,
-          GobblinClusterConfigurationKeys.GOBBLIN_CLUSTER_LOG4J_CONFIGURATION_FILE,
-          GobblinClusterConfigurationKeys.GOBBLIN_CLUSTER_LOG4J_CONFIGURATION_FILE);
-
       LOGGER.info(JvmUtils.getJvmInputArguments());
 
       String applicationName = cmd.getOptionValue(GobblinClusterConfigurationKeys.APPLICATION_NAME_OPTION_NAME);


### PR DESCRIPTION
Issue:

When running the bin/gobblin-cluster-master.sh
I got an exception below:
Exception in thread "main" java.io.FileNotFoundException: log4j-cluster.properties (No such file or directory)
at java.io.FileInputStream.open0(Native Method)
at java.io.FileInputStream.open(FileInputStream.java:195)
at java.io.FileInputStream.<init>(FileInputStream.java:138)
at java.io.FileInputStream.<init>(FileInputStream.java:93)
at org.apache.gobblin.util.logs.Log4jConfigurationHelper.updateLog4jConfiguration(Log4jConfigurationHelper.java:51)
at org.apache.gobblin.cluster.GobblinClusterManager.main(GobblinClusterManager.java:724)
bin/gobblin-cluster-worker.sh has a similar issue.

Analysis:

public static void updateLog4jConfiguration(Class<?> targetClass, String log4jPath, String log4jFileName)
throws IOException {
Closer closer = Closer.create();
try {
InputStream fileInputStream = closer.register(new FileInputStream(log4jPath));

The caller passes a simple file name
Log4jConfigurationHelper.updateLog4jConfiguration(GobblinClusterManager.class,
GobblinClusterConfigurationKeys.GOBBLIN_CLUSTER_LOG4J_CONFIGURATION_FILE,
GobblinClusterConfigurationKeys.GOBBLIN_CLUSTER_LOG4J_CONFIGURATION_FILE);

Solution:
This logic can be removed.

Users can simply pass in a custom log4j configuration directly if needed.
e.g.
-Dlog4j.configuration=file:/Users/foo/oss/gobblin/temp/my-log4j.properties
Or
add a custom log4j.properties file in the class path.