### PR TITLE
[GOBBLIN-336] Rename SingleHelixTask to SingleTask

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixTask.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixTask.java
@@ -69,7 +69,7 @@ public class GobblinHelixTask implements Task {
   private String jobKey;
   private Path workUnitFilePath;
 
-  private SingleHelixTask task;
+  private SingleTask task;
 
   public GobblinHelixTask(TaskCallbackContext taskCallbackContext, FileSystem fs, Path appWorkDir,
       TaskAttemptBuilder taskAttemptBuilder, StateStores stateStores)
@@ -81,7 +81,8 @@ public class GobblinHelixTask implements Task {
     Path jobStateFilePath = constructJobStateFilePath(appWorkDir);
 
     this.task =
-        new SingleHelixTask(this.jobId, workUnitFilePath, jobStateFilePath, fs, taskAttemptBuilder, stateStores);
+        new SingleTask(this.jobId, workUnitFilePath, jobStateFilePath, fs, taskAttemptBuilder,
+            stateStores);
   }
 
   private Path constructJobStateFilePath(Path appWorkDir) {
@@ -93,7 +94,8 @@ public class GobblinHelixTask implements Task {
     this.jobName = configMap.get(ConfigurationKeys.JOB_NAME_KEY);
     this.jobId = configMap.get(ConfigurationKeys.JOB_ID_KEY);
     this.jobKey = Long.toString(Id.parse(this.jobId).getSequence());
-    this.workUnitFilePath = new Path(configMap.get(GobblinClusterConfigurationKeys.WORK_UNIT_FILE_PATH));
+    this.workUnitFilePath =
+        new Path(configMap.get(GobblinClusterConfigurationKeys.WORK_UNIT_FILE_PATH));
   }
 
   @Override

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SingleTask.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SingleTask.java
@@ -44,9 +44,9 @@ import org.apache.gobblin.util.JobLauncherUtils;
 import org.apache.gobblin.util.SerializationUtils;
 
 
-public class SingleHelixTask {
+public class SingleTask {
 
-  private static final Logger _logger = LoggerFactory.getLogger(SingleHelixTask.class);
+  private static final Logger _logger = LoggerFactory.getLogger(SingleTask.class);
 
   private GobblinMultiTaskAttempt _taskattempt;
   private String _jobId;
@@ -56,7 +56,7 @@ public class SingleHelixTask {
   private TaskAttemptBuilder _taskAttemptBuilder;
   private StateStores _stateStores;
 
-  SingleHelixTask(String jobId, Path workUnitFilePath, Path jobStateFilePath, FileSystem fs,
+  SingleTask(String jobId, Path workUnitFilePath, Path jobStateFilePath, FileSystem fs,
       TaskAttemptBuilder taskAttemptBuilder, StateStores stateStores) {
     _jobId = jobId;
     _workUnitFilePath = workUnitFilePath;

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SingleTaskRunner.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SingleTaskRunner.java
@@ -54,7 +54,7 @@ class SingleTaskRunner {
   private final String workUnitFilePath;
   private final Config clusterConfig;
   private final Path appWorkPath;
-  private SingleHelixTask task;
+  private SingleTask task;
   private TaskExecutor taskExecutor;
   private GobblinHelixTaskStateTracker taskStateTracker;
   private ServiceManager serviceManager;
@@ -114,9 +114,8 @@ class SingleTaskRunner {
 
     final TaskAttemptBuilder taskAttemptBuilder = getTaskAttemptBuilder(stateStores);
 
-    this.task =
-        new SingleHelixTask(this.jobId, new Path(this.workUnitFilePath), jobStateFilePath, fs,
-            taskAttemptBuilder, stateStores);
+    this.task = new SingleTask(this.jobId, new Path(this.workUnitFilePath), jobStateFilePath, fs,
+        taskAttemptBuilder, stateStores);
   }
 
   private TaskAttemptBuilder getTaskAttemptBuilder(final StateStores stateStores) {


### PR DESCRIPTION
The class has no reference to Helix. It's used in the child process.

Plan to create a new class named SingleHelixTask in the next PR
to represent the Helix task instance.

Testing:

Integration tests passed.