### PR TITLE
[GOBBLIN-363] Clean up the job-level subdir in the _taskstate directo…

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobLauncher.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobLauncher.java
@@ -387,6 +387,10 @@ public class GobblinHelixJobLauncher extends AbstractJobLauncher {
   private void cleanupWorkingDirectory() throws IOException {
     LOGGER.info("Deleting persisted work units for job " + this.jobContext.getJobId());
     stateStores.wuStateStore.delete(this.jobContext.getJobId());
+
+    // delete the directory that stores the task state files
+    stateStores.taskStateStore.delete(outputTaskStateDir.getName());
+
     LOGGER.info("Deleting job state file for job " + this.jobContext.getJobId());
     Path jobStateFilePath = new Path(this.appWorkDir, this.jobContext.getJobId() + "." + JOB_STATE_FILE_NAME);
     this.fs.delete(jobStateFilePath, false);

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinHelixJobLauncherTest.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinHelixJobLauncherTest.java
@@ -276,7 +276,7 @@ public class GobblinHelixJobLauncherTest {
     Assert.assertEquals(testListener.getCompletes().get() == 1, true);
   }
 
-  public void testJobContextCleanup() throws Exception {
+  public void testJobCleanup() throws Exception {
     final ConcurrentHashMap<String, Boolean> runningMap = new ConcurrentHashMap<>();
 
     final Properties properties = generateJobProperties(this.baseConfig, "3", "_1504201348473");
@@ -302,6 +302,18 @@ public class GobblinHelixJobLauncherTest {
 
     // job context should have been deleted
     Assert.assertNull(jobContext);
+
+    // check that workunit and taskstate directory for the job are cleaned up
+    final File workunitsDir =
+        new File(this.appWorkDir + File.separator + GobblinClusterConfigurationKeys.INPUT_WORK_UNIT_DIR_NAME
+        + File.separator + jobIdKey);
+
+    final File taskstatesDir =
+        new File(this.appWorkDir + File.separator + GobblinClusterConfigurationKeys.OUTPUT_TASK_STATE_DIR_NAME
+            + File.separator + jobIdKey);
+
+    Assert.assertFalse(workunitsDir.exists());
+    Assert.assertFalse(taskstatesDir.exists());
   }
 
   @AfterClass


### PR DESCRIPTION
…ry in Gobblin Cluster after a job is done

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-363


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
The task state files are removed in the driver after they are deserialized, but the job-level directory such as _taskstates/job_1_1112 is not removed. This results in many empty directories in the _taskstates directory.

This fix removes the job-level subdirectory after the execution of the job.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

