### PR TITLE
GOBBLIN-485: AvroSchemaManager does not support using schema generated from Hive columns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 **/build/
 .gradle
 **/.gradle
+gradle.properties.release
 test-output
 **/test-output
 dist

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/conversion/hive/avro/AvroSchemaManagerTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/conversion/hive/avro/AvroSchemaManagerTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gobblin.data.management.conversion.hive.avro;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.metastore.api.SerDeInfo;
+import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.metadata.Partition;
+import org.apache.hadoop.hive.ql.metadata.Table;
+import org.apache.hadoop.hive.serde2.avro.AvroSerDe;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.configuration.State;
+
+
+public class AvroSchemaManagerTest {
+  @Test
+  public void testGetSchemaFromUrlUsingHiveSchema() throws IOException, HiveException {
+    FileSystem fs = FileSystem.getLocal(new Configuration());
+
+    String jobId = "123";
+    State state = new State();
+    state.setProp(ConfigurationKeys.JOB_ID_KEY, jobId);
+
+    AvroSchemaManager asm = new AvroSchemaManager(fs, state);
+    Partition partition = getTestPartition(new Table("testDb", "testTable"));
+    Path schemaPath = asm.getSchemaUrl(partition);
+
+    String actualSchema = fs.open(schemaPath).readUTF();
+    String expectedSchema = new String(Files.readAllBytes(
+        Paths.get(getClass().getClassLoader().getResource("avroSchemaManagerTest/expectedSchema.avsc").getFile())));
+    Assert.assertEquals(actualSchema, expectedSchema);
+  }
+
+  private Partition getTestPartition(Table table) throws HiveException {
+    Partition partition = new Partition(table, ImmutableMap.of("partition_key", "1"), null);
+    StorageDescriptor sd = new StorageDescriptor();
+    sd.setSerdeInfo(new SerDeInfo("avro", AvroSerDe.class.getName(), null));
+    sd.setCols(Lists.newArrayList(new FieldSchema("foo", "int", null)));
+    partition.getTPartition().setSd(sd);
+    return partition;
+  }
+}

--- a/gobblin-data-management/src/test/resources/avroSchemaManagerTest/expectedSchema.avsc
+++ b/gobblin-data-management/src/test/resources/avroSchemaManagerTest/expectedSchema.avsc
@@ -1,0 +1,1 @@
+{"type":"record","name":"baseRecord","fields":[{"name":"foo","type":["null","int"],"default":null}]}

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/AvroUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/AvroUtils.java
@@ -395,7 +395,7 @@ public class AvroUtils {
     }
 
     try (DataOutputStream dos = fs.create(filePath)) {
-      dos.writeChars(schema.toString());
+      dos.writeUTF(schema.toString());
     }
     fs.setPermission(filePath, perm);
   }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-485


### Description
- [x] Here are some details about my PR, including screenshots (if applicable): This PR adds support in AvroSchemaManager for generating a schema from the Hive columns if `avro.schema.literal` and `avro.schema.url` are not set.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

Internal Jira: LIHADOOP-36855