### PR TITLE
[GOBBLIN-342] Introduce option to set hive metastore uri in Hiveregister

### DIFF
--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/HiveRegister.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/HiveRegister.java
@@ -66,6 +66,7 @@ public abstract class HiveRegister implements Closeable {
   public static final String DEFAULT_HIVE_TABLE_COMPARATOR_TYPE = HiveTableComparator.class.getName();
   public static final String HIVE_PARTITION_COMPARATOR_TYPE = "hive.partition.comparator.type";
   public static final String DEFAULT_HIVE_PARTITION_COMPARATOR_TYPE = HivePartitionComparator.class.getName();
+  public static final String HIVE_METASTORE_URI_KEY = "hive.metastore.uri";
 
   protected static final String HIVE_DB_EXTENSION = ".db";
 
@@ -353,7 +354,10 @@ public abstract class HiveRegister implements Closeable {
    * will be returned. This {@link State} object is also used to instantiate the {@link HiveRegister} object.
    */
   public static HiveRegister get(State props) {
-    return get(props, Optional.<String> absent());
+    Optional<String> metastoreUri =
+        Optional.fromNullable(props.getProperties().getProperty(HIVE_METASTORE_URI_KEY));
+
+    return get(props, metastoreUri);
   }
 
   /**


### PR DESCRIPTION
Introduce option to set hive metastore uri in Hiveregister

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-342

### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

