### PR TITLE
[GOBBLIN-461] disabling PasswordManagerTests as they fail often on travis

### DIFF
--- a/gobblin-api/src/test/java/org/apache/gobblin/password/PasswordManagerTest.java
+++ b/gobblin-api/src/test/java/org/apache/gobblin/password/PasswordManagerTest.java
@@ -33,9 +33,10 @@ import org.testng.annotations.Test;
 
 import com.google.common.io.Files;
 
+@Test(enabled=false, groups = {"disabledOnTravis"} )
 public class PasswordManagerTest {
 
-  @Test
+  @Test (enabled=false)
   public void testReadNormalPassword() throws IOException {
     String password = UUID.randomUUID().toString();
     String masterPassword = UUID.randomUUID().toString();
@@ -46,7 +47,7 @@ public class PasswordManagerTest {
     masterPwdFile.delete();
   }
 
-  @Test
+  @Test (enabled=false)
   public void testMasterPasswordNotExist() {
     String password = "ENC(" + UUID.randomUUID().toString() + ")";
     State state = new State();
@@ -54,7 +55,7 @@ public class PasswordManagerTest {
     Assert.assertEquals(PasswordManager.getInstance(state).readPassword(password), password);
   }
 
-  @Test
+  @Test (enabled=false)
   public void testBasicEncryptionAndDecryption() throws IOException {
     String password = UUID.randomUUID().toString();
     String masterPassword = UUID.randomUUID().toString();
@@ -69,7 +70,7 @@ public class PasswordManagerTest {
     Assert.assertEquals(decrypted, password);
   }
 
-  @Test
+  @Test (enabled=false)
   public void testStrongEncryptionAndDecryption() throws IOException {
     String password = UUID.randomUUID().toString();
     String masterPassword = UUID.randomUUID().toString();
@@ -90,7 +91,7 @@ public class PasswordManagerTest {
     }
   }
 
-  @Test
+  @Test (enabled=false)
   public void testMultipleMasterPasswords() throws IOException {
     String password = UUID.randomUUID().toString();
 
@@ -146,7 +147,7 @@ public class PasswordManagerTest {
     Assert.fail("Password Manager decrypted too old password.");
   }
 
-  @Test
+  @Test (enabled=false)
   public void testMultipleMasterPasswordsWithoutPasswordFiles() throws IOException {
     String password = UUID.randomUUID().toString();
 


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below! @ibuenros please review


### JIRA
- [x] My PR addresses the following
    - https://issues.apache.org/jira/browse/GOBBLIN-461


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
These tests were disabled before; but recently enabled again

https://github.com/apache/incubator-gobblin/commit/57a6566ac635053bb171ee35c0d00b9f1e2483c8#diff-ef5fa9697f5bdd44cfa577f2ed2b869aL36

and since then they fail often.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: not needed as this is adding no new source code


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

