### PR TITLE
[GOBBLIN-336] move single task runner option constants to the option class

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
@@ -79,12 +79,4 @@ public class GobblinClusterConfigurationKeys {
 
   public static final String STOP_TIMEOUT_SECONDS = GOBBLIN_CLUSTER_PREFIX + "stopTimeoutSeconds";
   public static final long DEFAULT_STOP_TIMEOUT_SECONDS = 60;
-
-  // Arguments to the single task runner process
-  public static class SingleTaskRunnerCmdOption {
-    public static final String JOB_ID = "job_id";
-    public static final String WORK_UNIT_FILE_PATH = "work_unit_file_path";
-    public static final String JOB_STATE_FILE_PATH = "job_state_file_path";
-    public static final String CLUSTER_CONFIG_FILE_PATH = "cluster_config_file_path";
-  }
 }

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SingleTaskRunnerMainOptions.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SingleTaskRunnerMainOptions.java
@@ -31,13 +31,12 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableMap;
 
-import static org.apache.gobblin.cluster.GobblinClusterConfigurationKeys.SingleTaskRunnerCmdOption.CLUSTER_CONFIG_FILE_PATH;
-import static org.apache.gobblin.cluster.GobblinClusterConfigurationKeys.SingleTaskRunnerCmdOption.JOB_ID;
-import static org.apache.gobblin.cluster.GobblinClusterConfigurationKeys.SingleTaskRunnerCmdOption.WORK_UNIT_FILE_PATH;
-
 
 class SingleTaskRunnerMainOptions {
   private static final Logger logger = LoggerFactory.getLogger(SingleTaskRunnerMainOptions.class);
+  static final String CLUSTER_CONFIG_FILE_PATH = "cluster_config_file_path";
+  static final String WORK_UNIT_FILE_PATH = "work_unit_file_path";
+  static final String JOB_ID = "job_id";
   private static final ImmutableMap<String, String> OPTIONS_MAP = ImmutableMap
       .of(JOB_ID, "job id", WORK_UNIT_FILE_PATH, "work unit file path", CLUSTER_CONFIG_FILE_PATH,
           "cluster configuration file path");


### PR DESCRIPTION
This will improve class coherency.

Also removed an unused constant.