### PR TITLE
[GOBBLIN-357] Fix logging during Zookeeper connection loss

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobLauncher.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobLauncher.java
@@ -236,10 +236,12 @@ public class GobblinHelixJobLauncher extends AbstractJobLauncher {
       try {
         // #HELIX-0.6.7-WORKAROUND
         // working around helix 0.6.7 job delete issue with custom taskDriver
+        LOGGER.info("Cancelling job {} in Helix", this.jobContext.getJobId());
         GobblinHelixTaskDriver taskDriver = new GobblinHelixTaskDriver(this.helixManager);
         taskDriver.deleteJob(this.helixQueueName, this.jobContext.getJobId());
+        LOGGER.info("Job {} in cancelled Helix", this.jobContext.getJobId());
       } catch (IllegalArgumentException e) {
-        LOGGER.warn(String.format("Failed to cleanup job %s in Helix", this.jobContext.getJobId()), e);
+        LOGGER.warn("Failed to cancel job {} in Helix", this.jobContext.getJobId(), e);
       }
     }
   }

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/locks/ZookeeperBasedJobLock.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/locks/ZookeeperBasedJobLock.java
@@ -187,15 +187,15 @@ public class ZookeeperBasedJobLock implements ListenableJobLock {
               case LOST:
                 log.warn("Lost connection with zookeeper");
                 for (Map.Entry<String, JobLockEventListener> lockEventListener : lockEventListeners.entrySet()) {
-                  log.warn("Informing job %s that lock was lost", lockEventListener.getKey());
+                  log.warn("Informing job {} that lock was lost", lockEventListener.getKey());
                   lockEventListener.getValue().onLost();
                 }
                 break;
               case SUSPENDED:
-                log.warn("Lost connection with zookeeper");
+                log.warn("Suspended connection with zookeeper");
                 for (Map.Entry<String, JobLockEventListener> lockEventListener : lockEventListeners.entrySet()) {
-                  log.warn("Informing job %s that lock was lost", lockEventListener.getKey());
-                    lockEventListener.getValue().onLost();
+                  log.warn("Informing job {} that lock was suspended", lockEventListener.getKey());
+                  lockEventListener.getValue().onLost();
                 }
                 break;
               case CONNECTED:


### PR DESCRIPTION
@abti Feedback?

Fix log messages when the zookeeper connection is lost which were not being formatted correctly.
Add start & end log messages to job cancellation.