### PR TITLE
[GOBBLIN-367] Adding mrJob object as a field in MRTask

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/mapreduce/MRTask.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/mapreduce/MRTask.java
@@ -62,6 +62,7 @@ public class MRTask extends BaseAbstractTask {
 
   private final TaskContext taskContext;
   private final EventSubmitter eventSubmitter;
+  protected Job mrJob;
 
   public MRTask(TaskContext taskContext) {
     super(taskContext);
@@ -95,6 +96,7 @@ public class MRTask extends BaseAbstractTask {
       job.submit();
       this.eventSubmitter.submit(Events.MR_JOB_STARTED_EVENT, Events.JOB_URL, job.getTrackingURL());
       job.waitForCompletion(false);
+      this.mrJob = job;
 
       if (job.isSuccessful()) {
         this.eventSubmitter.submit(Events.MR_JOB_SUCCESSFUL, Events.JOB_URL, job.getTrackingURL());


### PR DESCRIPTION
 so that inherited Task could read jobUrl from it.

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-367] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-367


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

