### PR TITLE
[GOBBLIN-336] Add a new SingleHelixTask class

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SingleHelixTask.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SingleHelixTask.java
@@ -65,9 +65,6 @@ public class SingleHelixTask implements Task {
       } else {
         return new TaskResult(TaskResult.Status.FAILED, "Exit code: " + exitCode);
       }
-    } catch (final InterruptedException ie) {
-      logger.warn("SingleHelixTask interrupted", ie);
-      return new TaskResult(TaskResult.Status.CANCELED, "");
     } catch (final Throwable t) {
       logger.error("SingleHelixTask failed due to " + t.getMessage(), t);
       return new TaskResult(TaskResult.Status.FAILED, Throwables.getStackTraceAsString(t));

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SingleHelixTask.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SingleHelixTask.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.cluster;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+
+import org.apache.helix.task.Task;
+import org.apache.helix.task.TaskResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Throwables;
+
+import org.apache.gobblin.configuration.ConfigurationKeys;
+
+
+public class SingleHelixTask implements Task {
+
+  private static final Logger logger = LoggerFactory.getLogger(SingleHelixTask.class);
+
+  private final String jobId;
+  private final String jobName;
+
+  private final Process taskProcess;
+
+  SingleHelixTask(final SingleTaskLauncher launcher, final Map<String, String> configMap)
+      throws IOException {
+    this.jobName = configMap.get(ConfigurationKeys.JOB_NAME_KEY);
+    this.jobId = configMap.get(ConfigurationKeys.JOB_ID_KEY);
+    final Path workUnitFilePath =
+        Paths.get(configMap.get(GobblinClusterConfigurationKeys.WORK_UNIT_FILE_PATH));
+    logger.info(String
+        .format("Launching a single task process. job name: %s. job id: %s", this.jobName,
+            this.jobId));
+    this.taskProcess = launcher.launch(this.jobId, workUnitFilePath);
+  }
+
+  @Override
+  public TaskResult run() {
+    try {
+      logger.info(String
+          .format("Waiting for a single task process to finish. job name: %s. job id: %s",
+              this.jobName, this.jobId));
+      this.taskProcess.waitFor();
+      return new TaskResult(TaskResult.Status.COMPLETED, "");
+    } catch (final InterruptedException ie) {
+      Thread.currentThread().interrupt();
+      return new TaskResult(TaskResult.Status.CANCELED, "");
+    } catch (final Throwable t) {
+      logger.error("SingleHelixTask failed due to " + t.getMessage(), t);
+      return new TaskResult(TaskResult.Status.FAILED, Throwables.getStackTraceAsString(t));
+    }
+  }
+
+  @Override
+  public void cancel() {
+    logger.info(String
+        .format("Canceling a single task process. job name: %s. job id: %s", this.jobName,
+            this.jobId));
+    this.taskProcess.destroyForcibly();
+  }
+}

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SingleHelixTask.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SingleHelixTask.java
@@ -59,8 +59,12 @@ public class SingleHelixTask implements Task {
       logger.info(String
           .format("Waiting for a single task process to finish. job name: %s. job id: %s",
               this.jobName, this.jobId));
-      this.taskProcess.waitFor();
-      return new TaskResult(TaskResult.Status.COMPLETED, "");
+      int exitCode = this.taskProcess.waitFor();
+      if (exitCode == 0) {
+        return new TaskResult(TaskResult.Status.COMPLETED, "");
+      } else {
+        return new TaskResult(TaskResult.Status.FAILED, "Exit code: " + exitCode);
+      }
     } catch (final InterruptedException ie) {
       Thread.currentThread().interrupt();
       return new TaskResult(TaskResult.Status.CANCELED, "");

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SingleHelixTask.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SingleHelixTask.java
@@ -66,7 +66,7 @@ public class SingleHelixTask implements Task {
         return new TaskResult(TaskResult.Status.FAILED, "Exit code: " + exitCode);
       }
     } catch (final InterruptedException ie) {
-      Thread.currentThread().interrupt();
+      logger.warn("SingleHelixTask interrupted", ie);
       return new TaskResult(TaskResult.Status.CANCELED, "");
     } catch (final Throwable t) {
       logger.error("SingleHelixTask failed due to " + t.getMessage(), t);

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinClusterManagerTest.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinClusterManagerTest.java
@@ -57,7 +57,7 @@ import org.apache.gobblin.testing.AssertWithBackoff;
  *
  * @author Yinan Li
  */
-@Test(groups = { "disabledOnTravis" })
+@Test(groups = { "gobblin.cluster" })
 public class GobblinClusterManagerTest implements HelixMessageTestBase {
   public final static Logger LOG = LoggerFactory.getLogger(GobblinClusterManagerTest.class);
 

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinClusterManagerTest.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinClusterManagerTest.java
@@ -57,7 +57,7 @@ import org.apache.gobblin.testing.AssertWithBackoff;
  *
  * @author Yinan Li
  */
-@Test(groups = { "gobblin.cluster" })
+@Test(groups = { "disabledOnTravis" })
 public class GobblinClusterManagerTest implements HelixMessageTestBase {
   public final static Logger LOG = LoggerFactory.getLogger(GobblinClusterManagerTest.class);
 

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/SingleHelixTaskTest.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/SingleHelixTaskTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.cluster;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.apache.helix.task.TaskResult;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+public class SingleHelixTaskTest {
+  @Test
+  public void testRun()
+      throws IOException, InterruptedException {
+    final SingleTaskLauncher mockLauncher = mock(SingleTaskLauncher.class);
+    final Process mockProcess = mock(Process.class);
+    when(mockLauncher.launch(any(), any())).thenReturn(mockProcess);
+    final ImmutableMap<String, String> configMap = ImmutableMap
+        .of("job.name", "testJob", "job.id", "1", "gobblin.cluster.work.unit.file.path",
+            "work-unit.wu");
+
+    final SingleHelixTask task = new SingleHelixTask(mockLauncher, configMap);
+    final TaskResult result = task.run();
+
+    assertThat(result.getStatus()).isEqualTo(TaskResult.Status.COMPLETED);
+    final Path expectedPath = Paths.get("work-unit.wu");
+    verify(mockLauncher).launch("1", expectedPath);
+    verify(mockProcess).waitFor();
+  }
+
+  @Test
+  public void interruptedProcessShouldResultInCanceledStatus()
+      throws IOException, InterruptedException {
+    final TaskResult result = createTaskWithException(new InterruptedException());
+
+    assertThat(result.getStatus()).isEqualTo(TaskResult.Status.CANCELED);
+  }
+
+  @Test
+  public void NonInterruptedExceptionShouldResultInFailedStatus()
+      throws IOException, InterruptedException {
+    final TaskResult result = createTaskWithException(new RuntimeException());
+
+    assertThat(result.getStatus()).isEqualTo(TaskResult.Status.FAILED);
+  }
+
+  private TaskResult createTaskWithException(final Exception exceptionToThrow)
+      throws InterruptedException, IOException {
+    final SingleTaskLauncher mockLauncher = mock(SingleTaskLauncher.class);
+    final Process mockProcess = mock(Process.class);
+    when(mockLauncher.launch(any(), any())).thenReturn(mockProcess);
+    when(mockProcess.waitFor()).thenThrow(exceptionToThrow);
+    final ImmutableMap<String, String> configMap =
+        ImmutableMap.of("gobblin.cluster.work.unit.file.path", "work-unit.wu");
+
+    final SingleHelixTask task = new SingleHelixTask(mockLauncher, configMap);
+    return task.run();
+  }
+
+  @Test
+  public void testCancel()
+      throws IOException {
+    final SingleTaskLauncher mockLauncher = mock(SingleTaskLauncher.class);
+    final Process mockProcess = mock(Process.class);
+    when(mockLauncher.launch(any(), any())).thenReturn(mockProcess);
+    final ImmutableMap<String, String> configMap =
+        ImmutableMap.of("gobblin.cluster.work.unit.file.path", "work-unit.wu");
+
+    final SingleHelixTask task = new SingleHelixTask(mockLauncher, configMap);
+    task.cancel();
+    verify(mockProcess).destroyForcibly();
+  }
+}


### PR DESCRIPTION
This class will represent a single Helix task that is used later
when the task process isolation feature is turned on.

Testing:

Added new unit tests.