### PR TITLE
[GOBBLIN-455] Fix handling of jvmflags and jars flags in gobblin-yarn launcher

### DIFF
--- a/bin/gobblin-yarn.sh
+++ b/bin/gobblin-yarn.sh
@@ -80,11 +80,11 @@ do
       shift
       ;;
     --jvmflags)
-      JVM_FLAGS="$1"
+      JVM_FLAGS="$2"
       shift
       ;;
     --jars)
-      EXTRA_JARS="$1"
+      EXTRA_JARS="$2"
       shift
       ;;
     --help)
@@ -102,7 +102,7 @@ if [ -z "$JAVA_HOME" ]; then
 fi
 
 # User defined JVM flags overrides $GOBBLIN_JVM_FLAGS (if any)
-if [ -n "$JVM_FLAGS" ]; then
+if [ -z "$JVM_FLAGS" ]; then
   JVM_FLAGS="-Xmx1g -Xms512m"
 fi
 


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN-455) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-XXX


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Fixes handling of flags in gobblin-yarn launcher.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

