### PR TITLE
[GOBBLIN-478] Fixed bug to emit lineage events during Avro2ORC conversion

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/publisher/HiveConvertPublisher.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/publisher/HiveConvertPublisher.java
@@ -243,9 +243,8 @@ public class HiveConvertPublisher extends DataPublisher {
             } catch (Exception e) {
               log.error("Failed while emitting SLA event, but ignoring and moving forward to curate " + "all clean up commands", e);
             }
-            if (LineageUtils.shouldSetLineageInfo(wus.getWorkunit())) {
-              setDestLineageInfo(wus.getWorkunit(),
-                  (ConvertibleHiveDataset) ((HiveWorkUnit) wus.getWorkunit()).getHiveDataset(), this.lineageInfo);
+            if (LineageUtils.shouldSetLineageInfo(wus)) {
+              setDestLineageInfo(wus, this.lineageInfo);
             }
           }
         }
@@ -275,12 +274,13 @@ public class HiveConvertPublisher extends DataPublisher {
   }
 
   @VisibleForTesting
-  public void setDestLineageInfo(WorkUnit workUnit, ConvertibleHiveDataset convertibleHiveDataset,
-      Optional<LineageInfo> lineageInfo) {
+  public static void setDestLineageInfo(WorkUnitState wus, Optional<LineageInfo> lineageInfo) {
+    HiveWorkUnit hiveWorkUnit = new HiveWorkUnit(wus.getWorkunit());
+    ConvertibleHiveDataset convertibleHiveDataset = (ConvertibleHiveDataset) hiveWorkUnit.getHiveDataset();
     List<DatasetDescriptor> destDatasets = convertibleHiveDataset.getDestDatasets();
     for (int i = 0; i < destDatasets.size(); i++) {
       if (lineageInfo.isPresent()) {
-        lineageInfo.get().putDestination(destDatasets.get(i), i + 1, workUnit);
+        lineageInfo.get().putDestination(destDatasets.get(i), i + 1, wus);
       }
     }
   }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/source/HiveAvroToOrcSource.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/source/HiveAvroToOrcSource.java
@@ -19,23 +19,22 @@ package org.apache.gobblin.data.management.conversion.hive.source;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import java.util.List;
-
 import org.apache.gobblin.configuration.SourceState;
 import org.apache.gobblin.data.management.conversion.hive.dataset.ConvertibleHiveDataset;
 import org.apache.gobblin.data.management.conversion.hive.dataset.ConvertibleHiveDatasetFinder;
 import org.apache.gobblin.data.management.conversion.hive.utils.LineageUtils;
-import org.apache.gobblin.data.management.conversion.hive.watermarker.PartitionLevelWatermarker;
-import org.apache.gobblin.data.management.copy.hive.HiveDataset;
 import org.apache.gobblin.data.management.copy.hive.HiveDatasetFinder;
 import org.apache.gobblin.dataset.DatasetDescriptor;
 import org.apache.gobblin.metrics.event.lineage.LineageInfo;
 import org.apache.gobblin.source.workunit.WorkUnit;
+
 
 /**
  * An extension to {@link HiveSource} that is used for Avro to ORC conversion jobs.
  */
 public class HiveAvroToOrcSource extends HiveSource {
   private Optional<LineageInfo> lineageInfo;
+
   @Override
   public List<WorkUnit> getWorkunits(SourceState state) {
     if (!state.contains(HIVE_SOURCE_DATASET_FINDER_CLASS_KEY)) {
@@ -49,21 +48,19 @@ public class HiveAvroToOrcSource extends HiveSource {
     List<WorkUnit> workunits = super.getWorkunits(state);
     for (WorkUnit workUnit : workunits) {
       if (LineageUtils.shouldSetLineageInfo(workUnit)) {
-        setSourceLineageInfo(workUnit, (ConvertibleHiveDataset) ((HiveWorkUnit) workUnit).getHiveDataset(),
-            this.lineageInfo);
+        setSourceLineageInfo(workUnit, this.lineageInfo);
       }
     }
     return workunits;
   }
 
   @VisibleForTesting
-  public void setSourceLineageInfo(WorkUnit workUnit, ConvertibleHiveDataset hiveDataset,
-      Optional<LineageInfo> lineageInfo) {
-    DatasetDescriptor sourceDataset = hiveDataset.getSourceDataset();
+  public void setSourceLineageInfo(WorkUnit workUnit, Optional<LineageInfo> lineageInfo) {
+    HiveWorkUnit hiveWorkUnit = new HiveWorkUnit(workUnit);
+    ConvertibleHiveDataset convertibleHiveDataset = (ConvertibleHiveDataset) hiveWorkUnit.getHiveDataset();
+    DatasetDescriptor sourceDataset = convertibleHiveDataset.getSourceDataset();
     if (lineageInfo.isPresent()) {
       lineageInfo.get().setSource(sourceDataset, workUnit);
     }
   }
-
-
 }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/utils/LineageUtils.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/utils/LineageUtils.java
@@ -16,6 +16,7 @@
  */
 package org.apache.gobblin.data.management.conversion.hive.utils;
 
+import org.apache.gobblin.configuration.WorkUnitState;
 import org.apache.gobblin.data.management.conversion.hive.dataset.ConvertibleHiveDataset;
 import org.apache.gobblin.data.management.conversion.hive.source.HiveWorkUnit;
 import org.apache.gobblin.data.management.conversion.hive.watermarker.PartitionLevelWatermarker;
@@ -28,15 +29,17 @@ import org.apache.gobblin.source.workunit.WorkUnit;
  */
 public class LineageUtils {
   public static boolean shouldSetLineageInfo(WorkUnit workUnit) {
-    if (!(workUnit instanceof HiveWorkUnit)) {
-      return false;
-    }
-    HiveWorkUnit hiveWorkUnit = (HiveWorkUnit) workUnit;
+    // Create a HiveWorkUnit from the workunit
+    HiveWorkUnit hiveWorkUnit = new HiveWorkUnit(workUnit);
     if (hiveWorkUnit.getPropAsBoolean(PartitionLevelWatermarker.IS_WATERMARK_WORKUNIT_KEY, false)) {
       return false;
     }
     HiveDataset hiveDataset = hiveWorkUnit.getHiveDataset();
     return hiveDataset instanceof ConvertibleHiveDataset;
+  }
+
+  public static boolean shouldSetLineageInfo(WorkUnitState workUnitState) {
+    return shouldSetLineageInfo(workUnitState.getWorkunit());
   }
 
   private LineageUtils() {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-478


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Lineage events were not getting emitted during Avro2ORC conversion. For this lineage event, source information is set by HiveAvroToOrcSource and destination info is set by HiveConvertPublisher. HiveConvertPublisher gets collection of WorkUnitStates. On invoking getWorkUnit() method on WorkUnitState, publisher was expecting HiveWorkUnit while the returned workunit was ImmutableWorkUnit. 
Made changes to make sure, destination info is set correctly in WorkUnitState by HiveConvertPublisher

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Unit test is present

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

