### PR TITLE
[GOBBLIN-374] GobblinMetrics failed to close event reporters

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixTaskDriver.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixTaskDriver.java
@@ -304,14 +304,14 @@ public class GobblinHelixTaskDriver {
         if (currentData != null) {
           // Only update target state for non-completed workflows
           String finishTime = currentData.getSimpleField(WorkflowContext.FINISH_TIME);
-          if (finishTime == null || finishTime.equals(WorkflowContext.UNFINISHED)) {
+          if (finishTime == null || finishTime.equals(String.valueOf(WorkflowContext.UNFINISHED))) {
             currentData.setSimpleField(WorkflowConfig.WorkflowConfigProperty.TargetState.name(),
                 state.name());
           } else {
             LOG.info("TargetState DataUpdater: ignore to update target state " + finishTime);
           }
         } else {
-          LOG.error("TargetState DataUpdater: Fails to update target state " + currentData);
+          LOG.error("TargetState DataUpdater: Fails to update target state ");
         }
         return currentData;
       }

--- a/gobblin-metrics-libs/gobblin-metrics/src/main/java/org/apache/gobblin/metrics/GobblinMetrics.java
+++ b/gobblin-metrics-libs/gobblin-metrics/src/main/java/org/apache/gobblin/metrics/GobblinMetrics.java
@@ -423,19 +423,19 @@ public class GobblinMetrics {
     }
 
     this.metricsReportingStarted = true;
-    LOGGER.info("Metrics reporting has been started: GobblinMetrics {}", this.hashCode());
+    LOGGER.info("Metrics reporting has been started: GobblinMetrics {}", this.toString());
   }
 
   /**
    * Stop metric reporting.
    */
   public void stopMetricsReporting() {
+    LOGGER.info("Metrics reporting will be stopped: GobblinMetrics {}", this.toString());
+
     if (!this.metricsReportingStarted) {
       LOGGER.warn("Metric reporting has not started yet");
       return;
     }
-
-    LOGGER.info("Metrics reporting will be stopped: GobblinMetrics {}", this.hashCode());
 
     // Stop the JMX reporter
     if (this.jmxReporter.isPresent()) {
@@ -461,6 +461,8 @@ public class GobblinMetrics {
     }
 
     this.metricsReportingStarted = false;
+    // Remove from the cache registry
+    GobblinMetrics.remove(id);
     LOGGER.info("Metrics reporting stopped successfully");
   }
 

--- a/gobblin-metrics-libs/gobblin-metrics/src/main/java/org/apache/gobblin/metrics/GobblinMetricsRegistry.java
+++ b/gobblin-metrics-libs/gobblin-metrics/src/main/java/org/apache/gobblin/metrics/GobblinMetricsRegistry.java
@@ -46,7 +46,7 @@ public class GobblinMetricsRegistry {
 
   private static final GobblinMetricsRegistry GLOBAL_INSTANCE = new GobblinMetricsRegistry();
 
-  private final Cache<String, GobblinMetrics> metricsCache = CacheBuilder.newBuilder().softValues().build();
+  private final Cache<String, GobblinMetrics> metricsCache = CacheBuilder.newBuilder().build();
 
   private GobblinMetricsRegistry() {
     // Do nothing

--- a/gobblin-metrics-libs/gobblin-metrics/src/test/java/org/apache/gobblin/metrics/GobblinMetricsTest.java
+++ b/gobblin-metrics-libs/gobblin-metrics/src/test/java/org/apache/gobblin/metrics/GobblinMetricsTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.metrics;
+
+import java.util.Properties;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+@Test
+public class GobblinMetricsTest {
+
+  /**
+   * Test the {@link GobblinMetrics} instance is removed from {@link GobblinMetricsRegistry} when
+   * it stops metrics reporting
+   */
+  public void testStopReportingMetrics() {
+    String id = getClass().getSimpleName() + "-" + System.currentTimeMillis();
+    GobblinMetrics gobblinMetrics = GobblinMetrics.get(id);
+    gobblinMetrics.startMetricReporting(new Properties());
+    Assert.assertEquals(GobblinMetricsRegistry.getInstance().get(id).get(), gobblinMetrics);
+
+    gobblinMetrics.stopMetricsReporting();
+    Assert.assertFalse(GobblinMetricsRegistry.getInstance().get(id).isPresent());
+  }
+}


### PR DESCRIPTION
Dear Gobblin maintainers,

### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/GOBBLIN-374


### Description
- [x] Here are some details about my PR:
  - A GobblinMetrics instance is cached as a soft value, which can be GC'ed inadvertently without knowing that it is required to close the event reporters when job completes. 
  - The fix here is to cache as a strong reference and explicitly remove from the cache after stopping events reports

### Tests
- [x] My PR adds the following unit tests:
  - `GobblinMetrics#testStopReportingMetrics`

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

