### PR TITLE
[GOBBLIN-471] Skip nulls work units in DatasetFinderSource and LoopingDatasetFinder…

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/source/DatasetFinderSource.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/source/DatasetFinderSource.java
@@ -19,6 +19,7 @@ package org.apache.gobblin.data.management.source;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -110,9 +111,9 @@ public abstract class DatasetFinderSource<S, D> implements WorkUnitStreamSource<
         } else {
           return Stream.of(new DatasetWrapper(dataset));
         }
-      }).map(this::workUnitForPartitionInternal);
+      }).map(this::workUnitForPartitionInternal).filter(Objects::nonNull);
     } else {
-      return datasetStream.map(this::workUnitForDataset);
+      return datasetStream.map(this::workUnitForDataset).filter(Objects::nonNull);
     }
   }
 

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/source/LoopingDatasetFinderSource.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/source/LoopingDatasetFinderSource.java
@@ -205,6 +205,9 @@ public abstract class LoopingDatasetFinderSource<S, D> extends DatasetFinderSour
         if (this.currentPartitionIterator != null && this.currentPartitionIterator.hasNext()) {
           PartitionableDataset.DatasetPartition partition = this.currentPartitionIterator.next();
           WorkUnit workUnit = workUnitForDatasetPartition(partition);
+          if (workUnit == null) {
+            continue;
+          }
           addDatasetInfoToWorkUnit(workUnit, partition.getDataset());
           addPartitionInfoToWorkUnit(workUnit, partition);
           this.previousDataset = partition.getDataset();
@@ -218,6 +221,9 @@ public abstract class LoopingDatasetFinderSource<S, D> extends DatasetFinderSour
           this.currentPartitionIterator = getPartitionIterator((PartitionableDataset) dataset);
         } else {
           WorkUnit workUnit = workUnitForDataset(dataset);
+          if (workUnit == null) {
+            continue;
+          }
           addDatasetInfoToWorkUnit(workUnit, dataset);
           this.previousDataset = dataset;
           this.generatedWorkUnits++;


### PR DESCRIPTION
…Source.

This PR allows skipping datasets in DatasetFinderSource and LoopingDatasetFinderSource by returning null on `createWorkUnitForDataset[Partition]`.

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-XXX


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

