### PR TITLE
[GOBBLIN-403] Fix the NPE issue due to uninitialized kafkajobmonitor metrics 

### DIFF
--- a/gobblin-modules/gobblin-service-kafka/src/main/java/org/apache/gobblin/service/StreamingKafkaSpecConsumer.java
+++ b/gobblin-modules/gobblin-service-kafka/src/main/java/org/apache/gobblin/service/StreamingKafkaSpecConsumer.java
@@ -203,6 +203,8 @@ public class StreamingKafkaSpecConsumer extends AbstractIdleService implements S
     private ContextAwareGauge<Long> jobSpecEnq;
     private ContextAwareGauge<Long> jobSpecDeq;
     private ContextAwareGauge<Long> jobSpecConsumed;
+    private ContextAwareGauge<Long> jobSpecParseFailures;
+
     private AtomicLong jobSpecEnqCount = new AtomicLong(0);
     private AtomicLong jobSpecDeqCount = new AtomicLong(0);
 
@@ -210,14 +212,30 @@ public class StreamingKafkaSpecConsumer extends AbstractIdleService implements S
     public static final String SPEC_CONSUMER_JOB_SPEC_ENQ = "specConsumerJobSpecEnq";
     public static final String SPEC_CONSUMER_JOB_SPEC_DEQ = "specConsumerJobSpecDeq";
     public static final String SPEC_CONSUMER_JOB_SPEC_CONSUMED = "specConsumerJobSpecConsumed";
-
+    public static final String SPEC_CONSUMER_JOB_SPEC_PARSE_FAILURES = "specConsumerJobSpecParseFailures";
 
     public Metrics(MetricContext context) {
       this.jobSpecQueueSize = context.newContextAwareGauge(SPEC_CONSUMER_JOB_SPEC_QUEUE_SIZE, ()->StreamingKafkaSpecConsumer.this._jobSpecQueue.size());
       this.jobSpecEnq = context.newContextAwareGauge(SPEC_CONSUMER_JOB_SPEC_ENQ, ()->jobSpecEnqCount.get());
       this.jobSpecDeq = context.newContextAwareGauge(SPEC_CONSUMER_JOB_SPEC_DEQ, ()->jobSpecDeqCount.get());
       this.jobSpecConsumed = context.newContextAwareGauge(SPEC_CONSUMER_JOB_SPEC_CONSUMED,
-          ()->StreamingKafkaSpecConsumer.this._jobMonitor.getNewSpecs().getCount() + StreamingKafkaSpecConsumer.this._jobMonitor.getRemmovedSpecs().getCount());
+          ()->getNewSpecs() + getRemovedSpecs() + getMessageParseFailures());
+      this.jobSpecParseFailures = context.newContextAwareGauge(SPEC_CONSUMER_JOB_SPEC_PARSE_FAILURES, ()->getMessageParseFailures());
+    }
+
+    private long getNewSpecs() {
+      return StreamingKafkaSpecConsumer.this._jobMonitor.getNewSpecs() != null?
+          StreamingKafkaSpecConsumer.this._jobMonitor.getNewSpecs().getCount() : 0;
+    }
+
+    private long getRemovedSpecs() {
+      return StreamingKafkaSpecConsumer.this._jobMonitor.getRemmovedSpecs() != null?
+          StreamingKafkaSpecConsumer.this._jobMonitor.getRemmovedSpecs().getCount() : 0;
+    }
+
+    private long getMessageParseFailures() {
+      return StreamingKafkaSpecConsumer.this._jobMonitor.getMessageParseFailures() != null?
+          StreamingKafkaSpecConsumer.this._jobMonitor.getMessageParseFailures().getCount():0;
     }
 
     public Collection<ContextAwareGauge<?>> getGauges() {
@@ -226,13 +244,14 @@ public class StreamingKafkaSpecConsumer extends AbstractIdleService implements S
       list.add(jobSpecEnq);
       list.add(jobSpecDeq);
       list.add(jobSpecConsumed);
+      list.add(jobSpecParseFailures);
       return list;
     }
   }
 
   @Override
   public StandardMetrics getStandardMetrics() {
-    throw new UnsupportedOperationException("Implemented in sub class");
+    return this._metrics;
   }
 
   @Nonnull


### PR DESCRIPTION
Fix the NPE issue due to uninitialized kafkajobmonitor metrics 

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-403] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-403


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
  Fix the NPE issue due to uninitialized kafkajobmonitor metrics.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
   Cluster integration test

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

