### PR TITLE
[GOBBLIN-488] Make AsyncRequest aware of records

### DIFF
--- a/gobblin-docs/sinks/Http.md
+++ b/gobblin-docs/sinks/Http.md
@@ -72,6 +72,7 @@ Configurations for the builder are:
 |---|---|---|
 | `gobblin.writer.http.urlTemplate` | Required, the url template(schema and port included), together with `keys` and `queryParams`, to be resolved to request url | ```http://www.test.com/profiles/${memberId}``` |
 | `gobblin.writer.http.verb` | Required, [http verbs](http://www.restapitutorial.com/lessons/httpmethods.html) | get, update, delete, etc |
+| `gobblin.writer.http.errorCodeWhitelist` | Optional, http error codes allowed to pass through | 404, 500, etc. No error code is allowed by default |
 | `gobblin.writer.http.maxAttempts` | Optional, max number of attempts including initial send | Default is 3 |
 | `gobblin.writer.http.contentType` | Optional, content type of the request body | ```"application/json"```, which is the default value |
 
@@ -92,6 +93,7 @@ rest request. The 3 major components are:
  | `gobblin.writer.http.urlTemplate` | Required, the url template(schema and port included), together with `keys` and `queryParams`, to be resolved to request url. If the schema is `d2`, d2 is enabled | ```http://www.test.com/profiles/${memberId}``` |
  | `gobblin.writer.http.verb` | Required, [rest(rest.li) verbs](https://github.com/linkedin/rest.li/wiki/Rest.li-User-Guide#resource-methods) | get, update, put, delete, etc |
  | `gobblin.writer.http.maxAttempts` | Optional, max number of attempts including initial send | Default is 3 |
+ | `gobblin.writer.http.errorCodeWhitelist` | Optional, http error codes allowed to pass through | 404, 500, etc. No error code is allowed by default |
  | `gobblin.writer.http.d2.zkHosts`| Required for d2, the zookeeper address | |
  | `gobblin.writer.http.(d2.)ssl`| Optional, enable ssl | Default is false |
  | `gobblin.writer.http.(d2.)keyStoreFilePath`| Required for ssl | /tmp/identity.p12 |

--- a/gobblin-modules/gobblin-http/src/test/java/org/apache/gobblin/writer/AsyncHttpWriterTest.java
+++ b/gobblin-modules/gobblin-http/src/test/java/org/apache/gobblin/writer/AsyncHttpWriterTest.java
@@ -94,6 +94,7 @@ public class AsyncHttpWriterTest {
     }
 
     Assert.assertTrue(client.isCloseCalled);
+    Assert.assertTrue(responseHandler.recordsInLastRequest.size() == 1);
   }
 
   @Test
@@ -292,9 +293,15 @@ public class AsyncHttpWriterTest {
   class MockResponseHandler implements ResponseHandler<HttpUriRequest, CloseableHttpResponse> {
     volatile StatusType type = StatusType.OK;
     int attempts = 0;
+    List<Object> recordsInLastRequest;
 
     @Override
     public ResponseStatus handleResponse(Request<HttpUriRequest> request, CloseableHttpResponse response) {
+      if (request instanceof AsyncRequest) {
+        AsyncRequest asyncRequest = (AsyncRequest) request;
+        recordsInLastRequest = new ArrayList<>();
+        asyncRequest.getThunks().forEach( thunk -> recordsInLastRequest.add(thunk));
+      }
       attempts++;
       switch (type) {
         case OK:


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/GOBBLIN-488


### Description
- [x] Here are some details about my PR:
Currently, while building an `AsyncRequest` from a collection of records, it doesn't know what records are processed. The pr is to make it records aware so that a `ResponseHandler` can do post-process the records if necessary

### Tests
- [x] My PR adds the following unit tests:
It's more a refactor, leveraging existing unit test: `AsyncHttpWriterTest#testSuccessfulWrites`


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

