### PR TITLE
[GOBBLIN-421] Add parameterized type for Pusher message type

### DIFF
--- a/gobblin-modules/gobblin-kafka-08/src/main/java/org/apache/gobblin/metrics/kafka/KafkaProducerPusher.java
+++ b/gobblin-modules/gobblin-kafka-08/src/main/java/org/apache/gobblin/metrics/kafka/KafkaProducerPusher.java
@@ -37,7 +37,7 @@ import org.apache.gobblin.util.ConfigUtils;
 /**
  * Establishes a connection to a Kafka cluster and push byte messages to a specified topic.
  */
-public class KafkaProducerPusher implements Pusher {
+public class KafkaProducerPusher implements Pusher<byte[]> {
 
   private final String topic;
   private final KafkaProducer<String, byte[]> producer;

--- a/gobblin-modules/gobblin-kafka-08/src/main/java/org/apache/gobblin/metrics/kafka/KafkaPusher.java
+++ b/gobblin-modules/gobblin-kafka-08/src/main/java/org/apache/gobblin/metrics/kafka/KafkaPusher.java
@@ -33,7 +33,7 @@ import kafka.producer.ProducerConfig;
 /**
  * Establishes a connection to a Kafka cluster and pushed byte messages to a specified topic.
  */
-public class KafkaPusher implements Pusher {
+public class KafkaPusher implements Pusher<byte[]> {
 
   private final String topic;
   private final ProducerCloseable<String, byte[]> producer;

--- a/gobblin-modules/gobblin-kafka-09/src/main/java/org/apache/gobblin/metrics/kafka/KafkaProducerPusher.java
+++ b/gobblin-modules/gobblin-kafka-09/src/main/java/org/apache/gobblin/metrics/kafka/KafkaProducerPusher.java
@@ -37,7 +37,7 @@ import org.apache.gobblin.util.ConfigUtils;
 /**
  * Establish a connection to a Kafka cluster and push byte messages to a specified topic.
  */
-public class KafkaProducerPusher implements Pusher {
+public class KafkaProducerPusher implements Pusher<byte[]> {
 
   private final String topic;
   private final KafkaProducer<String, byte[]> producer;

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/metrics/kafka/LoggingPusher.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/metrics/kafka/LoggingPusher.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gobblin.metrics.kafka;
+
+import java.io.IOException;
+import java.util.List;
+
+import com.google.common.base.Optional;
+import com.typesafe.config.Config;
+
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.util.ConfigUtils;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * This is a {@Pusher} class that logs the messages
+ * @param <M> message type
+ */
+@Slf4j
+public class LoggingPusher<M> implements Pusher<M> {
+  private final String brokers;
+  private final String topic;
+  private static final String KAFKA_TOPIC = "kafka.topic";
+  private static final String NO_BROKERS = "NoBrokers";
+  private static final String NO_TOPIC = "NoTopic";
+
+  public LoggingPusher() {
+    this(NO_BROKERS, NO_TOPIC, Optional.absent());
+  }
+
+  public LoggingPusher(Config config) {
+    this.brokers = ConfigUtils.getString(config, ConfigurationKeys.KAFKA_BROKERS, NO_BROKERS);
+    this.topic = ConfigUtils.getString(config, KAFKA_TOPIC, NO_TOPIC);
+  }
+
+  /**
+   * Constructor like the one in KafkaProducerPusher for compatibility
+   */
+  public LoggingPusher(String brokers, String topic, Optional<Config> kafkaConfig) {
+    this.brokers = brokers;
+    this.topic = topic;
+  }
+
+  public void pushMessages(List<M> messages) {
+    for (M message: messages) {
+      log.info("Pushing to {}:{}: {}", this.brokers, this.topic, message.toString());
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+  }
+}

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/metrics/kafka/NoopPusher.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/metrics/kafka/NoopPusher.java
@@ -14,42 +14,34 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-package org.apache.gobblin.metrics.reporter;
-
+package org.apache.gobblin.metrics.kafka;
 
 import java.io.IOException;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Queue;
 
-import com.google.common.collect.Queues;
+import com.google.common.base.Optional;
+import com.typesafe.config.Config;
 
-import org.apache.gobblin.metrics.kafka.Pusher;
+import lombok.extern.slf4j.Slf4j;
 
 
 /**
- * Mock instance of {@link org.apache.gobblin.metrics.kafka.Pusher} used for testing.
+ * This is a {@Pusher} class that ignores the messages
+ * @param <M> message type
  */
-public class MockKafkaPusher implements Pusher<byte[]> {
+@Slf4j
+public class NoopPusher<M> implements Pusher<M> {
+  public NoopPusher() {}
 
-  Queue<byte[]> messages = Queues.newLinkedBlockingQueue();
+  public NoopPusher(Config config) {}
 
-  public MockKafkaPusher() {
-  }
+  /**
+   * Constructor like the one in KafkaProducerPusher for compatibility
+   */
+  public NoopPusher(String brokers, String topic, Optional<Config> kafkaConfig) {}
+
+  public void pushMessages(List<M> messages) {}
 
   @Override
-  public void pushMessages(List<byte[]> messages) {
-    this.messages.addAll(messages);
-  }
-
-  @Override
-  public void close()
-      throws IOException {
-  }
-
-  public Iterator<byte[]> messageIterator() {
-    return this.messages.iterator();
-  }
-
+  public void close() throws IOException {}
 }

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/metrics/kafka/Pusher.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/metrics/kafka/Pusher.java
@@ -24,10 +24,10 @@ import java.util.List;
 /**
  * Establish a connection to a Kafka cluster and push byte messages to a specified topic.
  */
-public interface Pusher extends Closeable {
+public interface Pusher<M> extends Closeable {
   /**
    * Push all byte array messages to the Kafka topic.
    * @param messages List of byte array messages to push to Kakfa.
    */
-  void pushMessages(List<byte[]> messages);
+  void pushMessages(List<M> messages);
 }

--- a/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/metrics/kafka/LoggingPusherTest.java
+++ b/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/metrics/kafka/LoggingPusherTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gobblin.metrics.kafka;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.log4j.AppenderSkeleton;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.apache.log4j.spi.LoggingEvent;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+
+
+@Test
+public class LoggingPusherTest {
+
+  @Test
+  public void testKafkaReporter() {
+
+    TestAppender testAppender = new TestAppender();
+    Logger logger = LogManager.getLogger(LoggingPusher.class.getName());
+    logger.addAppender(testAppender);
+
+    LoggingPusher<String> loggingPusher = new LoggingPusher<String>("broker", "topic", Optional.absent());
+
+    loggingPusher.pushMessages(ImmutableList.of("message1", "message2"));
+
+    Assert.assertEquals(testAppender.events.size(), 2);
+    Assert.assertEquals(testAppender.events.get(0).getRenderedMessage(), "Pushing to broker:topic: message1");
+    Assert.assertEquals(testAppender.events.get(1).getRenderedMessage(), "Pushing to broker:topic: message2");
+
+    logger.removeAppender(testAppender);
+  }
+
+
+  private class TestAppender extends AppenderSkeleton {
+    List<LoggingEvent> events = new ArrayList<LoggingEvent>();
+    public void close() {}
+    public boolean requiresLayout() {return false;}
+    @Override
+    protected void append(LoggingEvent event) {
+      events.add(event);
+    }
+  }
+}


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-421


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
The message type of the pusher interface is currently hard-coded to byte[]. Change this to a parameterized type to support pushers that send messages of other types.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

