### PR TITLE
[GOBBLIN-405] Fix race condition with access to immediately invalidat…

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/broker/ResourceEntry.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/broker/ResourceEntry.java
@@ -44,4 +44,21 @@ public interface ResourceEntry<T> extends SharedResourceFactoryResponse<T> {
    * key, blocking all requests for that key. As suck, this method should be reasonably fast.
    */
   void onInvalidate();
+
+  /**
+   * This method should guarantee that if all callers accessing the resource using this method then the object is
+   * returned atomically with respect to any validity state change.
+   *
+   * This is to avoid race conditions in cases where the state is changed when getting the resource. Some examples are
+   * resources that can only be used a certain number of times.
+   *
+   * @return null if the object is not valid, otherwise the valid object
+   */
+  default T getResourceIfValid() {
+    if (isValid()) {
+      return getResource();
+    } else {
+      return null;
+    }
+  }
 }

--- a/gobblin-utility/src/main/java/org/apache/gobblin/broker/ImmediatelyInvalidResourceEntry.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/broker/ImmediatelyInvalidResourceEntry.java
@@ -36,7 +36,7 @@ public class ImmediatelyInvalidResourceEntry<T> extends ResourceInstance<T> {
   }
 
   @Override
-  public T getResource() {
+  public synchronized T getResource() {
     // mark the object as invalid before returning so that a new one will be created on the next
     // request from the factory
     this.valid = false;
@@ -52,5 +52,18 @@ public class ImmediatelyInvalidResourceEntry<T> extends ResourceInstance<T> {
   @Override
   public void onInvalidate() {
     // these type of resource cannot be closed on invalidation since the lifetime can't be determined
+  }
+
+  /**
+   * This method is synchronized so that the validity check and validity change is atomic for callers of this method.
+   * @return
+   */
+  @Override
+  public synchronized T getResourceIfValid() {
+    if (this.valid) {
+      return getResource();
+    } else {
+      return null;
+    }
   }
 }


### PR DESCRIPTION
…ed resources

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-405


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
There are race conditions in the retrieval of immediately invalidate resources from the SharedResourcesBroker. This can result in an object being returned multiple times even though it should only be returned once. It can also result in valid objects being invalidated before a thread picks it up and it can also result in stack overflow due to a thread starving and retrying many times.

The fix introduces ResourceEntry#getResourceIfValid() to atomically get the resource if it is valid. A null is returned for invalid objects. The recursion in DefaultBrokerCache#getScoped() was replaced with iteration to avoid stack overflow and a lock was added to minimize retries.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

