### PR TITLE
[GOBBLIN-324] Add the cluster working directory config

### DIFF
--- a/conf/standalone/application.conf
+++ b/conf/standalone/application.conf
@@ -16,10 +16,22 @@
 #
 
 # Sample configuration properties for the Gobblin Standalone cluster
+gobblin.cluster.workDir=${gobblin.cluster.work.dir}/GobblinStandaloneCluster
+
+# default is the JobConfigurationManager
+# use this manager to accept jobs from Kafka. It requires some additional Kafka related parameters.
+#gobblin.cluster.job.configuration.manager=org.apache.gobblin.cluster.StreamingJobConfigurationManager
+#spec.kafka.topics=ruyang_test_kafka_gobblin
+#kafka.brokers="hostname:12913/kafka-queuing"
+#jobSpecMonitor.kafka.zookeeper.connect="hostname:12913/kafka-queuing"
 
 # Cluster configuration properties
-gobblin.cluster.helix.cluster.name=GobblinStandaloneCluster
-gobblin.cluster.job.conf.path=<path where Gobblin job configuration file are located>
+gobblin.cluster.helix.cluster.name=GobblinStandaloneClusterCli
+
+# used by the JobConfigurationManager
+gobblin.cluster.job.conf.path=${gobblin.cluster.work.dir}/jobs
+
+gobblin.cluster.jobconf.fullyQualifiedPath=${gobblin.cluster.work.dir}/jobs
 
 # File system URIs
 writer.fs.uri=${fs.uri}

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
@@ -35,7 +35,7 @@ public class GobblinClusterConfigurationKeys {
   public static final String STANDALONE_CLUSTER_MODE = "standalone_cluster";
   public static final String STANDALONE_CLUSTER_MODE_KEY = GOBBLIN_CLUSTER_PREFIX + "standaloneMode";
   public static final boolean DEFAULT_STANDALONE_CLUSTER_MODE = false;
-
+  public static final String CLUSTRER_WORK_DIR = GOBBLIN_CLUSTER_PREFIX + "workDir";
 
   // Helix configuration properties.
   public static final String HELIX_CLUSTER_NAME_KEY = GOBBLIN_CLUSTER_PREFIX + "helix.cluster.name";

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterManager.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterManager.java
@@ -163,7 +163,7 @@ public class GobblinClusterManager implements ApplicationLauncher {
 
     this.fs = buildFileSystem(config);
     this.appWorkDir = appWorkDirOptional.isPresent() ? appWorkDirOptional.get()
-        : GobblinClusterUtils.getAppWorkDirPath(this.fs, clusterName, applicationId);
+        : GobblinClusterUtils.getAppWorkDirPathFromConfig(config, this.fs, clusterName, applicationId);
 
     initializeAppLauncherAndServices();
   }

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterUtils.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterUtils.java
@@ -17,13 +17,14 @@
 
 package org.apache.gobblin.cluster;
 
+import static org.apache.gobblin.cluster.GobblinClusterConfigurationKeys.CLUSTRER_WORK_DIR;
+
+import com.typesafe.config.Config;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-
+import org.apache.gobblin.annotation.Alpha;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-
-import org.apache.gobblin.annotation.Alpha;
 
 @Alpha
 public class GobblinClusterUtils {
@@ -48,6 +49,14 @@ public class GobblinClusterUtils {
    * @return the cluster application working directory {@link Path}
    */
   public static Path getAppWorkDirPath(FileSystem fs, String applicationName, String applicationId) {
+    return new Path(fs.getHomeDirectory(), getAppWorkDirPath(applicationName, applicationId));
+  }
+
+  public static Path getAppWorkDirPathFromConfig(Config config, FileSystem fs,
+      String applicationName, String applicationId) {
+    if (config.hasPath(CLUSTRER_WORK_DIR)) {
+      return new Path(config.getString(CLUSTRER_WORK_DIR));
+    }
     return new Path(fs.getHomeDirectory(), getAppWorkDirPath(applicationName, applicationId));
   }
 

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinTaskRunner.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinTaskRunner.java
@@ -160,7 +160,7 @@ public class GobblinTaskRunner {
     TaskStateTracker taskStateTracker = new GobblinHelixTaskStateTracker(properties, this.helixManager);
 
     Path appWorkDir = appWorkDirOptional.isPresent() ? appWorkDirOptional.get() :
-        GobblinClusterUtils.getAppWorkDirPath(this.fs, applicationName, applicationId);
+        GobblinClusterUtils.getAppWorkDirPathFromConfig(config, this.fs, applicationName, applicationId);
 
     List<Service> services = Lists.newArrayList(taskExecutor, taskStateTracker,
         new JMXReportingService(ImmutableMap.of("task.executor" ,taskExecutor.getTaskExecutorQueueMetricSet())));

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinClusterUtilsTest.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinClusterUtilsTest.java
@@ -1,0 +1,45 @@
+package org.apache.gobblin.cluster;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.testng.annotations.Test;
+
+public class GobblinClusterUtilsTest {
+
+  FileSystem fs = mock(FileSystem.class);
+
+  @Test
+  public void work_dir_should_get_value_from_config_when_specified() throws Exception {
+    Map<String, String> configMap = new HashMap<>();
+    configMap.put("gobblin.cluster.workDir", "/foo/bar");
+
+    Config config = ConfigFactory.parseMap(configMap);
+
+    Path workDirPath = GobblinClusterUtils
+        .getAppWorkDirPathFromConfig(config, fs, "appName", "appid");
+
+    assertEquals(new Path("/foo/bar"), workDirPath);
+
+  }
+
+  @Test
+  public void work_dir_should_get_default_calculated_value_when_not_specified() throws Exception {
+    Map<String, String> configMap = new HashMap<>();
+    Config config = ConfigFactory.parseMap(configMap);
+
+    when(fs.getHomeDirectory()).thenReturn(new Path("/home/"));
+
+    Path workDirPath = GobblinClusterUtils
+        .getAppWorkDirPathFromConfig(config, fs, "appName", "appid");
+
+    assertEquals(new Path("/home/appName/appid"), workDirPath);
+  }
+}

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinClusterUtilsTest.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinClusterUtilsTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package org.apache.gobblin.cluster;
 
 import static org.mockito.Mockito.mock;

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinClusterUtilsTest.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinClusterUtilsTest.java
@@ -13,7 +13,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package org.apache.gobblin.cluster;


### PR DESCRIPTION
Currently, the appWorkDir value is passed to the GobblinClusterManager
constructor and the GobblinTaskRunner constructor.
It's used to determine where the state files will be stored.
The default launch scripts call the main methods which pass in a
hardcoded "null" value and the code will take a default value like
file:/Users/username/standalone_cluster/1

It's useful to specify this value via a configuration.

When the config is not specified, the behavior is the same as before.

Also add some examples in the sample config file.

Testing:

Add new unit tests.
Manually run the cluster with and without this config.