### PR TITLE
[GOBBLIN-353] Fix low watermark overridden by high watermark in SalesforceSource

### DIFF
--- a/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/SalesforceSource.java
+++ b/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/SalesforceSource.java
@@ -188,16 +188,13 @@ public class SalesforceSource extends QueryBasedSource<JsonArray, JsonElement> {
       throw new RuntimeException("Unexpected empty partition list");
     }
 
-    // If the last group is used as the last partition point
-    if (count == 0) {
-      // Exchange the last partition point with global high watermark
-      partitionPoints.set(partitionPoints.size() - 1, Long.toString(expectedHighWatermark));
-    } else {
+    if (count > 0) {
       // Summarize last group
       statistics.addValue(count);
-      // Add global high watermark as last point
-      partitionPoints.add(Long.toString(expectedHighWatermark));
     }
+
+    // Add global high watermark as last point
+    partitionPoints.add(Long.toString(expectedHighWatermark));
 
     log.info("Dynamic partitioning statistics: ");
     log.info("data: " + Arrays.toString(statistics.getValues()));

--- a/gobblin-salesforce/src/test/java/org/apache/gobblin/salesforce/SalesforceSourceTest.java
+++ b/gobblin-salesforce/src/test/java/org/apache/gobblin/salesforce/SalesforceSourceTest.java
@@ -22,6 +22,20 @@ import org.testng.annotations.Test;
 
 public class SalesforceSourceTest {
   @Test
+  void testGenerateSpecifiedPartitionFromSinglePointHistogram() {
+    SalesforceSource.Histogram histogram = new SalesforceSource.Histogram();
+    histogram.add(new SalesforceSource.HistogramGroup("2014-02-13-00:00:00", 10));
+    SalesforceSource source = new SalesforceSource();
+
+    long expectedHighWatermark = 20170407152123L;
+    long lowWatermark = 20140213000000L;
+    int maxPartitions = 2;
+    String expectedPartitions = "20140213000000,20170407152123";
+    String actualPartitions = source.generateSpecifiedPartitions(histogram, 1, maxPartitions, lowWatermark, expectedHighWatermark);
+    Assert.assertEquals(actualPartitions, expectedPartitions);
+  }
+
+  @Test
   void testGenerateSpecifiedPartition() {
     SalesforceSource.Histogram histogram = new SalesforceSource.Histogram();
     for (String group: HISTOGRAM.split(", ")) {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/GOBBLIN-353


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
  - When the histogram has size 1, `generateSpecifiedPartitions` in SalesforceSource will generate a single point partition list if `interval` is smaller than the total count. And the point in the list, which originally is the low watermark, will be replaced by high watermark.

### Tests
- [x] My PR adds the following unit tests:
  - `SalesforceSourceTest#testGenerateSpecifiedPartitionFromSinglePointHistogram`

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

