### PR TITLE
GOBBLIN-381: Add ability to filter hidden directories for ConfigBasedDatasets

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/replication/ConfigBasedDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/replication/ConfigBasedDataset.java
@@ -29,8 +29,6 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathFilter;
 
-import com.google.common.base.Predicate;
-import com.google.common.collect.Collections2;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/replication/HadoopFsEndPoint.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/replication/HadoopFsEndPoint.java
@@ -34,8 +34,9 @@ import org.apache.hadoop.fs.PathFilter;
 
 
 @Slf4j
-@Getter @Setter
-public abstract class HadoopFsEndPoint implements EndPoint{
+@Getter
+@Setter
+public abstract class HadoopFsEndPoint implements EndPoint {
   private PathFilter pathFilter;
   private boolean applyFilterToDirectories;
 
@@ -63,7 +64,7 @@ public abstract class HadoopFsEndPoint implements EndPoint{
    * @param path The path to be checked. For fs availability checking, just use "/"
    * @return If the filesystem/path exists or not.
    */
-  public boolean isPathAvailable(Path path){
+  public boolean isPathAvailable(Path path) {
     try {
       Configuration conf = HadoopUtils.newConfiguration();
       FileSystem fs = FileSystem.get(this.getFsURI(), conf);
@@ -87,5 +88,4 @@ public abstract class HadoopFsEndPoint implements EndPoint{
   public boolean isDatasetAvailable(Path datasetPath) {
     return isPathAvailable(datasetPath);
   }
-
 }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/replication/HadoopFsEndPoint.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/replication/HadoopFsEndPoint.java
@@ -20,6 +20,8 @@ package org.apache.gobblin.data.management.copy.replication;
 import java.io.IOException;
 import java.net.URI;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -28,9 +30,14 @@ import com.typesafe.config.Config;
 
 import org.apache.gobblin.util.HadoopUtils;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.hadoop.fs.PathFilter;
+
 
 @Slf4j
+@Getter @Setter
 public abstract class HadoopFsEndPoint implements EndPoint{
+  private PathFilter pathFilter;
+  private boolean applyFilterToDirectories;
 
   /**
    *
@@ -80,4 +87,5 @@ public abstract class HadoopFsEndPoint implements EndPoint{
   public boolean isDatasetAvailable(Path datasetPath) {
     return isPathAvailable(datasetPath);
   }
+
 }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/replication/ReplicaHadoopFsEndPoint.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/replication/ReplicaHadoopFsEndPoint.java
@@ -73,8 +73,7 @@ public class ReplicaHadoopFsEndPoint extends HadoopFsEndPoint {
   }
 
   @Override
-  public synchronized Collection<FileStatus> getFiles()
-      throws IOException {
+  public synchronized Collection<FileStatus> getFiles() throws IOException {
     if (filesInitialized) {
       return this.allFileStatus;
     }
@@ -90,7 +89,8 @@ public class ReplicaHadoopFsEndPoint extends HadoopFsEndPoint {
     //ReplicationDataValidPathPicker.getValidPaths(fs, this.rc.getPath(), this.rdc);
 
     for (Path p : validPaths) {
-      this.allFileStatus.addAll(FileListUtils.listFilesRecursively(fs, p, super.getPathFilter(),super.isApplyFilterToDirectories()));
+      this.allFileStatus.addAll(
+          FileListUtils.listFilesRecursively(fs, p, super.getPathFilter(), super.isApplyFilterToDirectories()));
     }
     return this.allFileStatus;
   }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/replication/ReplicaHadoopFsEndPoint.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/replication/ReplicaHadoopFsEndPoint.java
@@ -42,7 +42,6 @@ import org.apache.gobblin.source.extractor.Watermark;
 import org.apache.gobblin.util.FileListUtils;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.hadoop.fs.PathFilter;
 
 
 @Slf4j

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/replication/ReplicaHadoopFsEndPoint.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/replication/ReplicaHadoopFsEndPoint.java
@@ -42,6 +42,7 @@ import org.apache.gobblin.source.extractor.Watermark;
 import org.apache.gobblin.util.FileListUtils;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.hadoop.fs.PathFilter;
 
 
 @Slf4j
@@ -72,30 +73,31 @@ public class ReplicaHadoopFsEndPoint extends HadoopFsEndPoint {
   }
 
   @Override
-  public synchronized Collection<FileStatus> getFiles() throws IOException{
-    if(filesInitialized){
+  public synchronized Collection<FileStatus> getFiles()
+      throws IOException {
+    if (filesInitialized) {
       return this.allFileStatus;
     }
 
     this.filesInitialized = true;
     FileSystem fs = FileSystem.get(rc.getFsURI(), new Configuration());
 
-    if(!fs.exists(this.rc.getPath())){
+    if (!fs.exists(this.rc.getPath())) {
       return Collections.emptyList();
     }
 
     Collection<Path> validPaths = ReplicationDataValidPathPicker.getValidPaths(this);
-        //ReplicationDataValidPathPicker.getValidPaths(fs, this.rc.getPath(), this.rdc);
+    //ReplicationDataValidPathPicker.getValidPaths(fs, this.rc.getPath(), this.rdc);
 
-    for(Path p: validPaths){
-      this.allFileStatus.addAll(FileListUtils.listFilesRecursively(fs, p));
+    for (Path p : validPaths) {
+      this.allFileStatus.addAll(FileListUtils.listFilesRecursively(fs, p, super.getPathFilter(),super.isApplyFilterToDirectories()));
     }
     return this.allFileStatus;
   }
 
   @Override
   public synchronized Optional<ComparableWatermark> getWatermark() {
-    if(this.watermarkInitialized) {
+    if (this.watermarkInitialized) {
       return this.cachedWatermark;
     }
 
@@ -104,12 +106,12 @@ public class ReplicaHadoopFsEndPoint extends HadoopFsEndPoint {
       Path metaData = new Path(rc.getPath(), WATERMARK_FILE);
       FileSystem fs = FileSystem.get(rc.getFsURI(), new Configuration());
       if (fs.exists(metaData)) {
-        try(FSDataInputStream fin = fs.open(metaData)){
+        try (FSDataInputStream fin = fs.open(metaData)) {
           InputStreamReader reader = new InputStreamReader(fin, Charsets.UTF_8);
           String content = CharStreams.toString(reader);
           Watermark w = WatermarkMetadataUtil.deserialize(content);
-          if(w instanceof ComparableWatermark){
-            this.cachedWatermark = Optional.of((ComparableWatermark)w);
+          if (w instanceof ComparableWatermark) {
+            this.cachedWatermark = Optional.of((ComparableWatermark) w);
           }
         }
         return this.cachedWatermark;
@@ -120,7 +122,7 @@ public class ReplicaHadoopFsEndPoint extends HadoopFsEndPoint {
     } catch (IOException e) {
       log.warn("Can not find " + WATERMARK_FILE + " for replica " + this);
       return this.cachedWatermark;
-    } catch (WatermarkMetadataUtil.WatermarkMetadataMulFormatException e){
+    } catch (WatermarkMetadataUtil.WatermarkMetadataMulFormatException e) {
       log.warn("Can not create watermark from " + WATERMARK_FILE + " for replica " + this);
       return this.cachedWatermark;
     }
@@ -143,8 +145,11 @@ public class ReplicaHadoopFsEndPoint extends HadoopFsEndPoint {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this.getClass()).add("is source", this.isSource()).add("end point name", this.getEndPointName())
-        .add("hadoopfs config", this.rc).toString();
+    return Objects.toStringHelper(this.getClass())
+        .add("is source", this.isSource())
+        .add("end point name", this.getEndPointName())
+        .add("hadoopfs config", this.rc)
+        .toString();
   }
 
   @Override
@@ -153,7 +158,7 @@ public class ReplicaHadoopFsEndPoint extends HadoopFsEndPoint {
   }
 
   @Override
-  public Path getDatasetPath(){
+  public Path getDatasetPath() {
     return this.rc.getPath();
   }
 
@@ -168,23 +173,30 @@ public class ReplicaHadoopFsEndPoint extends HadoopFsEndPoint {
 
   @Override
   public boolean equals(Object obj) {
-    if (this == obj)
+    if (this == obj) {
       return true;
-    if (obj == null)
+    }
+    if (obj == null) {
       return false;
-    if (getClass() != obj.getClass())
+    }
+    if (getClass() != obj.getClass()) {
       return false;
+    }
     ReplicaHadoopFsEndPoint other = (ReplicaHadoopFsEndPoint) obj;
     if (rc == null) {
-      if (other.rc != null)
+      if (other.rc != null) {
         return false;
-    } else if (!rc.equals(other.rc))
+      }
+    } else if (!rc.equals(other.rc)) {
       return false;
+    }
     if (replicaName == null) {
-      if (other.replicaName != null)
+      if (other.replicaName != null) {
         return false;
-    } else if (!replicaName.equals(other.replicaName))
+      }
+    } else if (!replicaName.equals(other.replicaName)) {
       return false;
+    }
     return true;
   }
 }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/replication/SourceHadoopFsEndPoint.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/replication/SourceHadoopFsEndPoint.java
@@ -22,7 +22,6 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 
-import org.apache.gobblin.data.management.dataset.DatasetUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -37,7 +36,6 @@ import org.apache.gobblin.source.extractor.extract.LongWatermark;
 import org.apache.gobblin.util.FileListUtils;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.hadoop.fs.PathFilter;
 
 
 @Slf4j

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/replication/SourceHadoopFsEndPoint.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/replication/SourceHadoopFsEndPoint.java
@@ -22,6 +22,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 
+import org.apache.gobblin.data.management.dataset.DatasetUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -36,10 +37,11 @@ import org.apache.gobblin.source.extractor.extract.LongWatermark;
 import org.apache.gobblin.util.FileListUtils;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.hadoop.fs.PathFilter;
 
 
 @Slf4j
-public class SourceHadoopFsEndPoint extends HadoopFsEndPoint{
+public class SourceHadoopFsEndPoint extends HadoopFsEndPoint {
 
   @Getter
   private final HadoopFsReplicaConfig rc;
@@ -57,8 +59,8 @@ public class SourceHadoopFsEndPoint extends HadoopFsEndPoint{
   }
 
   @Override
-  public synchronized Collection<FileStatus> getFiles() throws IOException{
-    if(!this.initialized){
+  public synchronized Collection<FileStatus> getFiles() throws IOException {
+    if (!this.initialized) {
       this.getWatermark();
     }
     return this.allFileStatus;
@@ -66,7 +68,7 @@ public class SourceHadoopFsEndPoint extends HadoopFsEndPoint{
 
   @Override
   public synchronized Optional<ComparableWatermark> getWatermark() {
-    if(this.initialized) {
+    if (this.initialized) {
       return this.cachedWatermark;
     }
     try {
@@ -74,8 +76,9 @@ public class SourceHadoopFsEndPoint extends HadoopFsEndPoint{
       FileSystem fs = FileSystem.get(rc.getFsURI(), new Configuration());
 
       Collection<Path> validPaths = ReplicationDataValidPathPicker.getValidPaths(this);
-      for(Path p: validPaths){
-        this.allFileStatus.addAll(FileListUtils.listFilesRecursively(fs, p));
+      for (Path p : validPaths) {
+        this.allFileStatus.addAll(
+            FileListUtils.listFilesRecursively(fs, p, super.getPathFilter(), super.isApplyFilterToDirectories()));
       }
 
       for (FileStatus f : this.allFileStatus) {
@@ -115,8 +118,11 @@ public class SourceHadoopFsEndPoint extends HadoopFsEndPoint{
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this.getClass()).add("is source", this.isSource()).add("end point name", this.getEndPointName())
-        .add("hadoopfs config", this.rc).toString();
+    return Objects.toStringHelper(this.getClass())
+        .add("is source", this.isSource())
+        .add("end point name", this.getEndPointName())
+        .add("hadoopfs config", this.rc)
+        .toString();
   }
 
   @Override
@@ -125,7 +131,7 @@ public class SourceHadoopFsEndPoint extends HadoopFsEndPoint{
   }
 
   @Override
-  public Path getDatasetPath(){
+  public Path getDatasetPath() {
     return this.rc.getPath();
   }
 
@@ -139,18 +145,23 @@ public class SourceHadoopFsEndPoint extends HadoopFsEndPoint{
 
   @Override
   public boolean equals(Object obj) {
-    if (this == obj)
+    if (this == obj) {
       return true;
-    if (obj == null)
+    }
+    if (obj == null) {
       return false;
-    if (getClass() != obj.getClass())
+    }
+    if (getClass() != obj.getClass()) {
       return false;
+    }
     SourceHadoopFsEndPoint other = (SourceHadoopFsEndPoint) obj;
     if (rc == null) {
-      if (other.rc != null)
+      if (other.rc != null) {
         return false;
-    } else if (!rc.equals(other.rc))
+      }
+    } else if (!rc.equals(other.rc)) {
       return false;
+    }
     return true;
   }
 }

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/replication/ConfigBasedDatasetTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/replication/ConfigBasedDatasetTest.java
@@ -25,7 +25,6 @@ import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.gobblin.data.management.dataset.DatasetUtils;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathFilter;

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/replication/ConfigBasedDatasetTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/replication/ConfigBasedDatasetTest.java
@@ -22,9 +22,13 @@ import java.util.Collection;
 import java.util.Properties;
 import java.util.Set;
 
+import lombok.extern.slf4j.Slf4j;
+import org.apache.gobblin.data.management.dataset.DatasetUtils;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathFilter;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -47,28 +51,38 @@ import org.apache.gobblin.util.commit.DeleteFileCommitStep;
 
 
 /**
- * Unit test for {@link ConfigBasedDatasets}
+ * Unit test for {@link ConfigBasedDataset}
  * @author mitu
  *
  */
 @Test(groups = {"gobblin.data.management.copy.replication"})
+@Slf4j
+public class ConfigBasedDatasetTest {
 
-public class ConfigBasedDatasetsTest {
-
-  @Test
-  public void testGetCopyableFiles() throws Exception {
-    String sourceDir = getClass().getClassLoader().getResource("configBasedDatasetTest/src").getFile();
-    String destinationDir = getClass().getClassLoader().getResource("configBasedDatasetTest/dest").getFile();
+  public Collection<? extends CopyEntity> testGetCopyableFilesHelper(String sourceDir, String destinationDir,
+      long sourceWatermark, boolean isFilterEnabled) throws Exception {
     FileSystem localFs = FileSystem.getLocal(new Configuration());
     URI local = localFs.getUri();
-    long sourceWatermark = 100L;
 
     Properties properties = new Properties();
     properties.setProperty(ConfigurationKeys.DATA_PUBLISHER_FINAL_DIR, "/publisher");
+    PathFilter pathFilter = DatasetUtils.instantiatePathFilter(properties);
+    boolean applyFilterToDirectories = false;
+    if (isFilterEnabled) {
+      properties.setProperty(DatasetUtils.CONFIGURATION_KEY_PREFIX + "path.filter.class",
+          "org.apache.gobblin.util.filters.HiddenFilter");
+      properties.setProperty(CopyConfiguration.APPLY_FILTER_TO_DIRECTORIES, "true");
+
+      pathFilter = DatasetUtils.instantiatePathFilter(properties);
+      applyFilterToDirectories =
+          Boolean.parseBoolean(properties.getProperty(CopyConfiguration.APPLY_FILTER_TO_DIRECTORIES, "false"));
+    }
 
     CopyConfiguration copyConfiguration =
-        CopyConfiguration.builder(FileSystem.getLocal(new Configuration()), properties).publishDir(new Path(destinationDir))
-        .preserve(PreserveAttributes.fromMnemonicString("ugp")).build();
+        CopyConfiguration.builder(FileSystem.getLocal(new Configuration()), properties)
+            .publishDir(new Path(destinationDir))
+            .preserve(PreserveAttributes.fromMnemonicString("ugp"))
+            .build();
 
     ReplicationMetaData mockMetaData = Mockito.mock(ReplicationMetaData.class);
     Mockito.when(mockMetaData.toString()).thenReturn("Mock Meta Data");
@@ -82,27 +96,44 @@ public class ConfigBasedDatasetsTest {
     Mockito.when(copyFrom.getFsURI()).thenReturn(local);
     ComparableWatermark sw = new LongWatermark(sourceWatermark);
     Mockito.when(copyFrom.getWatermark()).thenReturn(Optional.of(sw));
-    Mockito.when(copyFrom.getFiles()).thenReturn(FileListUtils.listFilesRecursively(localFs, new Path(sourceDir)));
+    Mockito.when(copyFrom.getFiles())
+        .thenReturn(
+            FileListUtils.listFilesRecursively(localFs, new Path(sourceDir), pathFilter, applyFilterToDirectories));
 
     HadoopFsEndPoint copyTo = Mockito.mock(HadoopFsEndPoint.class);
     Mockito.when(copyTo.getDatasetPath()).thenReturn(new Path(destinationDir));
     Mockito.when(copyTo.getFsURI()).thenReturn(local);
-    Optional<ComparableWatermark>tmp = Optional.absent();
+    Optional<ComparableWatermark> tmp = Optional.absent();
     Mockito.when(copyTo.getWatermark()).thenReturn(tmp);
-    Mockito.when(copyTo.getFiles()).thenReturn(FileListUtils.listFilesRecursively(localFs, new Path(destinationDir)));
+    Mockito.when(copyTo.getFiles())
+        .thenReturn(FileListUtils.listFilesRecursively(localFs, new Path(destinationDir), pathFilter,
+            applyFilterToDirectories));
 
     CopyRoute route = Mockito.mock(CopyRoute.class);
     Mockito.when(route.getCopyFrom()).thenReturn(copyFrom);
     Mockito.when(route.getCopyTo()).thenReturn(copyTo);
 
     ConfigBasedDataset dataset = new ConfigBasedDataset(mockRC, properties, route);
-
     Collection<? extends CopyEntity> copyableFiles = dataset.getCopyableFiles(localFs, copyConfiguration);
+    return copyableFiles;
+  }
+
+  @Test
+  public void testGetCopyableFiles() throws Exception {
+    String sourceDir = getClass().getClassLoader().getResource("configBasedDatasetTest/src").getFile();
+    String destinationDir = getClass().getClassLoader().getResource("configBasedDatasetTest/dest").getFile();
+    long sourceWatermark = 100L;
+
+    Collection<? extends CopyEntity> copyableFiles =
+        testGetCopyableFilesHelper(sourceDir, destinationDir, sourceWatermark, false);
+    Assert.assertEquals(copyableFiles.size(), 8);
+    copyableFiles = testGetCopyableFilesHelper(sourceDir, destinationDir, sourceWatermark, true);
     Assert.assertEquals(copyableFiles.size(), 6);
 
-    Set<Path> paths = Sets.newHashSet(new Path("dir1/file2"), new Path("dir1/file1"), new Path("dir2/file1"), new Path("dir2/file3"));
+    Set<Path> paths =
+        Sets.newHashSet(new Path("dir1/file2"), new Path("dir1/file1"), new Path("dir2/file1"), new Path("dir2/file3"));
     for (CopyEntity copyEntity : copyableFiles) {
-      if(copyEntity instanceof CopyableFile) {
+      if (copyEntity instanceof CopyableFile) {
         CopyableFile file = (CopyableFile) copyEntity;
         Path originRelativePath =
             PathUtils.relativizePath(PathUtils.getPathWithoutSchemeAndAuthority(file.getOrigin().getPath()),
@@ -114,22 +145,19 @@ public class ConfigBasedDatasetsTest {
         Assert.assertTrue(paths.contains(originRelativePath));
         Assert.assertTrue(paths.contains(targetRelativePath));
         Assert.assertEquals(originRelativePath, targetRelativePath);
-      }
-      else if(copyEntity instanceof PrePublishStep){
-        PrePublishStep pre = (PrePublishStep)copyEntity;
+      } else if (copyEntity instanceof PrePublishStep) {
+        PrePublishStep pre = (PrePublishStep) copyEntity;
         Assert.assertTrue(pre.getStep() instanceof DeleteFileCommitStep);
         // need to delete this file
         Assert.assertTrue(pre.explain().indexOf("configBasedDatasetTest/dest/dir1/file1") > 0);
-      }
-      else if(copyEntity instanceof PostPublishStep){
-        PostPublishStep post = (PostPublishStep)copyEntity;
+      } else if (copyEntity instanceof PostPublishStep) {
+        PostPublishStep post = (PostPublishStep) copyEntity;
         Assert.assertTrue(post.getStep() instanceof WatermarkMetadataGenerationCommitStep);
-        Assert.assertTrue(post.explain().indexOf("dest/_metadata") > 0 && post.explain().indexOf(""+sourceWatermark)>0);
-      }
-      else{
+        Assert.assertTrue(
+            post.explain().indexOf("dest/_metadata") > 0 && post.explain().indexOf("" + sourceWatermark) > 0);
+      } else {
         throw new Exception("Wrong type");
       }
     }
   }
-
 }

--- a/gobblin-data-management/src/test/resources/configBasedDatasetTest/src/_dir1/file1
+++ b/gobblin-data-management/src/test/resources/configBasedDatasetTest/src/_dir1/file1
@@ -1,0 +1,1 @@
+_dir1:file1content

--- a/gobblin-data-management/src/test/resources/configBasedDatasetTest/src/_dir1/file2
+++ b/gobblin-data-management/src/test/resources/configBasedDatasetTest/src/_dir1/file2
@@ -1,0 +1,1 @@
+_dir1:file2content


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-381


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
This is related to GOBBLIN-368. ConfigBasedDatasets do not have the ability to apply path filters to directories. Similar to RecursiveCopyableDataset, ConfigBasedDatasets should filter files and/or directories based on the following configuration keys:

gobblin.copy.applyFilterToDirectories

gobblin.dataset.path.filter.class

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
    - Enhanced ConfigBasedDatasetTest class to test HiddenFilters and their application to directories (in addition to filenames).

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

