### PR TITLE
[GOBBLIN-409] Set collation to latin1_bin for the MySql state store b…

### DIFF
--- a/gobblin-metastore/src/main/java/org/apache/gobblin/metastore/MysqlStateStore.java
+++ b/gobblin-metastore/src/main/java/org/apache/gobblin/metastore/MysqlStateStore.java
@@ -101,8 +101,8 @@ public class MysqlStateStore<T extends State> implements StateStore<T> {
 
   // MySQL key length limit is 767 bytes
   private static final String CREATE_JOB_STATE_TABLE_TEMPLATE =
-      "CREATE TABLE IF NOT EXISTS $TABLE$ (store_name varchar(100) CHARACTER SET latin1 not null,"
-          + "table_name varchar(667) CHARACTER SET latin1 not null,"
+      "CREATE TABLE IF NOT EXISTS $TABLE$ (store_name varchar(100) CHARACTER SET latin1 COLLATE latin1_bin not null,"
+          + "table_name varchar(667) CHARACTER SET latin1 COLLATE latin1_bin not null,"
           + " modified_time timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,"
           + " state longblob, primary key(store_name, table_name))";
 


### PR DESCRIPTION
…acking table

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-409


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):


### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
The default MySQL collation is case insensitive. Explicitly set the collation to be case sensitive to avoid jobs and datasets that only differ in case from overwriting each other's states.

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

