### PR TITLE
GOBBLIN-474: Add end-of-datasets marker to workunit correctly to avoid an additional run when end of datasets is reached.

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/source/LoopingDatasetFinderSource.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/source/LoopingDatasetFinderSource.java
@@ -196,7 +196,14 @@ public abstract class LoopingDatasetFinderSource<S, D> extends DatasetFinderSour
          * efficiently determine the next dataset/partition to process in the subsequent run.
          */
         this.generatedWorkUnits++;
-        return generateNoopWorkUnit();
+        WorkUnit noopWorkUnit = generateNoopWorkUnit();
+        /**
+         * Check if we are at the end of datasets. If so, add the END_OF_DATASETS marker to the workunit.
+         */
+        if(!this.baseIterator.hasNext() && this.currentPartitionIterator != null && !this.currentPartitionIterator.hasNext()) {
+          noopWorkUnit.setProp(END_OF_DATASETS_KEY,true);
+        }
+        return noopWorkUnit;
       } else if (this.generatedWorkUnits > this.maxWorkUnits) {
         return endOfData();
       }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-474


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
When the number of maximum workunits per run setting in LoopingDatasetFinderSource equals the number of remaining datasets to process before the end of the loop, we do not place the "End-of-Dataset" marker in the last workunit. The subsequent run turns out to be essentially a no-op and is avoidable by correctly detecting the end-of-datasets.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Added a unit test. 

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

