### PR TITLE
[GOBBLIN-465] Add support for couchbase client cert auth

### DIFF
--- a/gobblin-modules/gobblin-couchbase/build.gradle
+++ b/gobblin-modules/gobblin-couchbase/build.gradle
@@ -23,7 +23,7 @@ dependencies {
   compile project(":gobblin-utility")
   compile project(":gobblin-metrics-libs:gobblin-metrics")
 
-  compile "com.couchbase.client:java-client:2.3.5"
+  compile "com.couchbase.client:java-client:2.5.4"
   compile externalDependency.avro
   compile externalDependency.jacksonCore
   compile externalDependency.jacksonMapper

--- a/gobblin-modules/gobblin-couchbase/scripts/install_test_deps.sh
+++ b/gobblin-modules/gobblin-couchbase/scripts/install_test_deps.sh
@@ -16,15 +16,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+MOCK_COUCHBASE_VERSION=1.5.18
 
 mkdir -p mock-couchbase
 if [ -d mock-couchbase/.git ];
   then
     git -C mock-couchbase pull
-    git -C mock-couchbase checkout b929a9f99a31a233c43bd94b6a696ad966206e02
+    git -C mock-couchbase checkout tags/${MOCK_COUCHBASE_VERSION}
   else
     git clone https://github.com/couchbase/CouchbaseMock.git mock-couchbase
-    git -C mock-couchbase checkout b929a9f99a31a233c43bd94b6a696ad966206e02
+    git -C mock-couchbase checkout tags/${MOCK_COUCHBASE_VERSION}
   fi
 pushd mock-couchbase
 if ! mvn package -Dmaven.test.skip=true; then

--- a/gobblin-modules/gobblin-couchbase/src/main/java/org/apache/gobblin/couchbase/writer/CouchbaseEnvironmentFactory.java
+++ b/gobblin-modules/gobblin-couchbase/src/main/java/org/apache/gobblin/couchbase/writer/CouchbaseEnvironmentFactory.java
@@ -20,6 +20,7 @@ package org.apache.gobblin.couchbase.writer;
 import com.couchbase.client.java.env.CouchbaseEnvironment;
 import com.couchbase.client.java.env.DefaultCouchbaseEnvironment;
 import com.typesafe.config.Config;
+import org.apache.gobblin.util.ConfigUtils;
 
 
 /**
@@ -38,9 +39,25 @@ public class CouchbaseEnvironmentFactory {
    */
   public static synchronized CouchbaseEnvironment getInstance(Config config)
   {
+    Boolean sslEnabled = ConfigUtils.getBoolean(config, CouchbaseWriterConfigurationKeys.SSL_ENABLED, false);
+    String sslKeystoreFile = ConfigUtils.getString(config, CouchbaseWriterConfigurationKeys.SSL_KEYSTORE_FILE, "");
+    String sslKeystorePassword = ConfigUtils.getString(config, CouchbaseWriterConfigurationKeys.SSL_KEYSTORE_PASSWORD, "");
+    String sslTruststoreFile = ConfigUtils.getString(config, CouchbaseWriterConfigurationKeys.SSL_TRUSTSTORE_FILE, "");
+    String sslTruststorePassword = ConfigUtils.getString(config, CouchbaseWriterConfigurationKeys.SSL_TRUSTSTORE_PASSWORD, "");
+    Boolean certAuthEnabled = ConfigUtils.getBoolean(config, CouchbaseWriterConfigurationKeys.CERT_AUTH_ENABLED, false);
+
+    DefaultCouchbaseEnvironment.Builder builder = DefaultCouchbaseEnvironment
+	.builder()
+        .sslEnabled(sslEnabled)
+        .sslKeystoreFile(sslKeystoreFile)
+        .sslKeystorePassword(sslKeystorePassword)
+        .sslTruststoreFile(sslTruststoreFile)
+        .sslTruststorePassword(sslTruststorePassword)
+        .certAuthEnabled(certAuthEnabled);
+
     if (couchbaseEnvironment == null)
     {
-      return DefaultCouchbaseEnvironment.create();
+      return builder.build();
     }
     else {
       return couchbaseEnvironment;

--- a/gobblin-modules/gobblin-couchbase/src/main/java/org/apache/gobblin/couchbase/writer/CouchbaseWriter.java
+++ b/gobblin-modules/gobblin-couchbase/src/main/java/org/apache/gobblin/couchbase/writer/CouchbaseWriter.java
@@ -109,16 +109,20 @@ public class CouchbaseWriter<D extends AbstractDocument> implements AsyncDataWri
   public CouchbaseWriter(CouchbaseEnvironment couchbaseEnvironment, Config config) {
 
     List<String> hosts = ConfigUtils.getStringList(config, CouchbaseWriterConfigurationKeys.BOOTSTRAP_SERVERS);
-
-    _cluster = CouchbaseCluster.create(couchbaseEnvironment, hosts);
+    String password = ConfigUtils.getString(config, CouchbaseWriterConfigurationKeys.PASSWORD, "");
 
     String bucketName = ConfigUtils.getString(config, CouchbaseWriterConfigurationKeys.BUCKET,
         CouchbaseWriterConfigurationKeys.BUCKET_DEFAULT);
 
-    String password = ConfigUtils.getString(config, CouchbaseWriterConfigurationKeys.PASSWORD, "");
+    _cluster = CouchbaseCluster.create(couchbaseEnvironment, hosts);
 
-    _bucket = _cluster.openBucket(bucketName, password,
-        Collections.<Transcoder<? extends Document, ?>>singletonList(_tupleDocumentTranscoder));
+    if(!password.isEmpty()) {
+      _bucket = _cluster.openBucket(bucketName, password,
+          Collections.<Transcoder<? extends Document, ?>>singletonList(_tupleDocumentTranscoder));
+    } else {
+      _bucket = _cluster.openBucket(bucketName,
+          Collections.<Transcoder<? extends Document, ?>>singletonList(_tupleDocumentTranscoder));
+    }
 
     _operationTimeout = ConfigUtils.getLong(config, CouchbaseWriterConfigurationKeys.OPERATION_TIMEOUT_MILLIS,
         CouchbaseWriterConfigurationKeys.OPERATION_TIMEOUT_DEFAULT);

--- a/gobblin-modules/gobblin-couchbase/src/main/java/org/apache/gobblin/couchbase/writer/CouchbaseWriterConfigurationKeys.java
+++ b/gobblin-modules/gobblin-couchbase/src/main/java/org/apache/gobblin/couchbase/writer/CouchbaseWriterConfigurationKeys.java
@@ -34,6 +34,13 @@ public class CouchbaseWriterConfigurationKeys {
   public static final String BUCKET_DEFAULT = "default";
   public static final String PASSWORD = prefix("password");
 
+  public static final String SSL_ENABLED = prefix("sslEnabled");
+  public static final String SSL_KEYSTORE_FILE = prefix("sslKeystoreFile");
+  public static final String SSL_KEYSTORE_PASSWORD = prefix("sslKeystorePassword");
+  public static final String SSL_TRUSTSTORE_FILE = prefix("sslTruststoreFile");
+  public static final String SSL_TRUSTSTORE_PASSWORD = prefix("sslTruststorePassword");
+  public static final String CERT_AUTH_ENABLED = prefix("certAuthEnabled");
+
   public static final String OPERATION_TIMEOUT_MILLIS = "operationTimeoutMillis";
   public static final long OPERATION_TIMEOUT_DEFAULT = 10000; // 10 second default timeout
 

--- a/gobblin-modules/gobblin-couchbase/src/test/java/org/apache/gobblin/couchbase/CouchbaseTestServer.java
+++ b/gobblin-modules/gobblin-couchbase/src/test/java/org/apache/gobblin/couchbase/CouchbaseTestServer.java
@@ -48,7 +48,7 @@ import org.apache.gobblin.test.TestUtils;
 public class CouchbaseTestServer {
 
   private static final String COUCHBASE_JAR_PATH="gobblin-modules/gobblin-couchbase/mock-couchbase/target/";
-  private static final String COUCHBASE_MOCK_JAR=COUCHBASE_JAR_PATH + "CouchbaseMock-1.4.4.jar";
+  private static final String COUCHBASE_MOCK_JAR=COUCHBASE_JAR_PATH + "CouchbaseMock-1.5.18.jar";
 
 
   private Process couchbaseProcess;
@@ -67,7 +67,7 @@ public class CouchbaseTestServer {
     String[] commands = {"/usr/bin/java",
       "-cp",
       COUCHBASE_MOCK_JAR,
-      "org.couchbase.mock.CouchbaseMock",
+      "com.couchbase.mock.CouchbaseMock",
       "--port",
       _port +"",
       "-n",


### PR DESCRIPTION
The requisite version bump eliminates support for couchbase v3.

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA

- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN-465) issues and references them in the PR title. For example, "[GOBBLIN-465] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-465

### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Bump API to 2.5.4. Exposes configuration values for performing cert auth. Skips SASL password auth if password is not provided.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: this change is mostly exposing new config values - coverage & flow doesn't really change here, but I'm happy to add tests if they are needed to pass. I have smoke tested the new and old functionality with this build against CB5.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

