### PR TITLE
[GOBBLIN-391] Use the DataPublisherFactory to allow sharing publisher…

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/publisher/DataPublisherFactory.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/publisher/DataPublisherFactory.java
@@ -54,6 +54,16 @@ public class DataPublisherFactory<S extends ScopeType<S>>
     }
   }
 
+  /**
+   * Is the publisher cacheable in the SharedResourcesBroker?
+   * @param publisher
+   * @return true if cacheable, else false
+   */
+  public static boolean isPublisherCacheable(DataPublisher publisher) {
+    // only threadsafe publishers are cacheable. non-threadsafe publishers are marked immediately for invalidation
+    return publisher.supportsCapability(Capability.THREADSAFE, Collections.EMPTY_MAP);
+  }
+
   @Override
   public String getName() {
     return FACTORY_NAME;
@@ -75,7 +85,7 @@ public class DataPublisherFactory<S extends ScopeType<S>>
       // by the broker.
       // Otherwise, it is not shareable, so return it as an immediately invalidated resource that will only be returned
       // once from the broker.
-      if (publisher.supportsCapability(Capability.THREADSAFE, Collections.EMPTY_MAP)) {
+      if (isPublisherCacheable(publisher)) {
         return new ResourceInstance<>(publisher);
       } else {
         return new ImmediatelyInvalidResourceEntry<>(publisher);

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/SafeDatasetCommit.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/SafeDatasetCommit.java
@@ -19,7 +19,6 @@ package org.apache.gobblin.runtime;
 
 import java.io.IOException;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
@@ -33,7 +32,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.io.Closer;
 
-import org.apache.gobblin.capability.Capability;
 import org.apache.gobblin.commit.CommitSequence;
 import org.apache.gobblin.commit.CommitStep;
 import org.apache.gobblin.commit.DeliverySemantics;
@@ -144,10 +142,12 @@ final class SafeDatasetCommit implements Callable<Void> {
 
               // non-threadsafe publishers are not shareable and are not retained in the broker, so register them with
               // the closer
-              if (!publisher.supportsCapability(Capability.THREADSAFE, Collections.EMPTY_MAP)) {
+              if (!DataPublisherFactory.isPublisherCacheable(publisher)) {
                 closer.register(publisher);
               }
             } else {
+              // NOTE: sharing of publishers is not supported when they are instantiated through the TaskFactory.
+              // This should be revisited if sharing is required.
               publisher = taskFactory.createDataPublisher(this.datasetState);
             }
 

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/SafeDatasetCommit.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/SafeDatasetCommit.java
@@ -19,6 +19,7 @@ package org.apache.gobblin.runtime;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
@@ -32,6 +33,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.io.Closer;
 
+import org.apache.gobblin.capability.Capability;
 import org.apache.gobblin.commit.CommitSequence;
 import org.apache.gobblin.commit.CommitStep;
 import org.apache.gobblin.commit.DeliverySemantics;
@@ -44,6 +46,7 @@ import org.apache.gobblin.metrics.event.FailureEventBuilder;
 import org.apache.gobblin.metrics.event.lineage.LineageInfo;
 import org.apache.gobblin.publisher.CommitSequencePublisher;
 import org.apache.gobblin.publisher.DataPublisher;
+import org.apache.gobblin.publisher.DataPublisherFactory;
 import org.apache.gobblin.publisher.UnpublishedHandling;
 import org.apache.gobblin.runtime.commit.DatasetStateCommitStep;
 import org.apache.gobblin.runtime.task.TaskFactory;
@@ -133,9 +136,21 @@ final class SafeDatasetCommit implements Callable<Void> {
             }
             generateCommitSequenceBuilder(this.datasetState, entry.getValue());
           } else {
-            DataPublisher publisher = taskFactory == null ? closer
-                .register(DataPublisher.getInstance(dataPublisherClass, this.jobContext.getJobState()))
-                : taskFactory.createDataPublisher(this.datasetState);
+            DataPublisher publisher;
+
+            if (taskFactory == null) {
+              publisher = DataPublisherFactory.get(dataPublisherClass.getName(), this.jobContext.getJobState(),
+                  this.jobContext.getJobBroker());
+
+              // non-threadsafe publishers are not shareable and are not retained in the broker, so register them with
+              // the closer
+              if (!publisher.supportsCapability(Capability.THREADSAFE, Collections.EMPTY_MAP)) {
+                closer.register(publisher);
+              }
+            } else {
+              publisher = taskFactory.createDataPublisher(this.datasetState);
+            }
+
             if (this.isJobCancelled) {
               if (publisher.canBeSkipped()) {
                 log.warn(publisher.getClass() + " will be skipped.");
@@ -160,11 +175,7 @@ final class SafeDatasetCommit implements Callable<Void> {
           this.datasetState.setState(JobState.RunningState.COMMITTED);
         }
       }
-    } catch (ReflectiveOperationException roe) {
-      log.error(String.format("Failed to instantiate data publisher for dataset %s of job %s.", this.datasetUrn,
-          this.jobContext.getJobId()), roe);
-      throw new RuntimeException(roe);
-    } catch (Throwable throwable) {
+    }  catch (Throwable throwable) {
       log.error(String.format("Failed to commit dataset state for dataset %s of job %s", this.datasetUrn,
           this.jobContext.getJobId()), throwable);
       throw new RuntimeException(throwable);


### PR DESCRIPTION
…s in SafeDatasetCommit

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-391


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
Some publishers are threadsafe and are shareable. Share these when possible to reduce instantiation cost.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

