### PR TITLE
Always  mark custom tasks as complete even if they throw exception in run()

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/task/TaskIFaceWrapper.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/task/TaskIFaceWrapper.java
@@ -73,8 +73,11 @@ public class TaskIFaceWrapper extends Task {
 
   @Override
   public void run() {
-    this.underlyingTask.run();
-    this.taskStateTracker.onTaskRunCompletion(this);
+    try {
+      this.underlyingTask.run();
+    } finally {
+      this.taskStateTracker.onTaskRunCompletion(this);
+    }
   }
 
   @Override

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/task/CustomTaskTest.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/task/CustomTaskTest.java
@@ -29,11 +29,22 @@ import org.apache.gobblin.writer.test.TestingEventBuses;
 import java.io.File;
 import java.util.Set;
 import java.util.UUID;
+
+import org.junit.internal.runners.statements.Fail;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 
 public class CustomTaskTest {
+
+  @Test(timeOut = 30000)
+  public void testTaskFailsWithException() throws Exception {
+    // Test that the job runner fails with a reasonable amount of time if a custom task throws an exception
+    JobExecutionResult result =
+        new EmbeddedGobblin("alwaysThrowsJob").setConfiguration(ConfigurationKeys.SOURCE_CLASS_KEY, FailsWithExceptionTaskFactory.Source.class.getName())
+        .run();
+    Assert.assertFalse(result.isSuccessful());
+  }
 
   @Test
   public void testCustomTask() throws Exception {

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/task/FailsWithExceptionTaskFactory.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/task/FailsWithExceptionTaskFactory.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gobblin.task;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.gobblin.configuration.SourceState;
+import org.apache.gobblin.configuration.State;
+import org.apache.gobblin.configuration.WorkUnitState;
+import org.apache.gobblin.publisher.DataPublisher;
+import org.apache.gobblin.runtime.JobState;
+import org.apache.gobblin.runtime.TaskContext;
+import org.apache.gobblin.runtime.task.TaskFactory;
+import org.apache.gobblin.runtime.task.TaskIFace;
+import org.apache.gobblin.runtime.task.TaskUtils;
+import org.apache.gobblin.source.extractor.Extractor;
+import org.apache.gobblin.source.workunit.WorkUnit;
+
+
+public class FailsWithExceptionTaskFactory implements TaskFactory {
+  @Override
+  public TaskIFace createTask(TaskContext taskContext) {
+    return new AlwaysThrowsTask();
+  }
+
+  @Override
+  public DataPublisher createDataPublisher(JobState.DatasetState datasetState) {
+    return null;
+  }
+
+  public static class Source implements org.apache.gobblin.source.Source<String, String> {
+    @Override
+    public List<WorkUnit> getWorkunits(SourceState state) {
+      WorkUnit wu = new WorkUnit();
+      TaskUtils.setTaskFactoryClass(wu, FailsWithExceptionTaskFactory.class);
+      return Collections.singletonList(wu);
+    }
+
+    @Override
+    public Extractor<String, String> getExtractor(WorkUnitState state)
+        throws IOException {
+      return null;
+    }
+
+    @Override
+    public void shutdown(SourceState state) {
+
+    }
+  }
+  private static class AlwaysThrowsTask implements TaskIFace {
+    @Override
+    public void run() {
+      throw new IllegalArgumentException("I always fail with an exception!");
+    }
+
+    @Override
+    public void commit() {
+
+    }
+
+    @Override
+    public State getPersistentState() {
+      return null;
+    }
+
+    @Override
+    public State getExecutionMetadata() {
+      return null;
+    }
+
+    @Override
+    public WorkUnitState.WorkingState getWorkingState() {
+      return null;
+    }
+
+    @Override
+    public void shutdown() {
+
+    }
+
+    @Override
+    public boolean awaitShutdown(long timeoutMillis)
+        throws InterruptedException {
+      return false;
+    }
+
+    @Override
+    public String getProgress() {
+      return null;
+    }
+
+    @Override
+    public boolean isSpeculativeExecutionSafe() {
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
If a custom task throws an exception in the run() method, it was not getting marked as complete which would result in the job hanging. Change the task wrapper to mark tasks complete in a finally block.

