### PR TITLE
[GOBBLIN-428] fix delete spec not propagating to cluster

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/job_monitor/KafkaJobMonitor.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/job_monitor/KafkaJobMonitor.java
@@ -71,13 +71,9 @@ public abstract class KafkaJobMonitor extends HighLevelConsumer<byte[], byte[]> 
     super(topic, ConfigUtils.getConfigOrEmpty(config, KAFKA_JOB_MONITOR_PREFIX), 1);
     this.jobCatalog = catalog;
     try {
-      if (config.hasPath(ConfigurationKeys.STATE_STORE_ENABLED) &&
-          config.getBoolean(ConfigurationKeys.STATE_STORE_ENABLED) &&
-          config.hasPath(ConfigurationKeys.STATE_STORE_ROOT_DIR_KEY)) {
-        this.datasetStateStore = DatasetStateStore.buildDatasetStateStore(config);
-      }
-    } catch (IOException e) {
-      log.warn("DatasetStateStore could not be created.");
+      this.datasetStateStore = DatasetStateStore.buildDatasetStateStore(config);
+    } catch (Exception e) {
+      log.warn("DatasetStateStore could not be created.", e);
     }
   }
 


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below! @htran1  please review


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-428


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
job states are not getting deleted on the cluster; because KafkaJobMonitor does not instantiate DataSetStore when state.store.enabled is not set to true in global cluster properties.

state.store.enabled is job specific and should be required to be set in cluster properties and should not be needed to instantiate DataSetStore.

Also, I believe DataSetStore can be tried to be instantiated always, because some job may need it.

### Tests
- [] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

