### PR TITLE
Partitionaware Hive Registration Policy

### DIFF
--- a/gobblin-hive-registration/build.gradle
+++ b/gobblin-hive-registration/build.gradle
@@ -43,6 +43,8 @@ dependencies {
   compile externalDependency.avroMapredH2
 
   testCompile externalDependency.testng
+  testCompile externalDependency.mockito
+
 }
 
 ext.classification="library"

--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/policy/PartitionAwareHiveRegistrationPolicy.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/policy/PartitionAwareHiveRegistrationPolicy.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.hive.policy;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
+
+import org.apache.gobblin.configuration.State;
+import org.apache.gobblin.hive.HivePartition;
+import org.apache.gobblin.hive.HiveRegistrationUnit;
+import org.apache.gobblin.hive.HiveTable;
+
+
+/**
+ * This is the partition aware implementation of {@link HiveRegistrationPolicyBase}.
+ * You can specify hive.partition.regex where the first match is the table location and the
+ * rest match are the partitions.
+ * The partition names can be specified with the hive.table.partition.keys property.
+ * The order of the partition names should match the order of regexp matches in the hive.partition.regexp expression.
+ *
+ * For example in the case of path: s3://testbucket/myawesomlogs/compacted/dt=20170101/hr=22/
+ * The hive.partition.regexp would look like: hive.partition.regex=(s3://testbucket/myawesomelogs/compacted/)dt=(.*)/hr=(.*)
+ * and the hive.table.partition.keys=dt,hr
+ *
+ * @author Tamas Nemeth
+ */
+
+public class PartitionAwareHiveRegistrationPolicy extends HiveRegistrationPolicyBase{
+  private static final Logger LOG = LoggerFactory.getLogger(PartitionAwareHiveRegistrationPolicy.class);
+
+  public static final String HIVE_PARTITION_REGEX = "hive.partition.regex";
+  public static final String HIVE_TABLE_PARTITION_KEYS = "hive.table.partition.keys";
+
+  public PartitionAwareHiveRegistrationPolicy(State props)
+      throws IOException {
+    super(props);
+  }
+
+  protected HiveTable getTable(Path path, String dbName, String tableName) throws IOException {
+    LOG.debug("Getting table definition for {}", tableName);
+
+    HiveTable table = super.getTable(path, dbName, tableName);
+
+    LOG.debug("Getting partition keys for {}", tableName);
+    if (!Strings.isNullOrEmpty(this.props.getProp(HIVE_TABLE_PARTITION_KEYS))) {
+      List<HiveRegistrationUnit.Column> partitionKeyColumns = Lists.<HiveRegistrationUnit.Column> newArrayList();
+
+      for (String key : this.props.getPropAsList(HIVE_TABLE_PARTITION_KEYS)) {
+        LOG.debug("Setting partition key {} for table {}", key, tableName);
+        partitionKeyColumns.add(new HiveRegistrationUnit.Column(key , "string", null));
+      }
+
+      table.setPartitionKeys(partitionKeyColumns);
+    }
+
+    return table;
+  }
+
+
+  protected Optional<HivePartition> getPartition(Path path, HiveTable table) throws IOException {
+
+    if (this.props.contains(HIVE_PARTITION_REGEX)) {
+      Pattern pattern = Pattern.compile(this.props.getProp(HIVE_PARTITION_REGEX));
+      List<String> partitionValues = Lists.newArrayList();
+
+      Matcher matcher = pattern.matcher(path.toString());
+      if (matcher.matches() && matcher.groupCount() >=2){
+        for (int i = 2; i <= matcher.groupCount(); i++) {
+          partitionValues.add(matcher.group(i));
+        }
+      } else {
+        return Optional.<HivePartition> absent();
+      }
+
+      HivePartition.Builder builder = new HivePartition.Builder();
+      builder.withDbName(table.getDbName());
+      builder.withColumns(table.getColumns());
+      builder.withTableName(table.getTableName());
+      builder.withPartitionValues(partitionValues);
+      builder.withProps(table.getProps());
+      builder.withStorageProps(table.getStorageProps());
+      builder.withSerdeProps(table.getSerDeProps());
+      builder.withSerdeManaager(table.getSerDeManager().orNull());
+
+      HivePartition partition = builder.build();
+      partition.setSerDeProps(path);
+
+      return Optional.of(partition);
+    }else {
+      return Optional.<HivePartition> absent();
+    }
+  }
+
+  protected Path getTableLocation(Path path) {
+    Optional<String> locationRegex = Optional.fromNullable(this.props.getProp(HIVE_PARTITION_REGEX));
+    if (locationRegex.isPresent()) {
+      Pattern pattern = Pattern.compile(locationRegex.get());
+      Matcher matcher = pattern.matcher(path.toString());
+      if (matcher.matches()) {
+        String location = matcher.group(1);
+        return new Path(location);
+      }else {
+        return path;
+      }
+    } else {
+      return path;
+    }
+  }
+
+}

--- a/gobblin-hive-registration/src/test/java/org/apache/gobblin/hive/policy/PartitionAwareHiveRegistrationPolicyTest.java
+++ b/gobblin-hive-registration/src/test/java/org/apache/gobblin/hive/policy/PartitionAwareHiveRegistrationPolicyTest.java
@@ -1,0 +1,91 @@
+package org.apache.gobblin.hive.policy;
+
+import org.apache.hadoop.fs.Path;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import org.apache.gobblin.configuration.State;
+import org.apache.gobblin.hive.HivePartition;
+import org.apache.gobblin.hive.HiveSerDeManager;
+import org.apache.gobblin.hive.HiveTable;
+
+import static org.apache.gobblin.hive.policy.PartitionAwareHiveRegistrationPolicy.HIVE_PARTITION_REGEX;
+import static org.apache.gobblin.hive.policy.PartitionAwareHiveRegistrationPolicy.HIVE_TABLE_PARTITION_KEYS;
+import static org.mockito.Mockito.mock;
+
+
+public class PartitionAwareHiveRegistrationPolicyTest {
+  private Path path;
+
+  @Test
+  public void testGetTable()
+      throws Exception {
+
+    State state = new State();
+    state.appendToListProp(HIVE_PARTITION_REGEX,"(s3://testbucket/myawesomelogs/compacted/)dt=(.*)/hr=(.*)");
+    state.appendToListProp(HIVE_TABLE_PARTITION_KEYS, "dt,hr");
+    this.path = new Path(getClass().getResource("/test-hive-table").toString());
+
+    PartitionAwareHiveRegistrationPolicy policy = new PartitionAwareHiveRegistrationPolicy(state);
+    HiveTable table = policy.getTable(path, "testDb", "testTable");
+
+    Assert.assertEquals(table.getPartitionKeys().size(), 2);
+    Assert.assertEquals(table.getPartitionKeys().get(0).getName(), "dt");
+    Assert.assertEquals(table.getPartitionKeys().get(0).getType(), "string");
+    Assert.assertEquals(table.getPartitionKeys().get(1).getName(), "hr");
+    Assert.assertEquals(table.getPartitionKeys().get(1).getType(), "string");
+  }
+
+  @Test
+  public void testGetPartition()
+      throws Exception {
+
+    HiveSerDeManager mockHiveSerDeManager = mock(HiveSerDeManager.class);
+
+    HiveTable table = new HiveTable.Builder().withDbName("test").withTableName("test").withSerdeManaager(mockHiveSerDeManager).build();
+    State state = new State();
+    state.appendToListProp(HIVE_PARTITION_REGEX,"(s3://testbucket/myawesomelogs/compacted/)dt=(.*)/hr=(.*)");
+
+    this.path = new Path("s3://testbucket/myawesomelogs/compacted/dt=20170101/hr=22/");
+
+    PartitionAwareHiveRegistrationPolicy policy = new PartitionAwareHiveRegistrationPolicy(state);
+
+    HivePartition partition = policy.getPartition(path, table).orNull();
+
+    Assert.assertEquals(partition.getValues().size(), 2);
+    Assert.assertEquals(partition.getValues().get(0), "20170101");
+    Assert.assertEquals(partition.getValues().get(1), "22");
+  }
+
+  @Test
+  public void testGetTableLocationWithTableRegexp()
+      throws Exception {
+
+    State state = new State();
+    state.appendToListProp(HIVE_PARTITION_REGEX,"(s3://testbucket/myawesomelogs/compacted/)dt=(.*)/hr=(.*)");
+
+    this.path = new Path("s3://testbucket/myawesomelogs/compacted/dt=20170101/hr=22/");
+
+    PartitionAwareHiveRegistrationPolicy policy = new PartitionAwareHiveRegistrationPolicy(state);
+
+    Path tableLocation = policy.getTableLocation(path);
+
+    Assert.assertEquals(tableLocation, new Path("s3://testbucket/myawesomelogs/compacted/"));
+  }
+
+  @Test
+  public void testGetTableLocationWithoutTableRegexp()
+      throws Exception {
+
+    State state = new State();
+
+    this.path = new Path("s3://testbucket/myawesomelogs/compacted/");
+
+    PartitionAwareHiveRegistrationPolicy policy = new PartitionAwareHiveRegistrationPolicy(state);
+
+    Path tableLocation = policy.getTableLocation(path);
+
+    Assert.assertEquals(tableLocation, new Path("s3://testbucket/myawesomelogs/compacted/"));
+  }
+
+}


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-425


### Description
This is the partition aware implementation of {@link HiveRegistrationPolicyBase}.
You can specify hive.partition.regex where the first match is the table location and the rest match are the partitions.
The partition names can be specified with the hive.table.partition.keys property.
The order of the partition names should match the order of regexp matches in the hive.partition.regexp expression.

 For example in the case of path: s3://testbucket/myawesomlogs/compacted/dt=20170101/hr=22/
 The hive.partition.regexp would look like: hive.partition.regex=(s3://testbucket/myawesomelogs/compacted/)dt=(.*)/hr=(.*) and the hive.table.partition.keys=dt,hr

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

