### PR TITLE
GOBBLIN-401: Provide a constructor for CombineSelectionPolicy with only the selection config as argument

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/policy/CombineSelectionPolicy.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/policy/CombineSelectionPolicy.java
@@ -71,12 +71,16 @@ public class CombineSelectionPolicy implements VersionSelectionPolicy<DatasetVer
   public static final String VERSION_SELECTION_COMBINE_OPERATION = "selection.combine.operation";
 
   public enum CombineOperation {
-    INTERSECT,
-    UNION
+    INTERSECT, UNION
   }
 
   private final List<VersionSelectionPolicy<DatasetVersion>> selectionPolicies;
   private final CombineOperation combineOperation;
+
+  public CombineSelectionPolicy(Config config)
+      throws IOException {
+    this(config, new Properties());
+  }
 
   public CombineSelectionPolicy(List<VersionSelectionPolicy<DatasetVersion>> selectionPolicies,
       CombineOperation combineOperation) {
@@ -85,17 +89,18 @@ public class CombineSelectionPolicy implements VersionSelectionPolicy<DatasetVer
   }
 
   @SuppressWarnings("unchecked")
-  public CombineSelectionPolicy(Config config, Properties jobProps) throws IOException {
+  public CombineSelectionPolicy(Config config, Properties jobProps)
+      throws IOException {
     Preconditions.checkArgument(config.hasPath(VERSION_SELECTION_POLICIES_PREFIX), "Combine operation not specified.");
 
     ImmutableList.Builder<VersionSelectionPolicy<DatasetVersion>> builder = ImmutableList.builder();
 
     for (String combineClassName : config.getStringList(VERSION_SELECTION_POLICIES_PREFIX)) {
       try {
-        builder.add((VersionSelectionPolicy<DatasetVersion>) GobblinConstructorUtils.invokeFirstConstructor(
-            Class.forName(combineClassName), ImmutableList.<Object> of(config), ImmutableList.<Object> of(jobProps)));
-      } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException | InstantiationException
-          | ClassNotFoundException e) {
+        builder.add((VersionSelectionPolicy<DatasetVersion>) GobblinConstructorUtils
+            .invokeFirstConstructor(Class.forName(combineClassName), ImmutableList.<Object>of(config),
+                ImmutableList.<Object>of(jobProps)));
+      } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException | InstantiationException | ClassNotFoundException e) {
         throw new IllegalArgumentException(e);
       }
     }
@@ -109,9 +114,9 @@ public class CombineSelectionPolicy implements VersionSelectionPolicy<DatasetVer
         CombineOperation.valueOf(config.getString(VERSION_SELECTION_COMBINE_OPERATION).toUpperCase());
   }
 
-  public CombineSelectionPolicy(Properties props) throws IOException {
+  public CombineSelectionPolicy(Properties props)
+      throws IOException {
     this(ConfigFactory.parseProperties(props), props);
-
   }
 
   /**
@@ -150,7 +155,6 @@ public class CombineSelectionPolicy implements VersionSelectionPolicy<DatasetVer
       default:
         throw new RuntimeException("Combine operation " + this.combineOperation + " not recognized.");
     }
-
   }
 
   @VisibleForTesting


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-401


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
When CombineSelectionPolicy is used as a selection policy class with ConfigBasedDatasetFinder, there is no constructor with appropriate signature for instantiation from ReplicationValidPathPicker class and we get an exception like the following:

java.lang.IllegalArgumentException: java.lang.NoSuchMethodException: No such accessible constructor on object: org.apache.gobblin.data.management.policy.CombineSelectionPolicy

We need to provide a constructor for CombineSelectionPolicy with only the selection config as an argument. 

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Not applicable.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

