### PR TITLE
Ignore generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,12 @@ gobblin.tar.gz
 *~
 metastore_db/
 GobblinKey_*.pem
+
+# generated nodeJs files
+node_modules/
+package-lock.json
+
+*.out
+
+# generated java files
+**/gen-java/


### PR DESCRIPTION
Ignore:

generated nodeJs modules and the lock file.
generated java files.
generated output files with the .out extension during manual and test
runs.