### PR TITLE
Log job child process exit status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,5 @@ package-lock.json
 
 # generated config files by tests
 **/generated-gobblin-cluster.conf
+
+temp/

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SingleHelixTask.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SingleHelixTask.java
@@ -61,8 +61,13 @@ public class SingleHelixTask implements Task {
               this.jobName, this.jobId));
       int exitCode = this.taskProcess.waitFor();
       if (exitCode == 0) {
+        logger.info(String
+            .format("Task process finished. job name: %s. job id: %s", this.jobName, this.jobId));
         return new TaskResult(TaskResult.Status.COMPLETED, "");
       } else {
+        logger.warn(String
+            .format("Task process failed with exitcode (%d). job name: %s. job id: %s", exitCode,
+                this.jobName, this.jobId));
         return new TaskResult(TaskResult.Status.FAILED, "Exit code: " + exitCode);
       }
     } catch (final Throwable t) {

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SingleHelixTask.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SingleHelixTask.java
@@ -61,13 +61,11 @@ public class SingleHelixTask implements Task {
               this.jobName, this.jobId));
       int exitCode = this.taskProcess.waitFor();
       if (exitCode == 0) {
-        logger.info(String
-            .format("Task process finished. job name: %s. job id: %s", this.jobName, this.jobId));
+        logger.info("Task process finished. job name: {}. job id: {}", this.jobName, this.jobId);
         return new TaskResult(TaskResult.Status.COMPLETED, "");
       } else {
-        logger.warn(String
-            .format("Task process failed with exitcode (%d). job name: %s. job id: %s", exitCode,
-                this.jobName, this.jobId));
+        logger.warn("Task process failed with exitcode ({}). job name: {}. job id: {}", exitCode,
+            this.jobName, this.jobId);
         return new TaskResult(TaskResult.Status.FAILED, "Exit code: " + exitCode);
       }
     } catch (final Throwable t) {

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SingleTaskLauncher.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SingleTaskLauncher.java
@@ -55,9 +55,8 @@ class SingleTaskLauncher {
     logger.info("Launching a task process.");
 
     // The -cp parameter list can be very long.
-    logger.debug("cmd: " + command);
     final String completeCmdLine = String.join(" ", command);
-    logger.debug("cmd line: \n" + completeCmdLine);
+    logger.debug("cmd line:\n{}", completeCmdLine);
 
     final Process taskProcess = this.processBuilder.start(command);
 

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SingleTaskLauncher.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SingleTaskLauncher.java
@@ -56,6 +56,9 @@ class SingleTaskLauncher {
 
     // The -cp parameter list can be very long.
     logger.debug("cmd: " + command);
+    final String completeCmdLine = String.join(" ", command);
+    logger.debug("cmd line: \n" + completeCmdLine);
+
     final Process taskProcess = this.processBuilder.start(command);
 
     return taskProcess;


### PR DESCRIPTION
Also

- log the cmd line in one line for the child process.

- ignore temp directory under the project root.

Testing:

Manually checked the log messages in the log of an integration test.
