### PR TITLE
[GOBBLIN-395] Add lineage for copying config based dataset

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/CopyableFile.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/CopyableFile.java
@@ -117,6 +117,30 @@ public class CopyableFile extends CopyEntity implements File {
   }
 
   /**
+   * Set file system based source and destination dataset for this {@link CopyableFile}
+   *
+   * @param originFs {@link FileSystem} where this {@link CopyableFile} origins
+   * @param targetFs {@link FileSystem} where this {@link CopyableFile} is copied to
+   */
+  public void setFsDatasets(FileSystem originFs, FileSystem targetFs) {
+    /*
+     * By default, the raw Gobblin dataset for CopyableFile lineage is its parent folder
+     * if itself is not a folder
+     */
+    boolean isDir = origin.isDirectory();
+
+    Path fullSourcePath = Path.getPathWithoutSchemeAndAuthority(origin.getPath());
+    String sourceDatasetName = isDir ? fullSourcePath.toString() : fullSourcePath.getParent().toString();
+    sourceDataset = new DatasetDescriptor(originFs.getScheme(), sourceDatasetName);
+    sourceDataset.addMetadata(DatasetConstants.FS_URI, originFs.getUri().toString());
+
+    Path fullDestinationPath = Path.getPathWithoutSchemeAndAuthority(destination);
+    String destinationDatasetName = isDir ? fullDestinationPath.toString() : fullDestinationPath.getParent().toString();
+    destinationDataset = new DatasetDescriptor(targetFs.getScheme(), destinationDatasetName);
+    destinationDataset.addMetadata(DatasetConstants.FS_URI, targetFs.getUri().toString());
+  }
+
+  /**
    * Get a {@link CopyableFile.Builder}.
    *
    * @param originFs {@link FileSystem} where original file exists.
@@ -146,36 +170,6 @@ public class CopyableFile extends CopyEntity implements File {
       CopyConfiguration copyConfiguration) {
     return _hiddenBuilder().originFS(originFs).origin(origin).destination(destination).configuration(copyConfiguration)
         .preserve(copyConfiguration.getPreserve());
-  }
-
-
-  /**
-   * Set file system based source and destination dataset of a {@link CopyableFile}
-   *
-   * @param copyableFile {@link CopyableFile} in action
-   * @param originFs {@link FileSystem} where the {@code copyableFile} exists
-   * @param copyConfiguration {@link CopyConfiguration} for the copy job
-   */
-  public static void setFsDatasets(CopyableFile copyableFile, FileSystem originFs, CopyConfiguration copyConfiguration) {
-    /*
-     * By default, the raw Gobblin dataset for CopyableFile lineage is its parent folder
-     * if itself is not a folder
-     */
-    FileStatus origin = copyableFile.getOrigin();
-    boolean isDir = origin.isDirectory();
-
-    Path fullSourcePath = Path.getPathWithoutSchemeAndAuthority(origin.getPath());
-    String sourceDataset = isDir ? fullSourcePath.toString() : fullSourcePath.getParent().toString();
-    DatasetDescriptor source = new DatasetDescriptor(originFs.getScheme(), sourceDataset);
-    source.addMetadata(DatasetConstants.FS_URI, originFs.getUri().toString());
-    copyableFile.setSourceDataset(source);
-
-    FileSystem targetFs = copyConfiguration.getTargetFs();
-    Path fullDestinationPath = Path.getPathWithoutSchemeAndAuthority(copyableFile.getDestination());
-    String destinationDataset = isDir ? fullDestinationPath.toString() : fullDestinationPath.getParent().toString();
-    DatasetDescriptor destination = new DatasetDescriptor(targetFs.getScheme(), destinationDataset);
-    destination.addMetadata(DatasetConstants.FS_URI, targetFs.getUri().toString());
-    copyableFile.setDestinationDataset(destination);
   }
 
   /**

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/RecursiveCopyableDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/RecursiveCopyableDataset.java
@@ -20,9 +20,7 @@ package org.apache.gobblin.data.management.copy;
 import org.apache.gobblin.commit.CommitStep;
 import org.apache.gobblin.data.management.copy.entities.PrePublishStep;
 import org.apache.gobblin.data.management.dataset.DatasetUtils;
-import org.apache.gobblin.dataset.DatasetConstants;
 import org.apache.gobblin.dataset.FileSystemDataset;
-import org.apache.gobblin.dataset.DatasetDescriptor;
 import org.apache.gobblin.util.PathUtils;
 import org.apache.gobblin.util.FileListUtils;
 import org.apache.gobblin.util.commit.DeleteFileCommitStep;
@@ -148,24 +146,7 @@ public class RecursiveCopyableDataset implements CopyableDataset, FileSystemData
               .datasetOutputPath(thisTargetPath.toString()).ancestorsOwnerAndPermission(CopyableFile
               .resolveReplicatedOwnerAndPermissionsRecursively(this.fs, file.getPath().getParent(), nonGlobSearchPath,
                   configuration)).build();
-
-      /*
-       * By default, the raw Gobblin dataset for CopyableFile lineage is its parent folder
-       * if itself is not a folder
-       */
-      boolean isDir = file.isDirectory();
-
-      Path fullSourcePath = Path.getPathWithoutSchemeAndAuthority(file.getPath());
-      String sourceDataset = isDir ? fullSourcePath.toString() : fullSourcePath.getParent().toString();
-      DatasetDescriptor source = new DatasetDescriptor(this.fs.getScheme(), sourceDataset);
-      source.addMetadata(DatasetConstants.FS_URI, this.fs.getUri().toString());
-      copyableFile.setSourceDataset(source);
-
-      String destinationDataset = isDir ? thisTargetPath.toString() : thisTargetPath.getParent().toString();
-      DatasetDescriptor destination = new DatasetDescriptor(targetFs.getScheme(), destinationDataset);
-      destination.addMetadata(DatasetConstants.FS_URI, targetFs.getUri().toString());
-      copyableFile.setDestinationDataset(destination);
-
+      CopyableFile.setFsDatasets(copyableFile, this.fs, configuration);
       copyableFiles.add(copyableFile);
     }
     copyEntities.addAll(this.copyableFileFilter.filter(this.fs, targetFs, copyableFiles));

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/RecursiveCopyableDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/RecursiveCopyableDataset.java
@@ -146,7 +146,7 @@ public class RecursiveCopyableDataset implements CopyableDataset, FileSystemData
               .datasetOutputPath(thisTargetPath.toString()).ancestorsOwnerAndPermission(CopyableFile
               .resolveReplicatedOwnerAndPermissionsRecursively(this.fs, file.getPath().getParent(), nonGlobSearchPath,
                   configuration)).build();
-      CopyableFile.setFsDatasets(copyableFile, this.fs, configuration);
+      copyableFile.setFsDatasets(this.fs, targetFs);
       copyableFiles.add(copyableFile);
     }
     copyEntities.addAll(this.copyableFileFilter.filter(this.fs, targetFs, copyableFiles));

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/replication/ConfigBasedDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/replication/ConfigBasedDataset.java
@@ -187,12 +187,11 @@ public class ConfigBasedDataset implements CopyableDataset {
         if (copyToFileMap.containsKey(newPath)) {
           deletedPaths.add(newPath);
         }
-
-        copyableFiles.add(
-            CopyableFile.fromOriginAndDestination(copyFromFs, originFileStatus, copyToFs.makeQualified(newPath),
-                copyConfiguration)
-                .fileSet(PathUtils.getPathWithoutSchemeAndAuthority(copyTo.getDatasetPath()).toString())
-                .build());
+        CopyableFile copyableFile = CopyableFile
+            .fromOriginAndDestination(copyFromFs, originFileStatus, copyToFs.makeQualified(newPath), copyConfiguration)
+            .fileSet(PathUtils.getPathWithoutSchemeAndAuthority(copyTo.getDatasetPath()).toString()).build();
+        CopyableFile.setFsDatasets(copyableFile, copyFromFs, copyConfiguration);
+        copyableFiles.add(copyableFile);
       }
 
       // clean up already checked paths

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/replication/ConfigBasedDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/replication/ConfigBasedDataset.java
@@ -190,7 +190,7 @@ public class ConfigBasedDataset implements CopyableDataset {
         CopyableFile copyableFile = CopyableFile
             .fromOriginAndDestination(copyFromFs, originFileStatus, copyToFs.makeQualified(newPath), copyConfiguration)
             .fileSet(PathUtils.getPathWithoutSchemeAndAuthority(copyTo.getDatasetPath()).toString()).build();
-        CopyableFile.setFsDatasets(copyableFile, copyFromFs, copyConfiguration);
+        copyableFile.setFsDatasets(copyFromFs, copyToFs);
         copyableFiles.add(copyableFile);
       }
 

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/CopyableFileTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/CopyableFileTest.java
@@ -18,6 +18,7 @@ package org.apache.gobblin.data.management.copy;
 
 import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Properties;
 
@@ -36,7 +37,12 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
 import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.dataset.DatasetDescriptor;
 import org.apache.gobblin.util.PathUtils;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 
 public class CopyableFileTest {
 
@@ -84,6 +90,53 @@ public class CopyableFileTest {
 
     Assert.assertEquals(deserialized, copyEntities);
 
+  }
+
+  @Test
+  public void testSetFsDatasets() throws URISyntaxException {
+    FileSystem originFs = mock(FileSystem.class);
+    String originFsUri = "hdfs://source.company.biz:2000";
+    String originPath = "/data/databases/source/profile";
+    when(originFs.getUri()).thenReturn(new URI(originFsUri));
+    when(originFs.getScheme()).thenReturn("hdfs");
+
+    FileSystem targetFs = mock(FileSystem.class);
+    String targetFsUri = "file:///";
+    String destinationPath = "/data/databases/destination/profile";
+    when(targetFs.getUri()).thenReturn(new URI(targetFsUri));
+    when(targetFs.getScheme()).thenReturn("file");
+    CopyConfiguration copyConfiguration = mock(CopyConfiguration.class);
+    when(copyConfiguration.getTargetFs()).thenReturn(targetFs);
+
+    // Test when source file is not a directory
+    FileStatus origin = new FileStatus(0l, false, 0, 0l, 0l, new Path(originPath));
+    CopyableFile copyableFile = new CopyableFile(origin, new Path(destinationPath), null, null, null,
+        PreserveAttributes.fromMnemonicString(""), "", 0, 0, Maps.<String, String>newHashMap(), "");
+    CopyableFile.setFsDatasets(copyableFile, originFs, copyConfiguration);
+    DatasetDescriptor source = copyableFile.getSourceDataset();
+    Assert.assertEquals(source.getName(), "/data/databases/source");
+    Assert.assertEquals(source.getPlatform(), "hdfs");
+    Assert.assertEquals(source.getMetadata().get("fsUri"), originFsUri);
+    DatasetDescriptor destination = copyableFile.getDestinationDataset();
+    Assert.assertEquals(destination.getName(), "/data/databases/destination");
+    Assert.assertEquals(destination.getPlatform(), "file");
+    Assert.assertEquals(destination.getMetadata().get("fsUri"), targetFsUri);
+
+    // Test when source file is a directory
+    originPath = originFsUri + originPath;
+    destinationPath = targetFsUri + destinationPath;
+    origin = new FileStatus(0l, true, 0, 0l, 0l, new Path(originPath));
+    copyableFile = new CopyableFile(origin, new Path(destinationPath), null, null, null,
+        PreserveAttributes.fromMnemonicString(""), "", 0, 0, Maps.<String, String>newHashMap(), "");
+    CopyableFile.setFsDatasets(copyableFile, originFs, copyConfiguration);
+    source = copyableFile.getSourceDataset();
+    Assert.assertEquals(source.getName(), "/data/databases/source/profile");
+    Assert.assertEquals(source.getPlatform(), "hdfs");
+    Assert.assertEquals(source.getMetadata().get("fsUri"), originFsUri);
+    destination = copyableFile.getDestinationDataset();
+    Assert.assertEquals(destination.getName(), "/data/databases/destination/profile");
+    Assert.assertEquals(destination.getPlatform(), "file");
+    Assert.assertEquals(destination.getMetadata().get("fsUri"), targetFsUri);
   }
 
 
@@ -200,7 +253,7 @@ public class CopyableFileTest {
 
     FileStatus fileStatus = new FileStatus(1, false, 0, 0, 0, 0, FsPermission.getDefault(), "owner", "group", path);
 
-    FileSystem fs = Mockito.mock(FileSystem.class);
+    FileSystem fs = mock(FileSystem.class);
     Mockito.doReturn(fileStatus).when(fs).getFileStatus(path);
     Mockito.doReturn(path).when(fs).makeQualified(path);
     Mockito.doReturn(new URI("hdfs://uri")).when(fs).getUri();

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/CopyableFileTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/CopyableFileTest.java
@@ -105,14 +105,12 @@ public class CopyableFileTest {
     String destinationPath = "/data/databases/destination/profile";
     when(targetFs.getUri()).thenReturn(new URI(targetFsUri));
     when(targetFs.getScheme()).thenReturn("file");
-    CopyConfiguration copyConfiguration = mock(CopyConfiguration.class);
-    when(copyConfiguration.getTargetFs()).thenReturn(targetFs);
 
     // Test when source file is not a directory
     FileStatus origin = new FileStatus(0l, false, 0, 0l, 0l, new Path(originPath));
     CopyableFile copyableFile = new CopyableFile(origin, new Path(destinationPath), null, null, null,
         PreserveAttributes.fromMnemonicString(""), "", 0, 0, Maps.<String, String>newHashMap(), "");
-    CopyableFile.setFsDatasets(copyableFile, originFs, copyConfiguration);
+    copyableFile.setFsDatasets(originFs, targetFs);
     DatasetDescriptor source = copyableFile.getSourceDataset();
     Assert.assertEquals(source.getName(), "/data/databases/source");
     Assert.assertEquals(source.getPlatform(), "hdfs");
@@ -128,7 +126,7 @@ public class CopyableFileTest {
     origin = new FileStatus(0l, true, 0, 0l, 0l, new Path(originPath));
     copyableFile = new CopyableFile(origin, new Path(destinationPath), null, null, null,
         PreserveAttributes.fromMnemonicString(""), "", 0, 0, Maps.<String, String>newHashMap(), "");
-    CopyableFile.setFsDatasets(copyableFile, originFs, copyConfiguration);
+    copyableFile.setFsDatasets(originFs, targetFs);
     source = copyableFile.getSourceDataset();
     Assert.assertEquals(source.getName(), "/data/databases/source/profile");
     Assert.assertEquals(source.getPlatform(), "hdfs");

--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/reporter/EventReporter.java
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/reporter/EventReporter.java
@@ -125,7 +125,7 @@ public abstract class EventReporter extends ScheduledReporter implements Closeab
     }
     try {
       if (!this.reportingQueue.offer(sanitizeEvent(event), 10, TimeUnit.SECONDS)) {
-        log.error("Enqueuing of event %s at reporter with class %s timed out. Sending of events is probably stuck.",
+        log.error("Enqueuing of event {} at reporter with class {} timed out. Sending of events is probably stuck.",
             event, this.getClass().getCanonicalName());
       }
     } catch (InterruptedException ie) {


### PR DESCRIPTION
Dear Gobblin maintainers,

### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/GOBBLIN-395


### Description
- [x] Here are some details about my PR:
  - Set file system based source and destination datasets for `CopyableFile`s of `ConfigBasedDataset`s

### Tests
- [x] My PR adds the following unit tests:
  - `CopyableFileTest#testSetFsDatasets`

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

