### PR TITLE
[GOBBLIN-407] fix job output path for full snapshot

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/WorkUnitState.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/WorkUnitState.java
@@ -62,6 +62,10 @@ public class WorkUnitState extends State {
 
   private static final Gson GSON = new Gson();
 
+  public String getOutputFilePath() {
+    return this.workUnit.getOutputFilePath();
+  }
+
   /**
    * Runtime state of the {@link WorkUnit}.
    *

--- a/gobblin-api/src/main/java/org/apache/gobblin/source/workunit/Extract.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/source/workunit/Extract.java
@@ -137,7 +137,9 @@ public class Extract extends State {
    * Get the writer output file path corresponding to this {@link Extract}.
    *
    * @return writer output file path corresponding to this {@link Extract}
+   * @deprecated As {@code this.getIsFull} is deprecated.
    */
+  @Deprecated
   public String getOutputFilePath() {
     return this.getNamespace().replaceAll("\\.", "/") + "/" + this.getTable() + "/" + this.getExtractId() + "_"
         + (this.getIsFull() ? "full" : "append");

--- a/gobblin-api/src/main/java/org/apache/gobblin/source/workunit/WorkUnit.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/source/workunit/WorkUnit.java
@@ -311,11 +311,7 @@ public class WorkUnit extends State {
 
   @Override
   public String getProp(String key) {
-    String value = super.getProp(key);
-    if (value == null) {
-      value = this.extract.getProp(key);
-    }
-    return value;
+    return getProp(key, null);
   }
 
   @Override
@@ -370,9 +366,14 @@ public class WorkUnit extends State {
   }
 
   public String getOutputFilePath() {
-    String namespace = getProp(ConfigurationKeys.EXTRACT_NAMESPACE_NAME_KEY, "");
-    String table = getProp(ConfigurationKeys.EXTRACT_TABLE_NAME_KEY, "");
-    String extractId = getProp(ConfigurationKeys.EXTRACT_EXTRACT_ID_KEY, "");
+    // Search for the properties in the workunit.
+    // This search for the property first in State and then in the Extract of this workunit.
+    getProp(ConfigurationKeys.EXTRACT_IS_FULL_KEY);
+    String namespace = getProp(ConfigurationKeys.EXTRACT_NAMESPACE_NAME_KEY);
+    String table = getProp(ConfigurationKeys.EXTRACT_TABLE_NAME_KEY);
+    String extractId = getProp(ConfigurationKeys.EXTRACT_EXTRACT_ID_KEY);
+    // getPropAsBoolean and other similar methods are not overridden in WorkUnit class
+    // Thus, to enable searching in WorkUnit's Extract, we use getProp, and not getPropAsBoolean
     boolean isFull =  Boolean.parseBoolean(getProp(ConfigurationKeys.EXTRACT_IS_FULL_KEY));
 
     return namespace.replaceAll("\\.", "/") + "/" + table + "/" + extractId + "_"

--- a/gobblin-api/src/main/java/org/apache/gobblin/source/workunit/WorkUnit.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/source/workunit/WorkUnit.java
@@ -318,6 +318,15 @@ public class WorkUnit extends State {
     return value;
   }
 
+  @Override
+  public String getProp(String key, String def) {
+    String value = super.getProp(key);
+    if (value == null) {
+      value = this.extract.getProp(key, def);
+    }
+    return value;
+  }
+
   /**
    * Set the low watermark of this {@link WorkUnit}.
    *
@@ -358,5 +367,15 @@ public class WorkUnit extends State {
     int result = super.hashCode();
     result = prime * result + ((this.extract == null) ? 0 : this.extract.hashCode());
     return result;
+  }
+
+  public String getOutputFilePath() {
+    String namespace = getProp(ConfigurationKeys.EXTRACT_NAMESPACE_NAME_KEY, "");
+    String table = getProp(ConfigurationKeys.EXTRACT_TABLE_NAME_KEY, "");
+    String extractId = getProp(ConfigurationKeys.EXTRACT_EXTRACT_ID_KEY, "");
+    boolean isFull =  Boolean.parseBoolean(getProp(ConfigurationKeys.EXTRACT_IS_FULL_KEY));
+
+    return namespace.replaceAll("\\.", "/") + "/" + table + "/" + extractId + "_"
+        + (isFull ? "full" : "append");
   }
 }

--- a/gobblin-api/src/main/java/org/apache/gobblin/source/workunit/WorkUnit.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/source/workunit/WorkUnit.java
@@ -368,10 +368,9 @@ public class WorkUnit extends State {
   public String getOutputFilePath() {
     // Search for the properties in the workunit.
     // This search for the property first in State and then in the Extract of this workunit.
-    getProp(ConfigurationKeys.EXTRACT_IS_FULL_KEY);
-    String namespace = getProp(ConfigurationKeys.EXTRACT_NAMESPACE_NAME_KEY);
-    String table = getProp(ConfigurationKeys.EXTRACT_TABLE_NAME_KEY);
-    String extractId = getProp(ConfigurationKeys.EXTRACT_EXTRACT_ID_KEY);
+    String namespace = getProp(ConfigurationKeys.EXTRACT_NAMESPACE_NAME_KEY, "");
+    String table = getProp(ConfigurationKeys.EXTRACT_TABLE_NAME_KEY, "");
+    String extractId = getProp(ConfigurationKeys.EXTRACT_EXTRACT_ID_KEY, "");
     // getPropAsBoolean and other similar methods are not overridden in WorkUnit class
     // Thus, to enable searching in WorkUnit's Extract, we use getProp, and not getPropAsBoolean
     boolean isFull =  Boolean.parseBoolean(getProp(ConfigurationKeys.EXTRACT_IS_FULL_KEY));

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/WriterUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/WriterUtils.java
@@ -211,8 +211,6 @@ public class WriterUtils {
       WorkUnitState workUnitState = (WorkUnitState) state;
       return new Path(ForkOperatorUtils.getPathForBranch(workUnitState, workUnitState.getOutputFilePath(),
           numBranches, branchId));
-
-
     } else if (state instanceof WorkUnit) {
       WorkUnit workUnit = (WorkUnit) state;
       return new Path(ForkOperatorUtils.getPathForBranch(workUnit, workUnit.getOutputFilePath(),

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/WriterUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/WriterUtils.java
@@ -209,12 +209,13 @@ public class WriterUtils {
   public static Path getDefaultWriterFilePath(State state, int numBranches, int branchId) {
     if (state instanceof WorkUnitState) {
       WorkUnitState workUnitState = (WorkUnitState) state;
-      return new Path(ForkOperatorUtils.getPathForBranch(workUnitState, workUnitState.getExtract().getOutputFilePath(),
+      return new Path(ForkOperatorUtils.getPathForBranch(workUnitState, workUnitState.getOutputFilePath(),
           numBranches, branchId));
+
 
     } else if (state instanceof WorkUnit) {
       WorkUnit workUnit = (WorkUnit) state;
-      return new Path(ForkOperatorUtils.getPathForBranch(workUnit, workUnit.getExtract().getOutputFilePath(),
+      return new Path(ForkOperatorUtils.getPathForBranch(workUnit, workUnit.getOutputFilePath(),
           numBranches, branchId));
     }
 


### PR DESCRIPTION
fix job output path for full snapshot

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below! @htran1 please review.


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-407


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
If the property 'extract.is.full' is set to true, job output should be written to _full directories. This stopped happening since changes in https://github.com/apache/incubator-gobblin/commit/df75b13e1f7ee5776ed18b7aade9014fae8deeea were pushed in, because it made it to ignore this property by not including it while creating 'Extract'.

In this PR, I moved the logic of finding output directory name from Extract to WorkUnitState, as Extract:getIsFull() is marked as deprecated.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
test case already present

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

