### PR TITLE
[GOBBLIN-98] Orc records get dropped and duplicated

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/converter/serde/OrcSerDeWrapper.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/converter/serde/OrcSerDeWrapper.java
@@ -25,7 +25,7 @@ import java.util.ArrayList;
 
 /**
  * The Hive's {@link OrcSerde} caches converted records - the {@link OrcSerde} has a single
- * {@link org.apache.hadoop.hive.ql.io.orc.OrcSerde.OrcSerdeRow} (basically an {@link ArrayList}) and every time the
+ * {@link org.apache.hadoop.hive.ql.io.orc.OrcSerde.OrcSerdeRow} and every time the
  * {@link org.apache.hadoop.hive.serde2.Serializer#serialize(Object, ObjectInspector)} method is called, the object is
  * re-used.
  *
@@ -37,13 +37,11 @@ import java.util.ArrayList;
  * @author Prateek Gupta
  */
 
-    public class OrcSerDeWrapper extends OrcSerde {
-    private OrcSerde record = null;
+public class OrcSerDeWrapper extends OrcSerde {
 
-    @Override
-    public Writable serialize(Object realRow, ObjectInspector inspector) {
-        record = new OrcSerde();
-        Object realRowClone = ((ArrayList) realRow).clone();
-        return record.serialize(realRowClone, inspector);
-    }
+  @Override
+  public Writable serialize(Object realRow, ObjectInspector inspector) {
+      Object realRowClone = ObjectInspectorUtils.copyToStandardObject(realRow, inspector);
+      return super.serialize(realRowClone, inspector);
+  }
 }

--- a/gobblin-core/src/main/java/org/apache/gobblin/converter/serde/OrcSerDeWrapper.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/converter/serde/OrcSerDeWrapper.java
@@ -19,6 +19,7 @@ package gobblin.converter.serde;
 
 import org.apache.hadoop.hive.ql.io.orc.OrcSerde;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils;
 import org.apache.hadoop.io.Writable;
 
 import java.util.ArrayList;

--- a/gobblin-core/src/main/java/org/apache/gobblin/converter/serde/OrcSerDeWrapper.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/converter/serde/OrcSerDeWrapper.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.converter.serde;
+
+import org.apache.hadoop.hive.ql.io.orc.OrcSerde;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.io.Writable;
+
+import java.util.ArrayList;
+
+/**
+ * The Hive's {@link OrcSerde} caches converted records - the {@link OrcSerde} has a single
+ * {@link org.apache.hadoop.hive.ql.io.orc.OrcSerde.OrcSerdeRow} (basically an {@link ArrayList}) and every time the
+ * {@link org.apache.hadoop.hive.serde2.Serializer#serialize(Object, ObjectInspector)} method is called, the object is
+ * re-used.
+ *
+ * The problem is that {@link org.apache.hadoop.hive.ql.io.orc.OrcSerde.OrcSerdeRow} is package protected and has no
+ * public constructor, so no copy can be made. This would be fine if {@link org.apache.hadoop.hive.ql.io.orc.OrcSerde.OrcSerdeRow}
+ * is immediately written out. But all Gobblin jobs have a buffer that the writer reads from. This buffering can cause
+ * race conditions where records get dropped and duplicated.
+ *
+ * @author Prateek Gupta
+ */
+
+    public class OrcSerDeWrapper extends OrcSerde {
+    private OrcSerde record = null;
+
+    @Override
+    public Writable serialize(Object realRow, ObjectInspector inspector) {
+        record = new OrcSerde();
+        Object realRowClone = ((ArrayList) realRow).clone();
+        return record.serialize(realRowClone, inspector);
+    }
+}

--- a/gobblin-core/src/test/resources/serde/serde.properties
+++ b/gobblin-core/src/test/resources/serde/serde.properties
@@ -17,7 +17,9 @@
 
 avro.schema.url=gobblin-core/src/test/resources/serde/serde.avsc
 source.hadoop.file.input.paths=gobblin-core/src/test/resources/serde/serde.avro
-serde.serializer.type=ORC
+serde.serializer.type=gobblin.converter.serde.OrcSerDeWrapper
+serde.serializer.input.format.type=org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+serde.serializer.output.format.type=org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
 serde.deserializer.type=AVRO
 writer.staging.dir=gobblin-core/src/test/resources/serde/output-staging
 writer.output.dir=gobblin-core/src/test/resources/serde/output


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/GOBBLIN-98


### Description
- [ ] Here are some details about my PR:
        The Hive's OrcSerde caches converted records - the OrcSerde has a single 
        org.apache.hadoop.hive.ql.io.orc.OrcSerde.OrcSerdeRow (basically an ArrayList) and every 
        time the org.apache.hadoop.hive.serde2.Serializer#serialize(Object, ObjectInspector) method 
        is called, the object is re-used.
        The problem is that org.apache.hadoop.hive.ql.io.orc.OrcSerde.OrcSerdeRow is package 
        protected and has no public constructor, so no copy can be made. This would be fine if 
        org.apache.hadoop.hive.ql.io.orc.OrcSerde.OrcSerdeRow is immediately written out. But all 
        Gobblin jobs have a buffer that the writer reads from. This buffering can cause race conditions 
        where records get dropped and duplicated.

### Tests
- [ ] My PR adds the following unit tests:
    - gobblin-core/src/test/java/gobblin/serde/HiveSerDeTest.java

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

