### PR TITLE
[GOBBLIN-344] Fix help method getResolver in LineageInfo is private

### DIFF
--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/lineage/LineageInfo.java
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/lineage/LineageInfo.java
@@ -236,7 +236,7 @@ public final class LineageInfo {
   /**
    * Get the configured {@link DatasetResolver} from {@link State}
    */
-  private static DatasetResolver getResolver(Config config) {
+  public static DatasetResolver getResolver(Config config) {
     String resolverFactory = config.getString(DATASET_RESOLVER_FACTORY);
     if (resolverFactory.equals(NoopDatasetResolver.FACTORY)) {
       return NoopDatasetResolver.INSTANCE;


### PR DESCRIPTION
Dear Gobblin maintainers,

### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. 
    - https://issues.apache.org/jira/browse/GOBBLIN-344


### Description
- [x] Here are some details about my PR:
  - In the PR https://github.com/apache/incubator-gobblin/pull/2187, I mistakenly made help method `LineageInfo#getResolver` private. It should be `public`.


### Tests
- [x] My PR does not need testing for this extremely good reason:
  - No logic change at all


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

