### PR TITLE
[GOBBLIN-436] Add default constructor for SalesforceSource

### DIFF
--- a/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/SalesforceSource.java
+++ b/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/SalesforceSource.java
@@ -110,6 +110,10 @@ public class SalesforceSource extends QueryBasedSource<JsonArray, JsonElement> {
   private static final Gson GSON = new Gson();
   private boolean isEarlyStopped = false;
 
+  public SalesforceSource() {
+    this.lineageInfo = Optional.absent();
+  }
+
   @VisibleForTesting
   SalesforceSource(LineageInfo lineageInfo) {
     this.lineageInfo = Optional.fromNullable(lineageInfo);

--- a/gobblin-salesforce/src/test/java/org/apache/gobblin/salesforce/SalesforceSourceTest.java
+++ b/gobblin-salesforce/src/test/java/org/apache/gobblin/salesforce/SalesforceSourceTest.java
@@ -58,7 +58,7 @@ public class SalesforceSourceTest {
   void testGenerateSpecifiedPartitionFromSinglePointHistogram() {
     SalesforceSource.Histogram histogram = new SalesforceSource.Histogram();
     histogram.add(new SalesforceSource.HistogramGroup("2014-02-13-00:00:00", 10));
-    SalesforceSource source = new SalesforceSource(null);
+    SalesforceSource source = new SalesforceSource();
 
     long expectedHighWatermark = 20170407152123L;
     long lowWatermark = 20140213000000L;
@@ -75,7 +75,7 @@ public class SalesforceSourceTest {
       String[] groupInfo = group.split("::");
       histogram.add(new SalesforceSource.HistogramGroup(groupInfo[0], Integer.parseInt(groupInfo[1])));
     }
-    SalesforceSource source = new SalesforceSource(null);
+    SalesforceSource source = new SalesforceSource();
 
     long expectedHighWatermark = 20170407152123L;
     long lowWatermark = 20140213000000L;


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-436


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
  Bring default constructor back

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  No test needed

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

