### PR TITLE
[GOBBLIN-355] Disable snapshot versioning until downstream fixes

### DIFF
--- a/gradle/scripts/release.gradle
+++ b/gradle/scripts/release.gradle
@@ -25,9 +25,11 @@ project(':') {
 def isRelease = ext.release.toBoolean()
 
 def releaseVersion = project.version
-if (!isRelease) {
-    releaseVersion += "-SNAPSHOT"
-}
+println String.format("Release Version: %s", releaseVersion)
+// GOBBLIN-355 Disable until downstream does not fix
+// if (!isRelease) {
+//     releaseVersion += "-SNAPSHOT"
+// }
 
 // Modify the gradle.properties to indicate whether this is a release.  This results in the
 // source releases generating artifacts without -SNAPSHOT appended to the version when they are


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-355


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Disable snapshot versioning until downstream fixes. It was added during 0.12.0 release

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Yes, built locally on downstream.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

