### PR TITLE
GOBBLIN-397: Create a new dataset version selection policy for filtering dataset versions that have "hidden" paths.

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/policy/HiddenFilterSelectionPolicy.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/policy/HiddenFilterSelectionPolicy.java
@@ -17,32 +17,33 @@
 
 package org.apache.gobblin.data.management.policy;
 
-import com.google.common.base.Predicate;
-import com.google.common.collect.Collections2;
-import com.google.common.collect.Lists;
-
-import com.typesafe.config.Config;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.gobblin.data.management.version.DatasetVersion;
-import org.apache.gobblin.data.management.version.FileSystemDatasetVersion;
 import org.apache.hadoop.fs.Path;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.Lists;
+import com.typesafe.config.Config;
+
+import org.apache.gobblin.data.management.version.FileSystemDatasetVersion;
+import org.apache.gobblin.util.ConfigUtils;
 
 
 /*
  * Select dataset versions that pass the hidden path filter i.e. accept paths that do not have sub-dirs whose names start with "." or "_".
  */
 public class HiddenFilterSelectionPolicy implements VersionSelectionPolicy<FileSystemDatasetVersion> {
-  public static final String HIDDEN_FILTER_HIDDEN_FILE_PREFIX_KEY="selection.hiddenFilter.hiddenFilePrefix";
-  public static final String[] DEFAULT_HIDDEN_FILE_PREFIXES = {".","_"};
+  public static final String HIDDEN_FILTER_HIDDEN_FILE_PREFIX_KEY = "selection.hiddenFilter.hiddenFilePrefix";
+  public static final String[] DEFAULT_HIDDEN_FILE_PREFIXES = {".", "_"};
   private List<String> hiddenFilePrefixes;
 
   public HiddenFilterSelectionPolicy(Config config) {
-    if(config.hasPath(HIDDEN_FILTER_HIDDEN_FILE_PREFIX_KEY)) {
-      this.hiddenFilePrefixes = config.getStringList(HIDDEN_FILTER_HIDDEN_FILE_PREFIX_KEY);
+    if (config.hasPath(HIDDEN_FILTER_HIDDEN_FILE_PREFIX_KEY)) {
+      this.hiddenFilePrefixes = ConfigUtils.getStringList(config, HIDDEN_FILTER_HIDDEN_FILE_PREFIX_KEY);
     } else {
       this.hiddenFilePrefixes = Arrays.asList(DEFAULT_HIDDEN_FILE_PREFIXES);
     }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/policy/HiddenFilterSelectionPolicy.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/policy/HiddenFilterSelectionPolicy.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.data.management.policy;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.Lists;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.gobblin.data.management.version.DatasetVersion;
+import org.apache.gobblin.data.management.version.FileSystemDatasetVersion;
+import org.apache.hadoop.fs.Path;
+
+
+/*
+ * Select dataset versions that pass the hidden path filter i.e. accept paths that do not have sub-dirs whose names start with "." or "_".
+ */
+public class HiddenFilterSelectionPolicy implements VersionSelectionPolicy<FileSystemDatasetVersion> {
+  private static final String[] HIDDEN_FILE_PREFIX = {"_", "."};
+
+  @Override
+  public Class<? extends DatasetVersion> versionClass() {
+    return DatasetVersion.class;
+  }
+
+  boolean isPathHidden(Path path) {
+    while (path != null) {
+      String name = path.getName();
+      for (String prefix : HIDDEN_FILE_PREFIX) {
+        if (name.startsWith(prefix)) {
+          return true;
+        }
+      }
+      path = path.getParent();
+    }
+    return false;
+  }
+
+  private Predicate<FileSystemDatasetVersion> getSelectionPredicate() {
+    return new Predicate<FileSystemDatasetVersion>() {
+      @Override
+      public boolean apply(FileSystemDatasetVersion version) {
+        Set<Path> paths = version.getPaths();
+        for (Path path : paths) {
+          Path p = path.getPathWithoutSchemeAndAuthority(path);
+          if (isPathHidden(p)) {
+            return false;
+          }
+        }
+        return true;
+      }
+    };
+  }
+
+  @Override
+  public Collection<FileSystemDatasetVersion> listSelectedVersions(List<FileSystemDatasetVersion> allVersions) {
+    return Lists.newArrayList(Collections2.filter(allVersions, getSelectionPredicate()));
+  }
+}

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/policy/HiddenFilterSelectionPolicy.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/policy/HiddenFilterSelectionPolicy.java
@@ -38,7 +38,7 @@ import org.apache.gobblin.util.ConfigUtils;
  */
 public class HiddenFilterSelectionPolicy implements VersionSelectionPolicy<FileSystemDatasetVersion> {
   public static final String HIDDEN_FILTER_HIDDEN_FILE_PREFIX_KEY = "selection.hiddenFilter.hiddenFilePrefix";
-  public static final String[] DEFAULT_HIDDEN_FILE_PREFIXES = {".", "_"};
+  private static final String[] DEFAULT_HIDDEN_FILE_PREFIXES = {".", "_"};
   private List<String> hiddenFilePrefixes;
 
   public HiddenFilterSelectionPolicy(Config config) {

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/policy/HiddenFilterSelectionPolicyTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/policy/HiddenFilterSelectionPolicyTest.java
@@ -17,23 +17,12 @@
 
 package org.apache.gobblin.data.management.policy;
 
-import com.google.common.collect.ImmutableMap;
-
-import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
-import lombok.extern.slf4j.Slf4j;
-
-import org.apache.gobblin.data.management.version.FileSystemDatasetVersion;
-import org.apache.gobblin.data.management.version.TimestampedDatasetVersion;
-import org.apache.hadoop.fs.Path;
 
 import org.joda.time.DateTime;
 
@@ -42,8 +31,16 @@ import org.testng.annotations.Test;
 
 import static org.testng.Assert.*;
 
+import com.google.common.collect.ImmutableMap;
 
-@Slf4j
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+import org.apache.gobblin.data.management.version.FileSystemDatasetVersion;
+import org.apache.gobblin.data.management.version.TimestampedDatasetVersion;
+import org.apache.hadoop.fs.Path;
+
+
 public class HiddenFilterSelectionPolicyTest {
   @Test
   public void testListSelectedVersions() throws Exception {
@@ -62,15 +59,22 @@ public class HiddenFilterSelectionPolicyTest {
     versionList.add(new TimestampedDatasetVersion(new DateTime(), path4));
 
     List<String> hiddenFilePrefixes = Arrays.asList("_", ".");
-    Config config = ConfigFactory.parseMap(
+    List<Config> configList = new ArrayList<>();
+    Config config1 = ConfigFactory.parseMap(
         ImmutableMap.of(HiddenFilterSelectionPolicy.HIDDEN_FILTER_HIDDEN_FILE_PREFIX_KEY, hiddenFilePrefixes));
-    HiddenFilterSelectionPolicy policy = new HiddenFilterSelectionPolicy(config);
-    Collection<FileSystemDatasetVersion> selectedVersions = policy.listSelectedVersions(versionList);
-    Assert.assertEquals(selectedVersions.size(), 2);
-    for (FileSystemDatasetVersion version : selectedVersions) {
-      Set<Path> paths = version.getPaths();
-      for (Path path : paths) {
-        Assert.assertTrue(pathSet.contains(path.toString()));
+    configList.add(config1);
+    Config config2 = ConfigFactory.parseMap(
+        ImmutableMap.of(HiddenFilterSelectionPolicy.HIDDEN_FILTER_HIDDEN_FILE_PREFIX_KEY, "_,."));
+    configList.add(config2);
+    for (Config config : configList) {
+      HiddenFilterSelectionPolicy policy = new HiddenFilterSelectionPolicy(config);
+      Collection<FileSystemDatasetVersion> selectedVersions = policy.listSelectedVersions(versionList);
+      Assert.assertEquals(selectedVersions.size(), 2);
+      for (FileSystemDatasetVersion version : selectedVersions) {
+        Set<Path> paths = version.getPaths();
+        for (Path path : paths) {
+          Assert.assertTrue(pathSet.contains(path.toString()));
+        }
       }
     }
   }

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/policy/HiddenFilterSelectionPolicyTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/policy/HiddenFilterSelectionPolicyTest.java
@@ -17,7 +17,13 @@
 
 package org.apache.gobblin.data.management.policy;
 
+import com.google.common.collect.ImmutableMap;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -48,11 +54,17 @@ public class HiddenFilterSelectionPolicyTest {
     Path path2 = new Path("/data/dataset/versions/version2");
     pathSet.add(path2.toString());
     Path path3 = new Path("/data/dataset/.temp/tmpPath");
+    Path path4 = new Path("/data/dataset/_temp/tmpPath");
+
     versionList.add(new TimestampedDatasetVersion(new DateTime(), path1));
     versionList.add(new TimestampedDatasetVersion(new DateTime(), path2));
     versionList.add(new TimestampedDatasetVersion(new DateTime(), path3));
+    versionList.add(new TimestampedDatasetVersion(new DateTime(), path4));
 
-    HiddenFilterSelectionPolicy policy = new HiddenFilterSelectionPolicy();
+    List<String> hiddenFilePrefixes = Arrays.asList("_", ".");
+    Config config = ConfigFactory.parseMap(
+        ImmutableMap.of(HiddenFilterSelectionPolicy.HIDDEN_FILTER_HIDDEN_FILE_PREFIX_KEY, hiddenFilePrefixes));
+    HiddenFilterSelectionPolicy policy = new HiddenFilterSelectionPolicy(config);
     Collection<FileSystemDatasetVersion> selectedVersions = policy.listSelectedVersions(versionList);
     Assert.assertEquals(selectedVersions.size(), 2);
     for (FileSystemDatasetVersion version : selectedVersions) {

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/policy/HiddenFilterSelectionPolicyTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/policy/HiddenFilterSelectionPolicyTest.java
@@ -24,21 +24,17 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.hadoop.fs.Path;
 import org.joda.time.DateTime;
-
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.*;
-
 import com.google.common.collect.ImmutableMap;
-
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
 import org.apache.gobblin.data.management.version.FileSystemDatasetVersion;
 import org.apache.gobblin.data.management.version.TimestampedDatasetVersion;
-import org.apache.hadoop.fs.Path;
 
 
 public class HiddenFilterSelectionPolicyTest {

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/policy/HiddenFilterSelectionPolicyTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/policy/HiddenFilterSelectionPolicyTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.data.management.policy;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.gobblin.data.management.version.FileSystemDatasetVersion;
+import org.apache.gobblin.data.management.version.TimestampedDatasetVersion;
+import org.apache.hadoop.fs.Path;
+
+import org.joda.time.DateTime;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+@Slf4j
+public class HiddenFilterSelectionPolicyTest {
+  @Test
+  public void testListSelectedVersions() throws Exception {
+    List<FileSystemDatasetVersion> versionList = new ArrayList<>();
+    Set<String> pathSet = new HashSet<>();
+    Path path1 = new Path("/data/dataset/versions/version1");
+    pathSet.add(path1.toString());
+    Path path2 = new Path("/data/dataset/versions/version2");
+    pathSet.add(path2.toString());
+    Path path3 = new Path("/data/dataset/.temp/tmpPath");
+    versionList.add(new TimestampedDatasetVersion(new DateTime(), path1));
+    versionList.add(new TimestampedDatasetVersion(new DateTime(), path2));
+    versionList.add(new TimestampedDatasetVersion(new DateTime(), path3));
+
+    HiddenFilterSelectionPolicy policy = new HiddenFilterSelectionPolicy();
+    Collection<FileSystemDatasetVersion> selectedVersions = policy.listSelectedVersions(versionList);
+    Assert.assertEquals(selectedVersions.size(), 2);
+    for (FileSystemDatasetVersion version : selectedVersions) {
+      Set<Path> paths = version.getPaths();
+      for (Path path : paths) {
+        Assert.assertTrue(pathSet.contains(path.toString()));
+      }
+    }
+  }
+}


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-397


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
We need the ability to filter out dataset versions that represent "hidden" paths i.e. paths which contain directories that start with "." or "_" (e.g. /data/logs/_temp/2018/01/01).

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  - Added unit tests for the new version selection policy.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

