### PR TITLE
[GOBBLIN-338] Adding setting to being able specify hive registration fs which is us…

### DIFF
--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/avro/HiveAvroSerDeManager.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/avro/HiveAvroSerDeManager.java
@@ -17,25 +17,28 @@
 
 package org.apache.gobblin.hive.avro;
 
-import com.codahale.metrics.Timer;
-import org.apache.gobblin.instrumented.Instrumented;
-import org.apache.gobblin.metrics.MetricContext;
 import java.io.IOException;
+import java.net.URI;
 
 import org.apache.avro.Schema;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
+import com.codahale.metrics.Timer;
 import com.google.common.base.Preconditions;
+
+import lombok.extern.slf4j.Slf4j;
 
 import org.apache.gobblin.annotation.Alpha;
 import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.hive.HiveRegistrationUnit;
 import org.apache.gobblin.hive.HiveSerDeManager;
 import org.apache.gobblin.hive.HiveSerDeWrapper;
+import org.apache.gobblin.hive.policy.HiveRegistrationPolicyBase;
+import org.apache.gobblin.instrumented.Instrumented;
+import org.apache.gobblin.metrics.MetricContext;
 import org.apache.gobblin.util.AvroUtils;
 import org.apache.gobblin.util.HadoopUtils;
-import lombok.extern.slf4j.Slf4j;
 
 
 /**
@@ -68,7 +71,13 @@ public class HiveAvroSerDeManager extends HiveSerDeManager {
 
   public HiveAvroSerDeManager(State props) throws IOException {
     super(props);
-    this.fs = FileSystem.get(HadoopUtils.getConfFromState(props));
+
+    if (props.contains(HiveRegistrationPolicyBase.HIVE_FS_URI)) {
+      this.fs = FileSystem.get(URI.create(props.getProp(HiveRegistrationPolicyBase.HIVE_FS_URI)), HadoopUtils.getConfFromState(props));
+    } else {
+      this.fs = FileSystem.get(HadoopUtils.getConfFromState(props));
+    }
+
     this.useSchemaFile = props.getPropAsBoolean(USE_SCHEMA_FILE, DEFAULT_USE_SCHEMA_FILE);
     this.schemaFileName = props.getProp(SCHEMA_FILE_NAME, DEFAULT_SCHEMA_FILE_NAME);
     this.schemaLiteralLengthLimit =


### PR DESCRIPTION
Get the fs  from the specified path in HiveAvroManager which is useful if you want to register data on other fs like s3 otherwise it will faile due to the following precondition: https://github.com/apache/incubator-gobblin/blob/5457af88d56b8fb89b172129fd1ff24ecdd4eba8/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/avro/HiveAvroSerDeManager.java#L124

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-338

### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

