### PR TITLE
Don't start services if non is needed

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinTaskRunner.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinTaskRunner.java
@@ -164,7 +164,11 @@ public class GobblinTaskRunner {
     this.taskStateModelFactory = registerHelixTaskFactory();
 
     services.addAll(getServices());
-    this.serviceManager = new ServiceManager(services);
+    if (services.isEmpty()) {
+      this.serviceManager = null;
+    } else {
+      this.serviceManager = new ServiceManager(services);
+    }
 
     logger.debug("GobblinTaskRunner: applicationName {}, helixInstanceName {}, applicationId {}, taskRunnerId {}, config {}, appWorkDir {}",
         applicationName, helixInstanceName, applicationId, taskRunnerId, config, appWorkDirOptional);
@@ -263,8 +267,10 @@ public class GobblinTaskRunner {
               this.taskRunnerId);
     }
 
-    this.serviceManager.startAsync();
-    this.serviceManager.awaitStopped();
+    if (this.serviceManager != null) {
+      this.serviceManager.startAsync();
+      this.serviceManager.awaitStopped();
+    }
   }
 
   public synchronized void stop() {
@@ -282,10 +288,7 @@ public class GobblinTaskRunner {
     }
 
     try {
-      // Give the services 5 minutes to stop to ensure that we are responsive to shutdown requests
-      this.serviceManager.stopAsync().awaitStopped(5, TimeUnit.MINUTES);
-    } catch (TimeoutException te) {
-      logger.error("Timeout in stopping the service manager", te);
+      stopServices();
     } finally {
       this.taskStateModelFactory.shutdown();
 
@@ -293,6 +296,17 @@ public class GobblinTaskRunner {
     }
 
     this.isStopped = true;
+  }
+
+  private void stopServices() {
+    if (this.serviceManager != null) {
+      try {
+        // Give the services 5 minutes to stop to ensure that we are responsive to shutdown requests
+        this.serviceManager.stopAsync().awaitStopped(5, TimeUnit.MINUTES);
+      } catch (TimeoutException te) {
+        logger.error("Timeout in stopping the service manager", te);
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
When process isolation feature is enabled, there may be no services
required to start in the worker process.

In this case, we will get a waring as below:

"Jan 23, 2018 10:43:50 AM com.google.common.util.concurrent.ServiceManager <init>
 WARNING: ServiceManager configured with no services.  Is your application configured properly?
 com.google.common.util.concurrent.ServiceManager$EmptyServiceManagerWarning
 	at com.google.common.util.concurrent.ServiceManager.<init>(ServiceManager.java:168)
 	at org.apache.gobblin.cluster.GobblinTaskRunner.<init>(GobblinTaskRunner.java:167)
 	at org.apache.gobblin.cluster.ClusterIntegrationTest.startWorker(ClusterIntegrationTest.java:196)
 	at org.apache.gobblin.cluster.ClusterIntegrationTest.startCluster(ClusterIntegrationTest.java:189)
 	at org.apache.gobblin.cluster.ClusterIntegrationTest.runSimpleJobAndVerifyResult(ClusterIntegrationTest.java:93)
 	at org.apache.gobblin.cluster.ClusterIntegrationTest.simpleJobShouldCompleteInTaskIsolationMode(ClusterIntegrationTest.java:87)
 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)

"

Fix:
Don't use the serviceManager member if no service is needed.

Testing:
Ran with the basic integration test and verified the warning is gone in
the log.