### PR TITLE
Log child process cmd line at the debug level

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SingleTaskLauncher.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SingleTaskLauncher.java
@@ -52,7 +52,10 @@ class SingleTaskLauncher {
       throws IOException {
     final SingleTaskLauncher.CmdBuilder cmdBuilder = this.new CmdBuilder(jobId, workUnitFilePath);
     final List<String> command = cmdBuilder.build();
-    logger.info("Launching a task process. cmd: " + command);
+    logger.info("Launching a task process.");
+
+    // The -cp parameter list can be very long.
+    logger.debug("cmd: " + command);
     final Process taskProcess = this.processBuilder.start(command);
 
     return taskProcess;


### PR DESCRIPTION
Due to the long class path, the log can be long and makes the debug
log less readable.

Testing:
Verified with the integration test with a custom log4j config.