### PR TITLE
[Gobblin-347] Ensure KafkaPusher is registered with the closer

### DIFF
--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/metrics/kafka/KafkaEventReporter.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/metrics/kafka/KafkaEventReporter.java
@@ -54,6 +54,7 @@ public class KafkaEventReporter extends EventReporter {
         String pusherClassName = builder.pusherClassName.or(PusherUtils.DEFAULT_KAFKA_PUSHER_CLASS_NAME);
         this.kafkaPusher = PusherUtils.getPusher(pusherClassName, builder.brokers, builder.topic, builder.config);
     }
+    this.closer.register(this.kafkaPusher);
   }
 
   @Override

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/metrics/kafka/KafkaReporter.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/metrics/kafka/KafkaReporter.java
@@ -80,6 +80,7 @@ public class KafkaReporter extends MetricReportReporter {
 
       this.kafkaPusher = PusherUtils.getPusher(pusherClassName, builder.brokers, builder.topic, Optional.of(kafkaConfig));
     }
+    this.closer.register(this.kafkaPusher);
   }
 
   protected AvroSerializer<MetricReport> createSerializer(SchemaVersionWriter schemaVersionWriter) throws IOException {


### PR DESCRIPTION
KafkaPusher is not closed when GobblinMetrics.stopReporting() is called, resulting in queued messages not getting sent.

This change registers KafkaPusher with the closer, so it can get closed appropriately.