### PR TITLE
[GOBBLIN-388] Allow classpath to be configured for child process

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
@@ -30,8 +30,11 @@ public class GobblinClusterConfigurationKeys {
 
   public static final String GOBBLIN_CLUSTER_PREFIX = "gobblin.cluster.";
 
+  // Task separation properties
   public static final String ENABLE_TASK_IN_SEPARATE_PROCESS =
       GOBBLIN_CLUSTER_PREFIX + "enableTaskInSeparateProcess";
+  public static final String TASK_CLASSPATH =
+      GOBBLIN_CLUSTER_PREFIX + "task.classpath";
 
   // General Gobblin Cluster application configuration properties.
   public static final String APPLICATION_NAME_OPTION_NAME = "app_name";

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinTaskRunner.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinTaskRunner.java
@@ -192,7 +192,7 @@ public class GobblinTaskRunner {
     TaskFactory taskFactory;
     if (isRunTaskInSeparateProcessEnabled) {
       logger.info("Running a task in a separate process is enabled.");
-      taskFactory = new HelixTaskFactory(this.containerMetrics, CLUSTER_CONF_PATH);
+      taskFactory = new HelixTaskFactory(this.containerMetrics, CLUSTER_CONF_PATH, config);
     } else {
       taskFactory = getInProcessTaskFactory();
     }

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/HelixTaskFactory.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/HelixTaskFactory.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 
 import com.codahale.metrics.Counter;
 import com.google.common.base.Optional;
+import com.typesafe.config.Config;
 
 import org.apache.gobblin.util.GobblinProcessBuilder;
 import org.apache.gobblin.util.SystemPropertiesWrapper;
@@ -49,7 +50,7 @@ public class HelixTaskFactory implements TaskFactory {
   private final Optional<Counter> newTasksCounter;
   private final SingleTaskLauncher launcher;
 
-  public HelixTaskFactory(Optional<ContainerMetrics> containerMetrics, Path clusterConfPath) {
+  public HelixTaskFactory(Optional<ContainerMetrics> containerMetrics, Path clusterConfPath, Config sysConfig) {
     this.containerMetrics = containerMetrics;
     if (this.containerMetrics.isPresent()) {
       this.newTasksCounter = Optional
@@ -58,7 +59,7 @@ public class HelixTaskFactory implements TaskFactory {
       this.newTasksCounter = Optional.absent();
     }
     launcher = new SingleTaskLauncher(new GobblinProcessBuilder(), new SystemPropertiesWrapper(),
-        clusterConfPath);
+        clusterConfPath, sysConfig);
   }
 
   @Override

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SingleTaskLauncher.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SingleTaskLauncher.java
@@ -29,6 +29,8 @@ import org.slf4j.LoggerFactory;
 import org.apache.gobblin.util.GobblinProcessBuilder;
 import org.apache.gobblin.util.SystemPropertiesWrapper;
 
+import com.typesafe.config.Config;
+
 import static org.apache.gobblin.cluster.SingleTaskRunnerMainOptions.CLUSTER_CONFIG_FILE_PATH;
 import static org.apache.gobblin.cluster.SingleTaskRunnerMainOptions.JOB_ID;
 import static org.apache.gobblin.cluster.SingleTaskRunnerMainOptions.WORK_UNIT_FILE_PATH;
@@ -40,12 +42,14 @@ class SingleTaskLauncher {
   private final GobblinProcessBuilder processBuilder;
   private final SystemPropertiesWrapper propertiesWrapper;
   private final Path clusterConfigFilePath;
+  private final Config sysConfig;
 
   SingleTaskLauncher(final GobblinProcessBuilder processBuilder,
-      final SystemPropertiesWrapper propertiesWrapper, final Path clusterConfigFilePath) {
+      final SystemPropertiesWrapper propertiesWrapper, final Path clusterConfigFilePath, Config sysConfig) {
     this.processBuilder = processBuilder;
     this.propertiesWrapper = propertiesWrapper;
     this.clusterConfigFilePath = clusterConfigFilePath;
+    this.sysConfig = sysConfig;
   }
 
   Process launch(final String jobId, final Path workUnitFilePath)
@@ -94,7 +98,12 @@ class SingleTaskLauncher {
 
     private void addClassPath() {
       this.cmd.add("-cp");
-      final String classPath = SingleTaskLauncher.this.propertiesWrapper.getJavaClassPath();
+      String classPath;
+      if (sysConfig.hasPath(GobblinClusterConfigurationKeys.TASK_CLASSPATH)) {
+        classPath = sysConfig.getString(GobblinClusterConfigurationKeys.TASK_CLASSPATH);
+      } else {
+        classPath = SingleTaskLauncher.this.propertiesWrapper.getJavaClassPath();
+      }
       this.cmd.add(classPath);
     }
 

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/SingleTaskLauncherTest.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/SingleTaskLauncherTest.java
@@ -28,6 +28,8 @@ import org.testng.annotations.Test;
 import org.apache.gobblin.util.GobblinProcessBuilder;
 import org.apache.gobblin.util.SystemPropertiesWrapper;
 
+import com.typesafe.config.ConfigFactory;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
@@ -56,7 +58,7 @@ public class SingleTaskLauncherTest {
 
     final Path clusterConfPath = Paths.get(CLUSTER_CONFIG_CONF_PATH);
     final SingleTaskLauncher launcher =
-        new SingleTaskLauncher(processBuilder, propertiesWrapper, clusterConfPath);
+        new SingleTaskLauncher(processBuilder, propertiesWrapper, clusterConfPath, ConfigFactory.empty());
 
     final Path workUnitPath = Paths.get(WORK_UNIT_PATH);
     final Process process = launcher.launch(JOB_ID, workUnitPath);


### PR DESCRIPTION
…lin cluster

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-388] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-388


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
   Allow user or external system to define the classpath that child process will use in the gobblin cluster task execution .

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
   ClusterIntegrationTest

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

