### PR TITLE
GOBBLIN-415: Check for the value of configuration key flow.runImmediately in Job config.

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobScheduler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobScheduler.java
@@ -28,6 +28,7 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.gobblin.util.PropertiesUtils;
 import org.apache.helix.HelixManager;
 import org.apache.helix.InstanceType;
 import org.quartz.DisallowConcurrentExecution;
@@ -222,7 +223,7 @@ public class GobblinServiceJobScheduler extends JobScheduler implements SpecCata
         if (jobConfig.containsKey(ConfigurationKeys.JOB_SCHEDULE_KEY)) {
           _log.info("Scheduling flow spec: " + addedSpec);
           scheduleJob(jobConfig, null);
-          if (jobConfig.containsKey(ConfigurationKeys.FLOW_RUN_IMMEDIATELY)) {
+          if (PropertiesUtils.getPropAsBoolean(jobConfig, ConfigurationKeys.FLOW_RUN_IMMEDIATELY, "false")) {
             _log.info("RunImmediately requested, hence executing FlowSpec: " + addedSpec);
             this.jobExecutor.execute(new NonScheduledJobRunner(jobConfig, null));
           }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobScheduler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobScheduler.java
@@ -28,7 +28,6 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.gobblin.util.PropertiesUtils;
 import org.apache.helix.HelixManager;
 import org.apache.helix.InstanceType;
 import org.quartz.DisallowConcurrentExecution;
@@ -62,6 +61,7 @@ import org.apache.gobblin.service.modules.utils.HelixUtils;
 import org.apache.gobblin.service.ServiceConfigKeys;
 import org.apache.gobblin.service.modules.orchestration.Orchestrator;
 import org.apache.gobblin.util.ConfigUtils;
+import org.apache.gobblin.util.PropertiesUtils;
 
 
 /**


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-415


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
GobblinServiceJobScheduler checks for the existence of the Config Key "flow.runImmediately" instead of its boolean value in deciding whether to schedule a flow for execution. We need to modify this behavior to check for the actual value of the config key provided in the job config.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  Change is trivial and ran clean build with unit tests. Also tested the change in local set up by restarting gobblin-service.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

