### PR TITLE
[GOBBLIN-334] Implement SharedResourceFactory for LineageInfo

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/broker/SharedNameKey.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/broker/SharedNameKey.java
@@ -15,16 +15,42 @@
  * limitations under the License.
  */
 
-package org.apache.gobblin.dataset;
+package org.apache.gobblin.broker;
 
-import com.typesafe.config.Config;
+import org.apache.gobblin.broker.iface.SharedResourceKey;
+
 
 /**
- * A factory that creates an instance of {@link DatasetResolver}
+ * A {@link SharedResourceKey} with only a string name
  */
-public interface DatasetResolverFactory {
-  /**
-   * Create a {@link DatasetResolver} instance
-   */
-  DatasetResolver createResolver(Config config);
+public class SharedNameKey implements SharedResourceKey {
+  private final String name;
+
+  public SharedNameKey(String name) {
+    this.name = name;
+  }
+
+  @Override
+  public String toConfigurationKey() {
+    return name;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    SharedNameKey that = (SharedNameKey) o;
+
+    return name != null ? name.equals(that.name) : that.name == null;
+  }
+
+  @Override
+  public int hashCode() {
+    return name != null ? name.hashCode() : 0;
+  }
 }

--- a/gobblin-api/src/main/java/org/apache/gobblin/broker/StringNameSharedResourceKey.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/broker/StringNameSharedResourceKey.java
@@ -23,10 +23,10 @@ import org.apache.gobblin.broker.iface.SharedResourceKey;
 /**
  * A {@link SharedResourceKey} with only a string name
  */
-public class SharedNameKey implements SharedResourceKey {
+public class StringNameSharedResourceKey implements SharedResourceKey {
   private final String name;
 
-  public SharedNameKey(String name) {
+  public StringNameSharedResourceKey(String name) {
     this.name = name;
   }
 
@@ -44,7 +44,7 @@ public class SharedNameKey implements SharedResourceKey {
       return false;
     }
 
-    SharedNameKey that = (SharedNameKey) o;
+    StringNameSharedResourceKey that = (StringNameSharedResourceKey) o;
 
     return name != null ? name.equals(that.name) : that.name == null;
   }

--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/SourceState.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/SourceState.java
@@ -37,10 +37,13 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
+import org.apache.gobblin.broker.gobblin_scopes.GobblinScopeTypes;
+import org.apache.gobblin.broker.iface.SharedResourcesBroker;
 import org.apache.gobblin.source.workunit.WorkUnit;
 import org.apache.gobblin.source.workunit.Extract;
 
 import lombok.Getter;
+import lombok.Setter;
 
 
 /**
@@ -66,6 +69,9 @@ public class SourceState extends State {
 
   @Getter
   private final List<WorkUnitState> previousWorkUnitStates = Lists.newArrayList();
+
+  @Getter @Setter
+  private SharedResourcesBroker<GobblinScopeTypes> broker;
 
   /**
    * Default constructor.

--- a/gobblin-api/src/main/java/org/apache/gobblin/dataset/NoopDatasetResolver.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/dataset/NoopDatasetResolver.java
@@ -25,6 +25,7 @@ import org.apache.gobblin.configuration.State;
  */
 public class NoopDatasetResolver implements DatasetResolver {
   public static final NoopDatasetResolver INSTANCE = new NoopDatasetResolver();
+  public static final String FACTORY = "NOOP";
 
   private NoopDatasetResolver() {}
 

--- a/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/QueryBasedSource.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/QueryBasedSource.java
@@ -47,7 +47,6 @@ import org.apache.gobblin.configuration.SourceState;
 import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.configuration.WorkUnitState;
 import org.apache.gobblin.configuration.WorkUnitState.WorkingState;
-import org.apache.gobblin.metrics.event.lineage.LineageEventBuilder;
 import org.apache.gobblin.metrics.event.lineage.LineageInfo;
 import org.apache.gobblin.source.extractor.JobCommitPolicy;
 import org.apache.gobblin.source.extractor.partition.Partition;
@@ -92,6 +91,8 @@ public abstract class QueryBasedSource<S, D> extends AbstractSource<S, D> {
    *    EXTRACT_TABLE_NAME_KEY = as specified in job config
    */
   public static final Integer CURRENT_WORK_UNIT_STATE_VERSION = 3;
+
+  protected Optional<LineageInfo> lineageInfo;
 
   /** A class that encapsulates a source entity (aka dataset) to be processed */
   @Data
@@ -168,6 +169,7 @@ public abstract class QueryBasedSource<S, D> extends AbstractSource<S, D> {
   @Override
   public List<WorkUnit> getWorkunits(SourceState state) {
     initLogger(state);
+    lineageInfo = LineageInfo.getLineageInfo(state.getBroker());
 
     List<WorkUnit> workUnits = Lists.newArrayList();
 

--- a/gobblin-core/src/test/java/org/apache/gobblin/publisher/BaseDataPublisherTest.java
+++ b/gobblin-core/src/test/java/org/apache/gobblin/publisher/BaseDataPublisherTest.java
@@ -42,6 +42,12 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.io.Files;
 import com.typesafe.config.ConfigFactory;
 
+import org.apache.gobblin.broker.SharedResourcesBrokerFactory;
+import org.apache.gobblin.broker.gobblin_scopes.GobblinScopeTypes;
+import org.apache.gobblin.broker.gobblin_scopes.JobScopeInstance;
+import org.apache.gobblin.broker.gobblin_scopes.TaskScopeInstance;
+import org.apache.gobblin.broker.iface.SharedResourcesBroker;
+import org.apache.gobblin.broker.iface.SubscopedBrokerBuilder;
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.configuration.WorkUnitState;
@@ -49,6 +55,7 @@ import org.apache.gobblin.dataset.DatasetDescriptor;
 import org.apache.gobblin.metadata.MetadataMerger;
 import org.apache.gobblin.metadata.types.GlobalMetadata;
 import org.apache.gobblin.metrics.event.lineage.LineageInfo;
+import org.apache.gobblin.source.workunit.WorkUnit;
 import org.apache.gobblin.util.ForkOperatorUtils;
 import org.apache.gobblin.writer.FsDataWriter;
 import org.apache.gobblin.writer.FsWriterMetrics;
@@ -529,7 +536,7 @@ public class BaseDataPublisherTest {
   public void testPublishSingleTask()
       throws IOException {
     WorkUnitState state = buildTaskState(1);
-    LineageInfo lineageInfo = new LineageInfo(ConfigFactory.empty());
+    LineageInfo lineageInfo = LineageInfo.getLineageInfo(state.getTaskBroker()).get();
     DatasetDescriptor source = new DatasetDescriptor("kafka", "testTopic");
     lineageInfo.setSource(source, state);
     BaseDataPublisher publisher = new BaseDataPublisher(state);
@@ -543,7 +550,7 @@ public class BaseDataPublisherTest {
       throws IOException {
     WorkUnitState state1 = buildTaskState(2);
     WorkUnitState state2 = buildTaskState(2);
-    LineageInfo lineageInfo = new LineageInfo(ConfigFactory.empty());
+    LineageInfo lineageInfo = LineageInfo.getLineageInfo(state1.getTaskBroker()).get();
     DatasetDescriptor source = new DatasetDescriptor("kafka", "testTopic");
     lineageInfo.setSource(source, state1);
     lineageInfo.setSource(source, state2);
@@ -626,7 +633,16 @@ public class BaseDataPublisherTest {
   }
 
   private WorkUnitState buildTaskState(int numBranches) {
-    WorkUnitState state = new WorkUnitState();
+    SharedResourcesBroker<GobblinScopeTypes> instanceBroker = SharedResourcesBrokerFactory
+        .createDefaultTopLevelBroker(ConfigFactory.empty(), GobblinScopeTypes.GLOBAL.defaultScopeInstance());
+    SharedResourcesBroker<GobblinScopeTypes> jobBroker = instanceBroker
+        .newSubscopedBuilder(new JobScopeInstance("LineageEventTest", String.valueOf(System.currentTimeMillis())))
+        .build();
+    SharedResourcesBroker<GobblinScopeTypes> taskBroker = jobBroker
+        .newSubscopedBuilder(new TaskScopeInstance("LineageEventTestTask" + String.valueOf(System.currentTimeMillis())))
+        .build();
+
+    WorkUnitState state = new WorkUnitState(WorkUnit.createEmpty(), new State(), taskBroker);
 
     state.setProp(ConfigurationKeys.EXTRACT_NAMESPACE_NAME_KEY, "namespace");
     state.setProp(ConfigurationKeys.EXTRACT_TABLE_NAME_KEY, "table");

--- a/gobblin-core/src/test/java/org/apache/gobblin/publisher/BaseDataPublisherTest.java
+++ b/gobblin-core/src/test/java/org/apache/gobblin/publisher/BaseDataPublisherTest.java
@@ -40,6 +40,7 @@ import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.Files;
+import com.typesafe.config.ConfigFactory;
 
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.State;
@@ -528,8 +529,9 @@ public class BaseDataPublisherTest {
   public void testPublishSingleTask()
       throws IOException {
     WorkUnitState state = buildTaskState(1);
+    LineageInfo lineageInfo = new LineageInfo(ConfigFactory.empty());
     DatasetDescriptor source = new DatasetDescriptor("kafka", "testTopic");
-    LineageInfo.setSource(source, state);
+    lineageInfo.setSource(source, state);
     BaseDataPublisher publisher = new BaseDataPublisher(state);
     publisher.publishData(state);
     Assert.assertTrue(state.contains("gobblin.event.lineage.branch.0.destination"));
@@ -541,9 +543,10 @@ public class BaseDataPublisherTest {
       throws IOException {
     WorkUnitState state1 = buildTaskState(2);
     WorkUnitState state2 = buildTaskState(2);
+    LineageInfo lineageInfo = new LineageInfo(ConfigFactory.empty());
     DatasetDescriptor source = new DatasetDescriptor("kafka", "testTopic");
-    LineageInfo.setSource(source, state1);
-    LineageInfo.setSource(source, state2);
+    lineageInfo.setSource(source, state1);
+    lineageInfo.setSource(source, state2);
     BaseDataPublisher publisher = new BaseDataPublisher(state1);
     publisher.publishData(ImmutableList.of(state1, state2));
     Assert.assertTrue(state1.contains("gobblin.event.lineage.branch.0.destination"));

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/CopySource.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/CopySource.java
@@ -118,6 +118,8 @@ public class CopySource extends AbstractSource<String, FileAwareInputStream> {
 
   public MetricContext metricContext;
 
+  protected Optional<LineageInfo> lineageInfo;
+
   /**
    * <ul>
    * Does the following:
@@ -139,6 +141,7 @@ public class CopySource extends AbstractSource<String, FileAwareInputStream> {
   public List<WorkUnit> getWorkunits(final SourceState state) {
 
     this.metricContext = Instrumented.getMetricContext(state, CopySource.class);
+    this.lineageInfo = LineageInfo.getLineageInfo(state.getBroker());
 
     try {
 
@@ -320,8 +323,10 @@ public class CopySource extends AbstractSource<String, FileAwareInputStream> {
        * a DatasetFinder. Consequently, the source and destination dataset for the CopyableFile lineage are expected
        * to be set by the same logic
        */
-      if (copyableFile.getSourceDataset() != null && copyableFile.getDestinationDataset() != null) {
-        LineageInfo.setSource(copyableFile.getSourceDataset(), workUnit);
+      if (lineageInfo.isPresent() &&
+          copyableFile.getSourceDataset() != null &&
+          copyableFile.getDestinationDataset() != null) {
+        lineageInfo.get().setSource(copyableFile.getSourceDataset(), workUnit);
       }
     }
   }

--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/broker/LineageInfoFactory.java
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/broker/LineageInfoFactory.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.metrics.broker;
+
+import org.apache.gobblin.broker.ResourceInstance;
+import org.apache.gobblin.broker.SharedNameKey;
+import org.apache.gobblin.broker.gobblin_scopes.GobblinScopeTypes;
+import org.apache.gobblin.broker.iface.ConfigView;
+import org.apache.gobblin.broker.iface.NotConfiguredException;
+import org.apache.gobblin.broker.iface.ScopedConfigView;
+import org.apache.gobblin.broker.iface.SharedResourceFactory;
+import org.apache.gobblin.broker.iface.SharedResourceFactoryResponse;
+import org.apache.gobblin.broker.iface.SharedResourcesBroker;
+import org.apache.gobblin.metrics.event.lineage.LineageInfo;
+
+
+/**
+ * A {@link SharedResourceFactory} to share a job level {@link LineageInfo} instance
+ */
+public class LineageInfoFactory implements SharedResourceFactory<LineageInfo, SharedNameKey, GobblinScopeTypes> {
+  public static final String KEY_NAME = "lineageEvent";
+  public static final String FACTORY_NAME = "lineageInfo";
+
+  @Override
+  public String getName() {
+    return FACTORY_NAME;
+  }
+
+  @Override
+  public SharedResourceFactoryResponse<LineageInfo> createResource(SharedResourcesBroker<GobblinScopeTypes> broker,
+      ScopedConfigView<GobblinScopeTypes, SharedNameKey> config)
+      throws NotConfiguredException {
+    return new ResourceInstance<>(new LineageInfo(config.getConfig()));
+  }
+
+  @Override
+  public GobblinScopeTypes getAutoScope(SharedResourcesBroker<GobblinScopeTypes> broker, ConfigView<GobblinScopeTypes, SharedNameKey> config) {
+    return GobblinScopeTypes.JOB;
+  }
+}

--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/broker/LineageInfoFactory.java
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/broker/LineageInfoFactory.java
@@ -17,8 +17,8 @@
 
 package org.apache.gobblin.metrics.broker;
 
+import org.apache.gobblin.broker.EmptyKey;
 import org.apache.gobblin.broker.ResourceInstance;
-import org.apache.gobblin.broker.SharedNameKey;
 import org.apache.gobblin.broker.gobblin_scopes.GobblinScopeTypes;
 import org.apache.gobblin.broker.iface.ConfigView;
 import org.apache.gobblin.broker.iface.NotConfiguredException;
@@ -32,8 +32,7 @@ import org.apache.gobblin.metrics.event.lineage.LineageInfo;
 /**
  * A {@link SharedResourceFactory} to share a job level {@link LineageInfo} instance
  */
-public class LineageInfoFactory implements SharedResourceFactory<LineageInfo, SharedNameKey, GobblinScopeTypes> {
-  public static final String KEY_NAME = "lineageEvent";
+public class LineageInfoFactory implements SharedResourceFactory<LineageInfo, EmptyKey, GobblinScopeTypes> {
   public static final String FACTORY_NAME = "lineageInfo";
 
   @Override
@@ -43,13 +42,13 @@ public class LineageInfoFactory implements SharedResourceFactory<LineageInfo, Sh
 
   @Override
   public SharedResourceFactoryResponse<LineageInfo> createResource(SharedResourcesBroker<GobblinScopeTypes> broker,
-      ScopedConfigView<GobblinScopeTypes, SharedNameKey> config)
+      ScopedConfigView<GobblinScopeTypes, EmptyKey> config)
       throws NotConfiguredException {
     return new ResourceInstance<>(new LineageInfo(config.getConfig()));
   }
 
   @Override
-  public GobblinScopeTypes getAutoScope(SharedResourcesBroker<GobblinScopeTypes> broker, ConfigView<GobblinScopeTypes, SharedNameKey> config) {
+  public GobblinScopeTypes getAutoScope(SharedResourcesBroker<GobblinScopeTypes> broker, ConfigView<GobblinScopeTypes, EmptyKey> config) {
     return GobblinScopeTypes.JOB;
   }
 }

--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/lineage/LineageInfo.java
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/lineage/LineageInfo.java
@@ -34,7 +34,7 @@ import com.typesafe.config.ConfigFactory;
 import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 
-import org.apache.gobblin.broker.SharedNameKey;
+import org.apache.gobblin.broker.EmptyKey;
 import org.apache.gobblin.broker.gobblin_scopes.GobblinScopeTypes;
 import org.apache.gobblin.broker.iface.NotConfiguredException;
 import org.apache.gobblin.broker.iface.SharedResourcesBroker;
@@ -221,8 +221,7 @@ public final class LineageInfo {
     }
 
     try {
-      LineageInfo lineageInfo = broker.getSharedResource(new LineageInfoFactory(),
-          new SharedNameKey(LineageInfoFactory.KEY_NAME));
+      LineageInfo lineageInfo = broker.getSharedResource(new LineageInfoFactory(), EmptyKey.INSTANCE);
       return Optional.of(lineageInfo);
     } catch (NotConfiguredException e) {
       log.warn("Fail to get LineageInfo instance from broker. Will not track data lineage", e);

--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/lineage/LineageInfo.java
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/lineage/LineageInfo.java
@@ -22,18 +22,28 @@ import java.util.Map;
 import java.util.Set;
 
 import com.google.common.base.Joiner;
+import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.gson.Gson;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
 
+import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 
+import org.apache.gobblin.broker.SharedNameKey;
+import org.apache.gobblin.broker.gobblin_scopes.GobblinScopeTypes;
+import org.apache.gobblin.broker.iface.NotConfiguredException;
+import org.apache.gobblin.broker.iface.SharedResourcesBroker;
 import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.dataset.DatasetDescriptor;
 import org.apache.gobblin.dataset.DatasetResolver;
 import org.apache.gobblin.dataset.DatasetResolverFactory;
 import org.apache.gobblin.dataset.NoopDatasetResolver;
+import org.apache.gobblin.metrics.broker.LineageInfoFactory;
 
 
 /**
@@ -62,11 +72,21 @@ import org.apache.gobblin.dataset.NoopDatasetResolver;
  */
 @Slf4j
 public final class LineageInfo {
+  private static final String DATASET_RESOLVER_FACTORY = "datasetResolverFactory";
+
   private static final String BRANCH = "branch";
   private static final Gson GSON = new Gson();
   private static final String NAME_KEY = "name";
 
-  private LineageInfo() {
+  private static final Config FALLBACK =
+      ConfigFactory.parseMap(ImmutableMap.<String, Object>builder()
+          .put(DATASET_RESOLVER_FACTORY, NoopDatasetResolver.FACTORY)
+          .build());
+
+  private final DatasetResolver resolver;
+
+  public LineageInfo(Config config) {
+    resolver = getResolver(config.withFallback(FALLBACK));
   }
 
   /**
@@ -80,8 +100,7 @@ public final class LineageInfo {
    * @param state state about a {@link org.apache.gobblin.source.workunit.WorkUnit}
    *
    */
-  public static void setSource(DatasetDescriptor source, State state) {
-    DatasetResolver resolver = getResolver(state);
+  public void setSource(DatasetDescriptor source, State state) {
     DatasetDescriptor descriptor = resolver.resolve(source, state);
     if (descriptor == null) {
       return;
@@ -100,14 +119,13 @@ public final class LineageInfo {
    *   the method is implemented to be threadsafe
    * </p>
    */
-  public static void putDestination(DatasetDescriptor destination, int branchId, State state) {
+  public void putDestination(DatasetDescriptor destination, int branchId, State state) {
     if (!hasLineageInfo(state)) {
       log.warn("State has no lineage info but branch " + branchId + " puts a destination: " + GSON.toJson(destination));
       return;
     }
     log.debug(String.format("Put destination %s for branch %d", GSON.toJson(destination), branchId));
     synchronized (state.getProp(getKey(NAME_KEY))) {
-      DatasetResolver resolver = getResolver(state);
       DatasetDescriptor descriptor = resolver.resolve(destination, state);
       if (descriptor == null) {
         return;
@@ -193,19 +211,38 @@ public final class LineageInfo {
     return Joiner.on('.').join(LineageEventBuilder.LIENAGE_EVENT_NAMESPACE, state.getProp(getKey(NAME_KEY)));
   }
 
+
+  /**
+   * Try to get a {@link LineageInfo} instance from the given {@link SharedResourcesBroker}
+   */
+  public static Optional<LineageInfo> getLineageInfo(@Nullable SharedResourcesBroker<GobblinScopeTypes> broker) {
+    if (broker == null) {
+      return Optional.absent();
+    }
+
+    try {
+      LineageInfo lineageInfo = broker.getSharedResource(new LineageInfoFactory(),
+          new SharedNameKey(LineageInfoFactory.KEY_NAME));
+      return Optional.of(lineageInfo);
+    } catch (NotConfiguredException e) {
+      log.warn("Fail to get LineageInfo instance from broker. Will not track data lineage", e);
+      return Optional.absent();
+    }
+  }
+
   /**
    * Get the configured {@link DatasetResolver} from {@link State}
    */
-  public static DatasetResolver getResolver(State state) {
-    String resolverFactory = state.getProp(DatasetResolverFactory.CLASS);
-    if (resolverFactory == null) {
+  private static DatasetResolver getResolver(Config config) {
+    String resolverFactory = config.getString(DATASET_RESOLVER_FACTORY);
+    if (resolverFactory.equals(NoopDatasetResolver.FACTORY)) {
       return NoopDatasetResolver.INSTANCE;
     }
 
     DatasetResolver resolver = NoopDatasetResolver.INSTANCE;
     try {
       DatasetResolverFactory factory = (DatasetResolverFactory) Class.forName(resolverFactory).newInstance();
-      resolver = factory.createResolver(state);
+      resolver = factory.createResolver(config);
     } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
       log.error(String.format("Fail to create a DatasetResolver with factory class %s", resolverFactory));
     }

--- a/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/source/extractor/extract/jdbc/MysqlSource.java
+++ b/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/source/extractor/extract/jdbc/MysqlSource.java
@@ -65,6 +65,8 @@ public class MysqlSource extends QueryBasedSource<JsonArray, JsonElement> {
     DatasetDescriptor source =
         new DatasetDescriptor(DatasetConstants.PLATFORM_MYSQL, database + "." + entity.getSourceEntityName());
     source.addMetadata(DatasetConstants.CONNECTION_URL, connectionUrl);
-    LineageInfo.setSource(source, workUnit);
+    if (lineageInfo.isPresent()) {
+      lineageInfo.get().setSource(source, workUnit);
+    }
   }
 }

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/JobContext.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/JobContext.java
@@ -45,6 +45,8 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.typesafe.config.Config;
 
+import org.apache.gobblin.broker.SharedNameKey;
+import org.apache.gobblin.broker.SimpleScopeType;
 import org.apache.gobblin.broker.gobblin_scopes.GobblinScopeTypes;
 import org.apache.gobblin.broker.gobblin_scopes.JobScopeInstance;
 import org.apache.gobblin.broker.iface.SharedResourcesBroker;
@@ -57,6 +59,8 @@ import org.apache.gobblin.metastore.DatasetStateStore;
 import org.apache.gobblin.metastore.JobHistoryStore;
 import org.apache.gobblin.metastore.MetaStoreModule;
 import org.apache.gobblin.metrics.GobblinMetrics;
+import org.apache.gobblin.metrics.broker.LineageInfoFactory;
+import org.apache.gobblin.metrics.event.lineage.LineageInfo;
 import org.apache.gobblin.publisher.DataPublisher;
 import org.apache.gobblin.runtime.JobState.DatasetState;
 import org.apache.gobblin.runtime.commit.FsCommitSequenceStore;
@@ -152,6 +156,7 @@ public class JobContext implements Closeable {
     this.jobState =
         new JobState(jobPropsState, this.datasetStateStore.getLatestDatasetStatesByUrns(this.jobName), this.jobName,
             this.jobId);
+    this.jobState.setBroker(this.jobBroker);
 
     stagingDirProvided = this.jobState.contains(ConfigurationKeys.WRITER_STAGING_DIR);
     outputDirProvided = this.jobState.contains(ConfigurationKeys.WRITER_OUTPUT_DIR);

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/JobContext.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/JobContext.java
@@ -45,8 +45,6 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.typesafe.config.Config;
 
-import org.apache.gobblin.broker.SharedNameKey;
-import org.apache.gobblin.broker.SimpleScopeType;
 import org.apache.gobblin.broker.gobblin_scopes.GobblinScopeTypes;
 import org.apache.gobblin.broker.gobblin_scopes.JobScopeInstance;
 import org.apache.gobblin.broker.iface.SharedResourcesBroker;
@@ -59,8 +57,6 @@ import org.apache.gobblin.metastore.DatasetStateStore;
 import org.apache.gobblin.metastore.JobHistoryStore;
 import org.apache.gobblin.metastore.MetaStoreModule;
 import org.apache.gobblin.metrics.GobblinMetrics;
-import org.apache.gobblin.metrics.broker.LineageInfoFactory;
-import org.apache.gobblin.metrics.event.lineage.LineageInfo;
 import org.apache.gobblin.publisher.DataPublisher;
 import org.apache.gobblin.runtime.JobState.DatasetState;
 import org.apache.gobblin.runtime.commit.FsCommitSequenceStore;

--- a/gobblin-utility/src/main/java/org/apache/gobblin/broker/EmptyKey.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/broker/EmptyKey.java
@@ -27,6 +27,9 @@ import lombok.EqualsAndHashCode;
  */
 @EqualsAndHashCode
 public final class EmptyKey implements SharedResourceKey {
+  /** A singleton instance */
+  public static final EmptyKey INSTANCE = new EmptyKey();
+
   @Override
   public String toConfigurationKey() {
     return null;


### PR DESCRIPTION
Dear Gobblin maintainers,

### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/GOBBLIN-334


### Description
- [x] Here are some details about my PR:
  - Currently, setting or putting a `DatasetDescriptor` with `LineageInfo` creates a new `DatasetResolver` every time. It's not performant.
  - The `SharedResourceFactory` (`LineageInfoFactory`) creates a single job level `LineageInfo` instance so that one job process creates only one `LineageInfo` object, hence only one `DatasetResolver` object. 

### Tests
- [x] My PR adds the following unit tests:
  - `LineageEventTest`

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

