### PR TITLE
[GOBBLIN-336] Set unused Helix task result info field to an empty string

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixTask.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixTask.java
@@ -101,8 +101,8 @@ public class GobblinHelixTask implements Task {
     try (Closer closer = Closer.create()) {
       closer.register(MDC.putCloseable(ConfigurationKeys.JOB_NAME_KEY, this.jobName));
       closer.register(MDC.putCloseable(ConfigurationKeys.JOB_KEY_KEY, this.jobKey));
-      int workUnitSize = this.task.run();
-      return new TaskResult(TaskResult.Status.COMPLETED, String.format("completed tasks: %d", workUnitSize));
+      this.task.run();
+      return new TaskResult(TaskResult.Status.COMPLETED, "");
     } catch (InterruptedException ie) {
       Thread.currentThread().interrupt();
       return new TaskResult(TaskResult.Status.CANCELED, "");

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SingleHelixTask.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SingleHelixTask.java
@@ -66,16 +66,9 @@ public class SingleHelixTask {
     _stateStores = stateStores;
   }
 
-  /**
-   *
-   * @return the number of work-units processed
-   * @throws IOException
-   * @throws InterruptedException
-   */
-  public int run()
+  public void run()
       throws IOException, InterruptedException {
     List<WorkUnit> workUnits = getWorkUnits();
-    int workUnitSize = workUnits.size();
 
     JobState jobState = getJobState();
     Config jobConfig = getConfigFromJobState(jobState);
@@ -86,7 +79,6 @@ public class SingleHelixTask {
 
       _taskattempt = _taskAttemptBuilder.build(workUnits.iterator(), _jobId, jobState, jobBroker);
       _taskattempt.runAndOptionallyCommitTaskAttempt(GobblinMultiTaskAttempt.CommitPolicy.IMMEDIATE);
-      return workUnitSize;
     }
   }
 


### PR DESCRIPTION
This field is not used.
This change removes the need for the child task process to send the
workunit count back to the control process.