### PR TITLE
[GOBBLIN-336] Refactor HelixTask to create taskAttempt with a builder

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixTaskFactory.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixTaskFactory.java
@@ -17,28 +17,26 @@
 
 package org.apache.gobblin.cluster;
 
-import com.typesafe.config.Config;
-import org.apache.gobblin.runtime.util.StateStores;
 import java.io.IOException;
 
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-
+import org.apache.helix.HelixManager;
 import org.apache.helix.task.Task;
 import org.apache.helix.task.TaskCallbackContext;
 import org.apache.helix.task.TaskFactory;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.codahale.metrics.Counter;
-
 import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
+import com.typesafe.config.Config;
 
 import org.apache.gobblin.annotation.Alpha;
 import org.apache.gobblin.runtime.TaskExecutor;
 import org.apache.gobblin.runtime.TaskStateTracker;
+import org.apache.gobblin.runtime.util.StateStores;
 
 
 /**
@@ -54,6 +52,7 @@ public class GobblinHelixTaskFactory implements TaskFactory {
   private static final String GOBBLIN_CLUSTER_NEW_HELIX_TASK_COUNTER = "gobblin.cluster.new.helix.task";
 
   private final Optional<ContainerMetrics> containerMetrics;
+  private final HelixManager helixManager;
 
   /**
    * A {@link Counter} to count the number of new {@link GobblinHelixTask}s that are created.
@@ -64,10 +63,12 @@ public class GobblinHelixTaskFactory implements TaskFactory {
   private final FileSystem fs;
   private final Path appWorkDir;
   private final StateStores stateStores;
+  private final TaskAttemptBuilder taskAttemptBuilder;
 
   public GobblinHelixTaskFactory(Optional<ContainerMetrics> containerMetrics, TaskExecutor taskExecutor,
-      TaskStateTracker taskStateTracker, FileSystem fs, Path appWorkDir, Config config) {
+      TaskStateTracker taskStateTracker, FileSystem fs, Path appWorkDir, Config config, HelixManager helixManager) {
     this.containerMetrics = containerMetrics;
+    this.helixManager = helixManager;
     if (this.containerMetrics.isPresent()) {
       this.newTasksCounter = Optional.of(this.containerMetrics.get().getCounter(GOBBLIN_CLUSTER_NEW_HELIX_TASK_COUNTER));
     } else {
@@ -79,6 +80,15 @@ public class GobblinHelixTaskFactory implements TaskFactory {
     this.appWorkDir = appWorkDir;
     this.stateStores = new StateStores(config, appWorkDir, GobblinClusterConfigurationKeys.OUTPUT_TASK_STATE_DIR_NAME,
         appWorkDir, GobblinClusterConfigurationKeys.INPUT_WORK_UNIT_DIR_NAME);
+    this.taskAttemptBuilder = createTaskAttemptBuilder();
+  }
+
+  private TaskAttemptBuilder createTaskAttemptBuilder() {
+    TaskAttemptBuilder builder = new TaskAttemptBuilder(this.taskStateTracker, this.taskExecutor);
+    builder.setContainerId(this.helixManager.getInstanceName());
+    builder.setTaskStateStore(this.stateStores.taskStateStore);
+
+    return builder;
   }
 
   @Override
@@ -87,8 +97,7 @@ public class GobblinHelixTaskFactory implements TaskFactory {
       if (this.newTasksCounter.isPresent()) {
         this.newTasksCounter.get().inc();
       }
-      return new GobblinHelixTask(context, this.containerMetrics, this.taskExecutor, this.taskStateTracker,
-          this.fs, this.appWorkDir, stateStores);
+      return new GobblinHelixTask(context, this.fs, this.appWorkDir, this.taskAttemptBuilder, this.stateStores);
     } catch (IOException ioe) {
       LOGGER.error("Failed to create a new GobblinHelixTask", ioe);
       throw Throwables.propagate(ioe);

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinTaskRunner.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinTaskRunner.java
@@ -178,7 +178,7 @@ public class GobblinTaskRunner {
     Map<String, TaskFactory> taskFactoryMap = Maps.newHashMap();
     taskFactoryMap.put(GOBBLIN_TASK_FACTORY_NAME,
         new GobblinHelixTaskFactory(this.containerMetrics, taskExecutor, taskStateTracker, this.fs, appWorkDir,
-            stateStoreJobConfig));
+            stateStoreJobConfig, this.helixManager));
     this.taskStateModelFactory = new TaskStateModelFactory(this.helixManager, taskFactoryMap);
     this.helixManager.getStateMachineEngine().registerStateModelFactory("Task", this.taskStateModelFactory);
   }

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/TaskAttemptBuilder.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/TaskAttemptBuilder.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.cluster;
+
+import java.util.Iterator;
+
+import com.google.common.base.Optional;
+
+import org.apache.gobblin.broker.gobblin_scopes.GobblinScopeTypes;
+import org.apache.gobblin.broker.iface.SharedResourcesBroker;
+import org.apache.gobblin.metastore.StateStore;
+import org.apache.gobblin.runtime.GobblinMultiTaskAttempt;
+import org.apache.gobblin.runtime.JobState;
+import org.apache.gobblin.runtime.TaskExecutor;
+import org.apache.gobblin.runtime.TaskState;
+import org.apache.gobblin.runtime.TaskStateTracker;
+import org.apache.gobblin.source.workunit.WorkUnit;
+
+
+public class TaskAttemptBuilder {
+  private final TaskStateTracker _taskStateTracker;
+  private final TaskExecutor _taskExecutor;
+  private String _containerId;
+  private StateStore<TaskState> _taskStateStore;
+
+  public TaskAttemptBuilder(TaskStateTracker taskStateTracker, TaskExecutor taskExecutor) {
+    _taskStateTracker = taskStateTracker;
+    _taskExecutor = taskExecutor;
+  }
+
+  public TaskAttemptBuilder setContainerId(String containerId) {
+    _containerId = containerId;
+    return this;
+  }
+
+  public TaskAttemptBuilder setTaskStateStore(StateStore<TaskState> taskStateStore) {
+    _taskStateStore = taskStateStore;
+    return this;
+  }
+
+  public GobblinMultiTaskAttempt build(Iterator<WorkUnit> workUnits, String jobId, JobState jobState,
+      SharedResourcesBroker<GobblinScopeTypes> jobBroker) {
+    GobblinMultiTaskAttempt attemptInstance =
+        new GobblinMultiTaskAttempt(workUnits, jobId, jobState, _taskStateTracker, _taskExecutor,
+            Optional.fromNullable(_containerId), Optional.fromNullable(_taskStateStore), jobBroker);
+
+    return attemptInstance;
+  }
+}

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinHelixTaskTest.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinHelixTaskTest.java
@@ -146,7 +146,7 @@ public class GobblinHelixTaskTest {
 
     GobblinHelixTaskFactory gobblinHelixTaskFactory =
         new GobblinHelixTaskFactory(Optional.<ContainerMetrics>absent(), this.taskExecutor, this.taskStateTracker,
-            this.localFs, this.appWorkDir, ConfigFactory.empty());
+            this.localFs, this.appWorkDir, ConfigFactory.empty(), this.helixManager);
     this.gobblinHelixTask = (GobblinHelixTask) gobblinHelixTaskFactory.createNewTask(taskCallbackContext);
   }
 


### PR DESCRIPTION
This allows the task attempt logic to be mocked out in unit tests in the
future.

Testing:

The integration test org.apache.gobblin.cluster.ClusterIntegrationTest
passed.