### PR TITLE
[GOBBLIN-387] pick job files in FIFO order

### DIFF
--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/PullFileLoader.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/PullFileLoader.java
@@ -192,10 +192,10 @@ public class PullFileLoader {
           if (status.isDirectory()) {
             pullFiles.addAll(loadPullFilesRecursivelyHelper(status.getPath(), fallback, loadGlobalProperties));
           } else if (this.javaPropsPullFileFilter.accept(status.getPath())) {
-            log.info("modification time of {} is {}", status.getPath(), status.getModificationTime());
+            log.debug("modification time of {} is {}", status.getPath(), status.getModificationTime());
             pullFiles.add(new ConfigWithTimeStamp(status.getModificationTime(), loadJavaPropsWithFallback(status.getPath(), fallback).resolve()));
           } else if (this.hoconPullFileFilter.accept(status.getPath())) {
-            log.info("modification time of {} is {}", status.getPath(), status.getModificationTime());
+            log.debug("modification time of {} is {}", status.getPath(), status.getModificationTime());
             pullFiles.add(new ConfigWithTimeStamp(status.getModificationTime(), loadHoconConfigAtPath(status.getPath()).withFallback(fallback).resolve()));
           }
         } catch (IOException ioe) {

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/PullFileLoader.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/PullFileLoader.java
@@ -23,6 +23,7 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
@@ -74,7 +75,7 @@ public class PullFileLoader {
 
   public static final String PROPERTY_DELIMITER_PARSING_ENABLED_KEY = "property.parsing.enablekey";
   public static final boolean DEFAULT_PROPERTY_DELIMITER_PARSING_ENABLED_KEY = false;
-  
+
   private final Path rootDirectory;
   private final FileSystem fs;
   private final ExtensionFilter javaPropsPullFileFilter;
@@ -145,28 +146,36 @@ public class PullFileLoader {
   }
 
   /**
-   * Find and load all pull files under a base {@link Path} recursively.
+   * Find and load all pull files under a base {@link Path} recursively in an order sorted by last modified date.
    * @param path base {@link Path} where pull files should be found recursively.
    * @param sysProps A {@link Config} used as fallback.
    * @param loadGlobalProperties if true, will also load at most one *.properties file per directory from the
    *          {@link #rootDirectory} to the pull file {@link Path} for each pull file.
    * @return The loaded {@link Config}s.
    */
-  public Collection<Config> loadPullFilesRecursively(Path path, Config sysProps, boolean loadGlobalProperties) {
+  public List<Config> loadPullFilesRecursively(Path path, Config sysProps, boolean loadGlobalProperties) {
     try {
       Config fallback = sysProps;
       if (loadGlobalProperties && PathUtils.isAncestor(this.rootDirectory, path.getParent())) {
         fallback = loadAncestorGlobalConfigs(path.getParent(), fallback);
       }
-      return loadPullFilesRecursivelyHelper(path, fallback, loadGlobalProperties);
+      return getSortedConfigs(loadPullFilesRecursivelyHelper(path, fallback, loadGlobalProperties));
     } catch (IOException ioe) {
       return Lists.newArrayList();
     }
   }
 
-  private Collection<Config> loadPullFilesRecursivelyHelper(Path path, Config fallback, boolean loadGlobalProperties) {
-    List<Config> pullFiles = Lists.newArrayList();
+  private List<Config> getSortedConfigs(List<ConfigWithTimeStamp> configsWithTimeStamps) {
+    List<Config> sortedConfigs = Lists.newArrayList();
+    Collections.sort(configsWithTimeStamps);
+    for (ConfigWithTimeStamp configWithTimeStamp : configsWithTimeStamps) {
+      sortedConfigs.add(configWithTimeStamp.config);
+    }
+    return sortedConfigs;
+  }
 
+  private List<ConfigWithTimeStamp> loadPullFilesRecursivelyHelper(Path path, Config fallback, boolean loadGlobalProperties) {
+    List<ConfigWithTimeStamp> pullFiles = Lists.newArrayList();
     try {
       if (loadGlobalProperties) {
         fallback = findAndLoadGlobalConfigInDirectory(path, fallback);
@@ -183,9 +192,11 @@ public class PullFileLoader {
           if (status.isDirectory()) {
             pullFiles.addAll(loadPullFilesRecursivelyHelper(status.getPath(), fallback, loadGlobalProperties));
           } else if (this.javaPropsPullFileFilter.accept(status.getPath())) {
-            pullFiles.add(loadJavaPropsWithFallback(status.getPath(), fallback).resolve());
+            log.info("modification time of {} is {}", status.getPath(), status.getModificationTime());
+            pullFiles.add(new ConfigWithTimeStamp(status.getModificationTime(), loadJavaPropsWithFallback(status.getPath(), fallback).resolve()));
           } else if (this.hoconPullFileFilter.accept(status.getPath())) {
-            pullFiles.add(loadHoconConfigAtPath(status.getPath()).withFallback(fallback).resolve());
+            log.info("modification time of {} is {}", status.getPath(), status.getModificationTime());
+            pullFiles.add(new ConfigWithTimeStamp(status.getModificationTime(), loadHoconConfigAtPath(status.getPath()).withFallback(fallback).resolve()));
           }
         } catch (IOException ioe) {
           // Failed to load specific subpath, try with the other subpaths in this directory
@@ -298,4 +309,18 @@ public class PullFileLoader {
     }
   }
 
+  private class ConfigWithTimeStamp implements Comparable {
+    long timeStamp;
+    Config config;
+
+    public ConfigWithTimeStamp(long timeStamp, Config config) {
+      this.timeStamp = timeStamp;
+      this.config = config;
+    }
+
+    @Override
+    public int compareTo(Object otherConfigWithTimeStamp) {
+      return (int)(timeStamp - ((ConfigWithTimeStamp)otherConfigWithTimeStamp).timeStamp);
+    }
+  }
 }

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/PullFileLoader.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/PullFileLoader.java
@@ -24,6 +24,7 @@ import java.io.Reader;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
@@ -167,7 +168,7 @@ public class PullFileLoader {
 
   private List<Config> getSortedConfigs(List<ConfigWithTimeStamp> configsWithTimeStamps) {
     List<Config> sortedConfigs = Lists.newArrayList();
-    Collections.sort(configsWithTimeStamps);
+    Collections.sort(configsWithTimeStamps, (config1, config2) -> (config1.timeStamp > config2.timeStamp) ? 1 : -1);
     for (ConfigWithTimeStamp configWithTimeStamp : configsWithTimeStamps) {
       sortedConfigs.add(configWithTimeStamp.config);
     }
@@ -309,18 +310,13 @@ public class PullFileLoader {
     }
   }
 
-  private class ConfigWithTimeStamp implements Comparable {
+  private static class ConfigWithTimeStamp {
     long timeStamp;
     Config config;
 
     public ConfigWithTimeStamp(long timeStamp, Config config) {
       this.timeStamp = timeStamp;
       this.config = config;
-    }
-
-    @Override
-    public int compareTo(Object otherConfigWithTimeStamp) {
-      return (int)(timeStamp - ((ConfigWithTimeStamp)otherConfigWithTimeStamp).timeStamp);
     }
   }
 }

--- a/gobblin-utility/src/test/java/org/apache/gobblin/util/PullFileLoaderTest.java
+++ b/gobblin-utility/src/test/java/org/apache/gobblin/util/PullFileLoaderTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.gobblin.util;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.Collection;
@@ -149,7 +150,9 @@ public class PullFileLoaderTest {
   @Test void testJobLoadingOrder() throws Exception {
     Properties sysProps = new Properties();
     FileSystem fs = FileSystem.getLocal(new Configuration());
-    Path localBasePath = new Path(Files.createTempDir().getAbsolutePath(), "PullFileLoaderTestDir");
+    File tmpDir = Files.createTempDir();
+    tmpDir.deleteOnExit();
+    Path localBasePath = new Path(tmpDir.getAbsolutePath(), "PullFileLoaderTestDir");
     fs.mkdirs(localBasePath);
 
     for (int i=5; i>0; i--) {

--- a/gobblin-utility/src/test/java/org/apache/gobblin/util/PullFileLoaderTest.java
+++ b/gobblin-utility/src/test/java/org/apache/gobblin/util/PullFileLoaderTest.java
@@ -18,7 +18,9 @@
 package org.apache.gobblin.util;
 
 import java.io.IOException;
+import java.io.PrintWriter;
 import java.util.Collection;
+import java.util.List;
 import java.util.Properties;
 
 import org.apache.hadoop.conf.Configuration;
@@ -28,6 +30,7 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.io.Files;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
@@ -139,6 +142,34 @@ public class PullFileLoaderTest {
     Assert.assertEquals(pullFile.entrySet().size(), 4);
   }
 
+  /**
+   * Tests to verify job written first to the job catalog is picked up first.
+   * @throws Exception
+   */
+  @Test void testJobLoadingOrder() throws Exception {
+    Properties sysProps = new Properties();
+    FileSystem fs = FileSystem.getLocal(new Configuration());
+    Path localBasePath = new Path(Files.createTempDir().getAbsolutePath(), "PullFileLoaderTestDir");
+    fs.mkdirs(localBasePath);
+
+    for (int i=5; i>0; i--) {
+      String job = localBasePath.toString() + "/job" + i + ".conf";
+      PrintWriter writer = new PrintWriter(job, "UTF-8");
+      writer.println("key=job" + i + "_val");
+      writer.close();
+      Thread.sleep(1000);
+    }
+
+    List<Config> configs =
+        loader.loadPullFilesRecursively(localBasePath, ConfigUtils.propertiesToConfig(sysProps), false);
+
+    int i = 5;
+    for (Config config : configs) {
+      Assert.assertEquals(config.getString("key"), "job" + i + "_val");
+      i--;
+    }
+  }
+
   @Test
   public void testJobLoadingWithSysPropsAndGlobalProps() throws Exception {
     Path path;
@@ -230,7 +261,7 @@ public class PullFileLoaderTest {
     pullFile = loader.loadPullFile(path, cfg, false);
     Assert.assertEquals(pullFile.getString("json.property.key"), pullFile.getString("json.property.key1"));
   }
-  
+
   private Config pullFileFromPath(Collection<Config> configs, Path path) throws IOException {
     for (Config config : configs) {
       if (config.getString(ConfigurationKeys.JOB_CONFIG_FILE_PATH_KEY).equals(path.toString())) {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below! @abti please review


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-387


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
This PR will address the issue of reading job files from job catalog/job config directory in random order. After these changes, job files will be read in FIFO order.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Added unit test, to make sure files are read in order they were created; and not in alphabetical order.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

