### PR TITLE
[GOBBLIN-384] Update Python version to v3

### DIFF
--- a/dev/gobblin-pr
+++ b/dev/gobblin-pr
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
@@ -37,6 +37,10 @@ import subprocess
 import sys
 import textwrap
 
+# Print current SSL version, commented and left around for debugging
+# import ssl
+# print(ssl.OPENSSL_VERSION)
+
 # Python 3 compatibility
 try:
     import urllib2 as urllib
@@ -48,13 +52,13 @@ if sys.version_info[0] == 3:
 try:
     import click
 except ImportError:
-    print("Could not find the click library. Run 'sudo pip install click' to install.")
+    print("Could not find the click library. Run 'sudo pip3 install click' to install.")
     sys.exit(-1)
 
 try:
     import keyring
 except ImportError:
-    print("Could not find the keyring library. Run 'sudo pip install keyring' to install.")
+    print("Could not find the keyring library. Run 'sudo pip3 install keyring' to install.")
     sys.exit(-1)
 
 # Location of your Gobblin git development area
@@ -532,7 +536,7 @@ def resolve_jira_issue(comment=None, jira_id=None, merge_branches=None):
     except ImportError:
         raise PRToolError(
             "Could not find jira-python library; exiting. Run "
-            "'sudo pip install jira' to install.")
+            "'sudo pip3 install jira' to install.")
 
     if merge_branches is None:
         merge_branches = []


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-384


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Default python points to < Openssl v1.0 on Mac, and is a hassle to upgrade. Whereas Jira servers have started blocking any call with older SSL versions. 

An alternate that requires little work for all environments but helps is to bump up the python version to python3. This can installed via brew on Mac along with newer Openssl. 

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tested locally

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

