### PR TITLE
[GOBBLIN-486] Change access modifiers for SalesforceWriter to protected

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/writer/http/SalesforceRestWriter.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/writer/http/SalesforceRestWriter.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 
+import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -53,6 +54,7 @@ import com.google.gson.JsonParser;
  * Writes to Salesforce via RESTful API, supporting INSERT_ONLY_NOT_EXIST, and UPSERT.
  *
  */
+@Getter
 public class SalesforceRestWriter extends RestJsonWriter {
   public static enum Operation {
     INSERT_ONLY_NOT_EXIST,
@@ -60,20 +62,20 @@ public class SalesforceRestWriter extends RestJsonWriter {
   }
   static final String DUPLICATE_VALUE_ERR_CODE = "DUPLICATE_VALUE";
 
-  private String accessToken;
+  protected String accessToken;
 
-  private final URI oauthEndPoint;
-  private final String clientId;
-  private final String clientSecret;
-  private final String userId;
-  private final String password;
-  private final String securityToken;
-  private final Operation operation;
+  protected final URI oauthEndPoint;
+  protected final String clientId;
+  protected final String clientSecret;
+  protected final String userId;
+  protected final String password;
+  protected final String securityToken;
+  protected final Operation operation;
 
-  private final int batchSize;
-  private final Optional<String> batchResourcePath;
-  private Optional<JsonArray> batchRecords = Optional.absent();
-  private long numRecordsWritten = 0L;
+  protected final int batchSize;
+  protected final Optional<String> batchResourcePath;
+  protected Optional<JsonArray> batchRecords = Optional.absent();
+  protected long numRecordsWritten = 0L;
 
   public SalesforceRestWriter(SalesForceRestWriterBuilder builder) {
     super(builder);


### PR DESCRIPTION
Change access modifiers for SalesforceWriter to protected to help extend on top of it.

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-486


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Change access modifiers for SalesforceWriter to protected to help extend on top of it.

Right now all fields are private and no getter is available. So, we need to open it up to protected for allowing custom impls on top of it.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tested locally, only access modifier is changed.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

