### PR TITLE
[GOBBLIN-364] Exclude JobState from WorkUnit created by PartitionedFileSourceBase

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/filebased/FileBasedSource.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/filebased/FileBasedSource.java
@@ -168,28 +168,27 @@ public abstract class FileBasedSource<S, D> extends AbstractSource<S, D> {
 
       // Distribute the files across the workunits
       for (int fileOffset = 0; fileOffset < filesToPull.size(); fileOffset += filesPerPartition) {
-        SourceState partitionState = new SourceState();
-        partitionState.addAll(state);
+        // Use extract table name to create extract
+        Extract extract = new Extract(tableType, nameSpaceName, extractTableName);
+        WorkUnit workUnit = WorkUnit.create(extract);
 
         // Eventually these setters should be integrated with framework support for generalized watermark handling
-        partitionState.setProp(ConfigurationKeys.SOURCE_FILEBASED_FS_SNAPSHOT,
+        workUnit.setProp(ConfigurationKeys.SOURCE_FILEBASED_FS_SNAPSHOT,
             StringUtils.join(effectiveSnapshot, ","));
 
         List<String> partitionFilesToPull = filesToPull.subList(fileOffset,
             fileOffset + filesPerPartition > filesToPull.size() ? filesToPull.size() : fileOffset + filesPerPartition);
-        partitionState.setProp(ConfigurationKeys.SOURCE_FILEBASED_FILES_TO_PULL,
+        workUnit.setProp(ConfigurationKeys.SOURCE_FILEBASED_FILES_TO_PULL,
             StringUtils.join(partitionFilesToPull, ","));
         if (state.getPropAsBoolean(ConfigurationKeys.SOURCE_FILEBASED_PRESERVE_FILE_NAME, false)) {
           if (partitionFilesToPull.size() != 1) {
             throw new RuntimeException("Cannot preserve the file name if a workunit is given multiple files");
           }
-          partitionState.setProp(ConfigurationKeys.DATA_PUBLISHER_FINAL_DIR,
-              partitionState.getProp(ConfigurationKeys.SOURCE_FILEBASED_FILES_TO_PULL));
+          workUnit.setProp(ConfigurationKeys.DATA_PUBLISHER_FINAL_DIR,
+              workUnit.getProp(ConfigurationKeys.SOURCE_FILEBASED_FILES_TO_PULL));
         }
 
-        // Use extract table name to create extract
-        Extract extract = partitionState.createExtract(tableType, nameSpaceName, extractTableName);
-        workUnits.add(partitionState.createWorkUnit(extract));
+        workUnits.add(workUnit);
       }
 
       log.info("Total number of work units for the current run: " + (workUnits.size() - previousWorkUnitsForRetry.size()));


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/GOBBLIN-364


### Description
- [x] Here are some details about my PR:
  - `PartitionedFileSourceBase` source has a copy of the entire job configurations. For the following 2 reasons, we want to exclude job configurations from `WorkUnit`:
    - It's redundant as the runtime counterpart of `WorkUnit`, which is `WorkUnitState`, would have a reference to all job configurations.
    - Adding job configurations to `WorkUnit` has the bad side effect of masking dynamic job level configurations in MR Task runner

### Tests
- [x] My PR adds the following unit tests:
  - `DatePartitionedAvroFileExtractorTest#testJobStateNotCopiedToWorkUnit`

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

