### PR TITLE
Add gobblin-service-kafka as a runtime dependency of the cluster module

### DIFF
--- a/gobblin-cluster/build.gradle
+++ b/gobblin-cluster/build.gradle
@@ -50,6 +50,8 @@ dependencies {
   compile externalDependency.findBugsAnnotations
   compile externalDependency.helix
 
+  runtime project(":gobblin-modules:gobblin-service-kafka")
+
   testCompile project(":gobblin-example")
 
   testCompile externalDependency.testng


### PR DESCRIPTION
This will allow running the cluster from an IDE with configurations that
require the Kafka module,  e.g. the StreamingJobConfigManager.