### PR TITLE
[GOBBLIN-490] Allow jobs to be re-distributed to worker nodes and launch there

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
@@ -72,9 +72,9 @@ public class GobblinClusterConfigurationKeys {
   public static final String HELIX_INSTANCE_TAGS_KEY = GOBBLIN_CLUSTER_PREFIX + "helixInstanceTags";
 
   // Planning job properties
-  public static String PLANNING_JOB_NAME_PREFIX = "PlanningJob";
-  public static String PLANNING_CONF_PREFIX = "planning.";
-  public static String PLANNING_ID_KEY = PLANNING_CONF_PREFIX + "id.key";
+  public static final String PLANNING_JOB_NAME_PREFIX = "PlanningJob";
+  public static final String PLANNING_CONF_PREFIX = GOBBLIN_CLUSTER_PREFIX + "planning.";
+  public static final String PLANNING_ID_KEY = PLANNING_CONF_PREFIX + "idKey";
 
   /**
    * A path pointing to a directory that contains job execution files to be executed by Gobblin. This directory can

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
@@ -47,6 +47,11 @@ public class GobblinClusterConfigurationKeys {
   public static final boolean DEFAULT_STANDALONE_CLUSTER_MODE = false;
   public static final String CLUSTER_WORK_DIR = GOBBLIN_CLUSTER_PREFIX + "workDir";
 
+  public static final String DISTRIBUTED_JOB_LAUNCHER_ENABLED = GOBBLIN_CLUSTER_PREFIX + "distributedJobLauncherEnabled";
+  public static final boolean DEFAULT_DISTRIBUTED_JOB_LAUNCHER_ENABLED = false;
+  public static final String DISTRIBUTED_JOB_LAUNCHER_BUILDER = GOBBLIN_CLUSTER_PREFIX + "distributedJobLauncherBuilder";
+
+
   // Helix configuration properties.
   public static final String HELIX_CLUSTER_NAME_KEY = GOBBLIN_CLUSTER_PREFIX + "helix.cluster.name";
   public static final String MANAGER_CLUSTER_NAME_KEY = GOBBLIN_CLUSTER_PREFIX + "manager.cluster.name";
@@ -65,6 +70,11 @@ public class GobblinClusterConfigurationKeys {
   public static final boolean JOB_EXECUTE_IN_SCHEDULING_THREAD_DEFAULT = true;
   public static final String HELIX_JOB_TAG_KEY = GOBBLIN_CLUSTER_PREFIX + "helixJobTag";
   public static final String HELIX_INSTANCE_TAGS_KEY = GOBBLIN_CLUSTER_PREFIX + "helixInstanceTags";
+
+  // Planning job properties
+  public static String PLANNING_JOB_NAME_PREFIX = "PlanningJob";
+  public static String PLANNING_CONF_PREFIX = "planning.";
+  public static String PLANNING_ID_KEY = PLANNING_CONF_PREFIX + "id.key";
 
   /**
    * A path pointing to a directory that contains job execution files to be executed by Gobblin. This directory can

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixDistributeJobExecutionLauncher.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixDistributeJobExecutionLauncher.java
@@ -1,0 +1,280 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.cluster;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeoutException;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.helix.HelixManager;
+import org.apache.helix.task.JobConfig;
+import org.apache.helix.task.TaskConfig;
+import org.apache.helix.task.TaskDriver;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigValueFactory;
+
+import javax.annotation.Nonnull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.gobblin.annotation.Alpha;
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.configuration.State;
+import org.apache.gobblin.metrics.MetricContext;
+import org.apache.gobblin.metrics.Tag;
+import org.apache.gobblin.runtime.JobState;
+import org.apache.gobblin.runtime.TaskState;
+import org.apache.gobblin.runtime.api.ExecutionResult;
+import org.apache.gobblin.runtime.api.JobExecutionLauncher;
+import org.apache.gobblin.runtime.api.JobExecutionMonitor;
+import org.apache.gobblin.runtime.api.JobSpec;
+import org.apache.gobblin.runtime.api.MonitoredObject;
+import org.apache.gobblin.runtime.util.StateStores;
+import org.apache.gobblin.source.extractor.partition.Partitioner;
+import org.apache.gobblin.util.ConfigUtils;
+import org.apache.gobblin.util.JobLauncherUtils;
+import org.apache.gobblin.util.PropertiesUtils;
+
+
+/**
+ * This {@link JobExecutionLauncher} submits job to Helix. The job will be assigned to one of Helix participant instances.
+ * The assigned instances parse job properties and run the task driver logic.
+ */
+@Alpha
+@Slf4j
+class GobblinHelixDistributeJobExecutionLauncher implements JobExecutionLauncher {
+  protected HelixManager helixManager;
+  protected TaskDriver helixTaskDriver;
+  protected Properties sysProperties;
+  protected Properties jobProperties;
+  protected StateStores stateStores;
+
+  protected static final String PLANNING_WORK_UNIT_DIR_NAME = "_plan_workunits";
+  protected static final String PLANNING_TASK_STATE_DIR_NAME = "_plan_taskstates";
+  protected static final String PLANNING_JOB_STATE_DIR_NAME = "_plan_jobstates";
+
+  public GobblinHelixDistributeJobExecutionLauncher(Builder builder) throws Exception {
+    this.helixManager = builder.manager;
+    this.helixTaskDriver = new TaskDriver(this.helixManager);
+    this.sysProperties = builder.sysProperties;
+    this.jobProperties = builder.jobProperties;
+
+    Config combined = ConfigUtils.propertiesToConfig(jobProperties)
+        .withFallback(ConfigUtils.propertiesToConfig(sysProperties));
+
+    Config stateStoreJobConfig = combined
+        .withValue(ConfigurationKeys.STATE_STORE_FS_URI_KEY, ConfigValueFactory.fromAnyRef(
+            new URI(builder.appWorkDir.toUri().getScheme(), null, builder.appWorkDir.toUri().getHost(),
+                builder.appWorkDir.toUri().getPort(), null, null, null).toString()));
+
+    this.stateStores = new StateStores(stateStoreJobConfig,
+        builder.appWorkDir, PLANNING_TASK_STATE_DIR_NAME,
+        builder.appWorkDir, PLANNING_WORK_UNIT_DIR_NAME,
+        builder.appWorkDir, PLANNING_JOB_STATE_DIR_NAME);
+  }
+
+  @Setter
+  public static class Builder {
+    Properties sysProperties;
+    Properties jobProperties;
+    HelixManager manager;
+    Path appWorkDir;
+    public GobblinHelixDistributeJobExecutionLauncher build() throws Exception {
+      return new GobblinHelixDistributeJobExecutionLauncher(this);
+    }
+  }
+
+  private String getPlanningJobName (Properties jobProps) {
+    String jobName = JobState.getJobNameFromProps(jobProps);
+    return GobblinClusterConfigurationKeys.PLANNING_JOB_NAME_PREFIX + jobName;
+  }
+
+  protected String getPlanningJobId (Properties jobProps) {
+    if (jobProps.containsKey(GobblinClusterConfigurationKeys.PLANNING_ID_KEY)) {
+      return jobProps.getProperty(GobblinClusterConfigurationKeys.PLANNING_ID_KEY);
+    }
+    String planningId = JobLauncherUtils.newJobId(getPlanningJobName(jobProps));
+    jobProps.setProperty(GobblinClusterConfigurationKeys.PLANNING_ID_KEY, planningId);
+    return planningId;
+  }
+
+  private JobConfig.Builder createPlanningJob (Properties jobProps) {
+    // Create a single task for job planning
+    String planningId = getPlanningJobId(jobProps);
+    Map<String, TaskConfig> taskConfigMap = Maps.newHashMap();
+    Map<String, String> rawConfigMap = Maps.newHashMap();
+    for (String key : jobProps.stringPropertyNames()) {
+      rawConfigMap.put(GobblinClusterConfigurationKeys.PLANNING_CONF_PREFIX + key, (String)jobProps.get(key));
+    }
+    rawConfigMap.put(GobblinClusterConfigurationKeys.TASK_SUCCESS_OPTIONAL_KEY, "true");
+
+    // Create a single Job which only contains a single task
+    taskConfigMap.put(planningId, TaskConfig.Builder.from(rawConfigMap));
+    JobConfig.Builder jobConfigBuilder = new JobConfig.Builder();
+
+    jobConfigBuilder.setTimeoutPerTask(PropertiesUtils.getPropAsLong(
+        jobProps,
+        ConfigurationKeys.HELIX_TASK_TIMEOUT_SECONDS,
+        ConfigurationKeys.DEFAULT_HELIX_TASK_TIMEOUT_SECONDS) * 1000);
+
+    jobConfigBuilder.setFailureThreshold(1);
+    jobConfigBuilder.addTaskConfigMap(taskConfigMap).setCommand(GobblinTaskRunner.GOBBLIN_JOB_FACTORY_NAME);
+
+    return jobConfigBuilder;
+  }
+
+  private void submitJobToHelix(String jobName, String jobId, JobConfig.Builder jobConfigBuilder) throws Exception {
+    TaskDriver taskDriver = new TaskDriver(this.helixManager);
+    HelixUtils.submitJobToQueue(jobConfigBuilder,
+        jobName,
+        jobId,
+        taskDriver,
+        this.helixManager,
+        60*60);
+  }
+
+  @Override
+  public DistributeJobMonitor launchJob(JobSpec jobSpec) {
+    return new DistributeJobMonitor(new DistributeJobCallable(this.jobProperties));
+  }
+
+  @AllArgsConstructor
+  private class DistributeJobCallable implements Callable<ExecutionResult> {
+    Properties jobProps;
+    @Override
+    public DistributeJobResult call()
+        throws Exception {
+      String planningName = getPlanningJobName(this.jobProps);
+      String planningId = getPlanningJobId(this.jobProps);
+      JobConfig.Builder builder = createPlanningJob(this.jobProps);
+      try {
+        submitJobToHelix(planningName, planningId, builder);
+        return waitForJobCompletion(planningName, planningId);
+      } catch (Exception e) {
+        log.error(planningName + " is not able to submit.");
+        return new DistributeJobResult(Optional.empty(), Optional.of(e));
+      }
+    }
+  }
+
+  private DistributeJobResult waitForJobCompletion(String planningName, String planningId) throws InterruptedException {
+    boolean timeoutEnabled = Boolean.parseBoolean(this.jobProperties.getProperty(ConfigurationKeys.HELIX_JOB_TIMEOUT_ENABLED_KEY,
+        ConfigurationKeys.DEFAULT_HELIX_JOB_TIMEOUT_ENABLED));
+    long timeoutInSeconds = Long.parseLong(this.jobProperties.getProperty(ConfigurationKeys.HELIX_JOB_TIMEOUT_SECONDS,
+        ConfigurationKeys.DEFAULT_HELIX_JOB_TIMEOUT_SECONDS));
+
+    try {
+      HelixUtils.waitJobCompletion(
+          GobblinHelixDistributeJobExecutionLauncher.this.helixManager,
+          planningName,
+          planningId,
+          timeoutEnabled? Optional.of(timeoutInSeconds) : Optional.empty());
+      return getResultFromUserContent();
+    } catch (TimeoutException te) {
+      HelixUtils.helixTaskDriverWaitToStop(helixManager, helixTaskDriver, planningName, 10L);
+      this.helixTaskDriver.delete(planningName);
+      this.helixTaskDriver.resume(planningName);
+      log.info("stopped the queue, deleted the job");
+      return new DistributeJobResult(Optional.empty(), Optional.of(te));
+    }
+  }
+
+  //TODO: change below to Helix UserConentStore
+  protected DistributeJobResult getResultFromUserContent() {
+    String planningId = getPlanningJobId(this.jobProperties);
+    try {
+      TaskState taskState = this.stateStores.getTaskStateStore().get(planningId, planningId, planningId);
+      return new DistributeJobResult(Optional.of(taskState.getProperties()), Optional.empty());
+    } catch (IOException e) {
+      return new DistributeJobResult(Optional.empty(), Optional.of(e));
+    }
+  }
+
+  @Getter
+  @AllArgsConstructor
+  class DistributeJobResult implements ExecutionResult {
+    boolean isEarlyStopped = false;
+    Optional<Properties> properties;
+    Optional<Throwable> throwable;
+    public DistributeJobResult(Optional<Properties> properties, Optional<Throwable> throwable) {
+      this.properties = properties;
+      this.throwable = throwable;
+      if (properties.isPresent()) {
+        isEarlyStopped = PropertiesUtils.getPropAsBoolean(this.properties.get(), Partitioner.IS_EARLY_STOPPED, "false");
+      }
+    }
+  }
+
+  class DistributeJobMonitor extends FutureTask<ExecutionResult> implements JobExecutionMonitor {
+    private ExecutorService executor = Executors.newSingleThreadExecutor();
+    public DistributeJobMonitor (Callable<ExecutionResult> c) {
+      super(c);
+      this.executor.execute(this);
+    }
+
+    @Override
+    public MonitoredObject getRunningState() {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  @Override
+  public StandardMetrics getMetrics() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Nonnull
+  @Override
+  public MetricContext getMetricContext() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean isInstrumentationEnabled() {
+    return false;
+  }
+
+  @Override
+  public List<Tag<?>> generateTags(State state) {
+    return Lists.newArrayList();
+  }
+
+  @Override
+  public void switchMetricContext(List<Tag<?>> tags) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void switchMetricContext(MetricContext context) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobFactory.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobFactory.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.cluster;
+
+import java.net.URI;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.helix.task.Task;
+import org.apache.helix.task.TaskCallbackContext;
+import org.apache.helix.task.TaskFactory;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigValueFactory;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.runtime.util.StateStores;
+import org.apache.gobblin.util.PathUtils;
+
+
+/**
+ * An implementation of Helix's {@link TaskFactory} for {@link GobblinHelixJobTask}s.
+ */
+@Slf4j
+public class GobblinHelixJobFactory implements TaskFactory {
+  protected Config sysConfig;
+  protected StateStores stateStores;
+
+  public GobblinHelixJobFactory(TaskRunnerSuiteBase.Builder builder) {
+    this.sysConfig = builder.getConfig();
+    Path appWorkDir = builder.getAppWorkPath();
+    URI rootPathUri = PathUtils.getRootPath(appWorkDir).toUri();
+    Config stateStoreJobConfig = sysConfig
+        .withValue(ConfigurationKeys.STATE_STORE_FS_URI_KEY,
+            ConfigValueFactory.fromAnyRef(rootPathUri.toString()));
+
+    this.stateStores = new StateStores(stateStoreJobConfig,
+        appWorkDir, GobblinHelixDistributeJobExecutionLauncher.PLANNING_TASK_STATE_DIR_NAME,
+        appWorkDir, GobblinHelixDistributeJobExecutionLauncher.PLANNING_WORK_UNIT_DIR_NAME,
+        appWorkDir, GobblinHelixDistributeJobExecutionLauncher.PLANNING_JOB_STATE_DIR_NAME);
+  }
+
+  @Override
+  public Task createNewTask(TaskCallbackContext context) {
+    return new GobblinHelixJobTask(context, this.sysConfig, stateStores);
+  }
+}

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobTask.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobTask.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.cluster;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Properties;
+
+import org.apache.helix.task.Task;
+import org.apache.helix.task.TaskCallbackContext;
+import org.apache.helix.task.TaskConfig;
+import org.apache.helix.task.TaskResult;
+
+import com.google.common.collect.ImmutableMap;
+import com.typesafe.config.Config;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.configuration.WorkUnitState;
+import org.apache.gobblin.runtime.TaskState;
+import org.apache.gobblin.runtime.util.StateStores;
+import org.apache.gobblin.source.extractor.partition.Partitioner;
+import org.apache.gobblin.util.ConfigUtils;
+
+/**
+ * An implementation of Helix's {@link org.apache.helix.task.Task} that runs original {@link GobblinHelixJobLauncher}
+ */
+@Slf4j
+public class GobblinHelixJobTask implements Task {
+
+  private final TaskConfig taskConfig;
+  private Config sysConfig;
+  private Properties jobConfig;
+  private StateStores stateStores;
+  private String planningJobId;
+
+  public GobblinHelixJobTask(TaskCallbackContext context,
+      Config sysConfig,
+      StateStores stateStores) {
+    this.taskConfig = context.getTaskConfig();
+    this.sysConfig = sysConfig;
+    this.jobConfig = ConfigUtils.configToProperties(sysConfig);
+    Map<String, String> configMap = this.taskConfig.getConfigMap();
+    for (Map.Entry<String, String> entry: configMap.entrySet()) {
+      if (entry.getKey().startsWith(GobblinClusterConfigurationKeys.PLANNING_CONF_PREFIX)) {
+          String key = entry.getKey().replaceFirst(GobblinClusterConfigurationKeys.PLANNING_CONF_PREFIX, "");
+          jobConfig.put(key, entry.getValue());
+      }
+    }
+
+    if (!jobConfig.containsKey(GobblinClusterConfigurationKeys.PLANNING_ID_KEY)) {
+      throw new RuntimeException("Job doesn't have plannning ID");
+    }
+
+    this.planningJobId = jobConfig.getProperty(GobblinClusterConfigurationKeys.PLANNING_ID_KEY);
+    this.stateStores = stateStores;
+  }
+
+  @Override
+  public TaskResult run() {
+    log.info("We will run planning job " + this.planningJobId);
+
+    // TODO: We should run GobblinHelixJobLauncher#launchJob() here
+
+    try {
+      setResultToUserContent(ImmutableMap.of(Partitioner.IS_EARLY_STOPPED, "false"));
+    } catch (IOException e) {
+      return new TaskResult(TaskResult.Status.FAILED, "State store cannot be persisted for job " + planningJobId);
+    }
+    return new TaskResult(TaskResult.Status.COMPLETED, "");
+  }
+
+  //TODO: change below to Helix UserConentStore
+  protected void setResultToUserContent(Map<String, String> keyValues) throws IOException {
+    WorkUnitState wus = new WorkUnitState();
+    wus.setProp(ConfigurationKeys.JOB_ID_KEY, this.planningJobId);
+    wus.setProp(ConfigurationKeys.TASK_ID_KEY, this.planningJobId);
+    wus.setProp(ConfigurationKeys.TASK_KEY_KEY, this.planningJobId);
+    keyValues.forEach((key, value)->wus.setProp(key, value));
+    TaskState taskState = new TaskState(wus);
+
+    this.stateStores.getTaskStateStore().put(this.planningJobId, this.planningJobId, taskState);
+  }
+
+  @Override
+  public void cancel() {
+    // TODO: We should delete the real job.
+  }
+}

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobTask.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobTask.java
@@ -26,6 +26,7 @@ import org.apache.helix.task.TaskCallbackContext;
 import org.apache.helix.task.TaskConfig;
 import org.apache.helix.task.TaskResult;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.typesafe.config.Config;
 
@@ -58,8 +59,8 @@ public class GobblinHelixJobTask implements Task {
     this.jobConfig = ConfigUtils.configToProperties(sysConfig);
     Map<String, String> configMap = this.taskConfig.getConfigMap();
     for (Map.Entry<String, String> entry: configMap.entrySet()) {
-      if (entry.getKey().startsWith(GobblinClusterConfigurationKeys.PLANNING_CONF_PREFIX)) {
-          String key = entry.getKey().replaceFirst(GobblinClusterConfigurationKeys.PLANNING_CONF_PREFIX, "");
+      if (entry.getKey().startsWith(GobblinHelixDistributeJobExecutionLauncher.JOB_PROPS_PREFIX)) {
+          String key = entry.getKey().replaceFirst(GobblinHelixDistributeJobExecutionLauncher.JOB_PROPS_PREFIX, "");
           jobConfig.put(key, entry.getValue());
       }
     }
@@ -87,6 +88,7 @@ public class GobblinHelixJobTask implements Task {
   }
 
   //TODO: change below to Helix UserConentStore
+  @VisibleForTesting
   protected void setResultToUserContent(Map<String, String> keyValues) throws IOException {
     WorkUnitState wus = new WorkUnitState();
     wus.setProp(ConfigurationKeys.JOB_ID_KEY, this.planningJobId);

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinTaskRunner.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinTaskRunner.java
@@ -59,7 +59,6 @@ import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.common.eventbus.EventBus;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.Service;
@@ -116,6 +115,8 @@ public class GobblinTaskRunner implements StandardMetricsBridge {
   static final java.nio.file.Path CLUSTER_CONF_PATH = Paths.get("generated-gobblin-cluster.conf");
 
   static final String GOBBLIN_TASK_FACTORY_NAME = "GobblinTaskFactory";
+
+  static final String GOBBLIN_JOB_FACTORY_NAME = "GobblinJobFactory";
 
   private final String helixInstanceName;
 
@@ -175,7 +176,7 @@ public class GobblinTaskRunner implements StandardMetricsBridge {
         .setFileSystem(this.fs)
         .setHelixManager(this.helixManager).build();
 
-    this.taskStateModelFactory = createTaskStateModelFactory(suite.getTaskFactory());
+    this.taskStateModelFactory = createTaskStateModelFactory(suite.getTaskFactoryMap());
     this.metrics = suite.getTaskMetrics();
     this.metricContext = suite.getMetricContext();
     this.services.addAll(suite.getServices());
@@ -205,10 +206,7 @@ public class GobblinTaskRunner implements StandardMetricsBridge {
         this.clusterName, this.helixInstanceName, InstanceType.PARTICIPANT, zkConnectionString);
   }
 
-  private TaskStateModelFactory createTaskStateModelFactory(TaskFactory factory) {
-    Map<String, TaskFactory> taskFactoryMap = Maps.newHashMap();
-
-    taskFactoryMap.put(GOBBLIN_TASK_FACTORY_NAME, factory);
+  private TaskStateModelFactory createTaskStateModelFactory(Map<String, TaskFactory> taskFactoryMap) {
     TaskStateModelFactory taskStateModelFactory =
         new TaskStateModelFactory(this.helixManager, taskFactoryMap);
     this.helixManager.getStateMachineEngine()

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/HelixRetriggeringJobCallable.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/HelixRetriggeringJobCallable.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.cluster;
+
+import java.util.Properties;
+import java.util.concurrent.Callable;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.helix.HelixManager;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.gobblin.annotation.Alpha;
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.runtime.JobException;
+import org.apache.gobblin.runtime.JobLauncher;
+import org.apache.gobblin.runtime.api.ExecutionResult;
+import org.apache.gobblin.runtime.api.JobExecutionMonitor;
+import org.apache.gobblin.runtime.listeners.JobListener;
+import org.apache.gobblin.util.ClassAliasResolver;
+import org.apache.gobblin.util.PropertiesUtils;
+import org.apache.gobblin.util.reflection.GobblinConstructorUtils;
+
+
+/**
+ * A {@link Callable} that runs {@link JobLauncher} multiple times iff re-triggering is enabled and job stops early.
+ */
+@Slf4j
+@Alpha
+class HelixRetriggeringJobCallable implements Callable {
+  private GobblinHelixJobScheduler jobScheduler;
+  private Properties sysProps;
+  private Properties jobProps;
+  private JobListener jobListener;
+  private JobLauncher currentJobLauncher = null;
+  private JobExecutionMonitor currentJobMonitor = null;
+  private Path appWorkDir;
+  private HelixManager helixManager;
+
+  public HelixRetriggeringJobCallable(
+      GobblinHelixJobScheduler jobScheduler,
+      Properties sysProps,
+      Properties jobProps,
+      JobListener jobListener,
+      Path appWorkDir,
+      HelixManager helixManager) {
+    this.jobScheduler = jobScheduler;
+    this.sysProps = sysProps;
+    this.jobProps = jobProps;
+    this.jobListener = jobListener;
+    this.appWorkDir = appWorkDir;
+    this.helixManager = helixManager;
+  }
+
+  private boolean isRetriggeringEnabled() {
+    return PropertiesUtils.getPropAsBoolean(jobProps, ConfigurationKeys.JOB_RETRIGGERING_ENABLED,
+        ConfigurationKeys.DEFAULT_JOB_RETRIGGERING_ENABLED);
+  }
+
+  private boolean isDistributeJobEnabled() {
+    Properties combinedProps = new Properties();
+    combinedProps.putAll(sysProps);
+    combinedProps.putAll(jobProps);
+    return (PropertiesUtils.getPropAsBoolean(combinedProps,
+        GobblinClusterConfigurationKeys.DISTRIBUTED_JOB_LAUNCHER_ENABLED,
+        Boolean.toString(GobblinClusterConfigurationKeys.DEFAULT_DISTRIBUTED_JOB_LAUNCHER_ENABLED)));
+  }
+
+  @Override
+  public Void call() throws JobException {
+    if (isDistributeJobEnabled()) {
+      launchJobExecutionLauncherLoop();
+    } else {
+      launchJobLauncherLoop();
+    }
+
+    return null;
+  }
+
+  private void launchJobLauncherLoop() throws JobException {
+    try {
+      while (true) {
+        currentJobLauncher = this.jobScheduler.buildJobLauncher(jobProps);
+        boolean isEarlyStopped = this.jobScheduler.runJob(jobProps, jobListener, currentJobLauncher);
+        boolean isRetriggerEnabled = this.isRetriggeringEnabled();
+        if (isEarlyStopped && isRetriggerEnabled) {
+          log.info("Job {} will be re-triggered.", jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY));
+        } else {
+          break;
+        }
+        currentJobLauncher = null;
+      }
+    } catch (Exception e) {
+      log.error("Failed to run job {}", jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY), e);
+      throw new JobException("Failed to run job " + jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY), e);
+    }
+  }
+
+  private void launchJobExecutionLauncherLoop() throws JobException {
+    try {
+      while (true) {
+        String builderStr = jobProps.getProperty(GobblinClusterConfigurationKeys.DISTRIBUTED_JOB_LAUNCHER_BUILDER, GobblinHelixDistributeJobExecutionLauncher.Builder.class.getName());
+        GobblinHelixDistributeJobExecutionLauncher.Builder builder = GobblinConstructorUtils.<GobblinHelixDistributeJobExecutionLauncher.Builder>invokeLongestConstructor(
+            new ClassAliasResolver(GobblinHelixDistributeJobExecutionLauncher.Builder.class).resolveClass(builderStr));
+
+        builder.setSysProperties(this.sysProps);
+        builder.setJobProperties(this.jobProps);
+        builder.setManager(this.helixManager);
+        builder.setAppWorkDir(this.appWorkDir);
+
+        this.currentJobMonitor = builder.build().launchJob(null);
+        ExecutionResult result = this.currentJobMonitor.get();
+        boolean isEarlyStopped = ((GobblinHelixDistributeJobExecutionLauncher.DistributeJobResult) result).isEarlyStopped();
+        boolean isRetriggerEnabled = this.isRetriggeringEnabled();
+        if (isEarlyStopped && isRetriggerEnabled) {
+          log.info("DistributeJob {} will be re-triggered.", jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY));
+        } else {
+          break;
+        }
+        currentJobMonitor = null;
+      }
+    } catch (Exception e) {
+      log.error("Failed to run job {}", jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY), e);
+      throw new JobException("Failed to run job " + jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY), e);
+    }
+  }
+
+  public void cancel() throws JobException {
+    if (currentJobLauncher != null) {
+      currentJobLauncher.cancelJob(this.jobListener);
+    } else if (currentJobMonitor != null) {
+      currentJobMonitor.cancel(false);
+    }
+  }
+}

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/TaskRunnerSuiteBase.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/TaskRunnerSuiteBase.java
@@ -18,6 +18,7 @@
 package org.apache.gobblin.cluster;
 
 import java.util.List;
+import java.util.Map;
 
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -32,6 +33,7 @@ import com.typesafe.config.Config;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
+import org.apache.gobblin.annotation.Alpha;
 import org.apache.gobblin.instrumented.Instrumented;
 import org.apache.gobblin.instrumented.StandardMetricsBridge;
 import org.apache.gobblin.metrics.MetricContext;
@@ -46,8 +48,10 @@ import org.apache.gobblin.util.ConfigUtils;
  * A list of {@link Service} : register any runtime services necessary to run the tasks.
  */
 @Slf4j
+@Alpha
 public abstract class TaskRunnerSuiteBase {
   protected TaskFactory taskFactory;
+  protected TaskFactory jobFactory;
   protected MetricContext metricContext;
   protected StandardMetricsBridge.StandardMetrics taskMetrics;
   protected List<Service> services = Lists.newArrayList();
@@ -62,7 +66,7 @@ public abstract class TaskRunnerSuiteBase {
 
   protected abstract StandardMetricsBridge.StandardMetrics getTaskMetrics();
 
-  protected abstract TaskFactory getTaskFactory();
+  protected abstract Map<String, TaskFactory> getTaskFactoryMap();
 
   protected abstract List<Service> getServices();
 

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/TaskRunnerSuiteProcessModel.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/TaskRunnerSuiteProcessModel.java
@@ -18,10 +18,12 @@
 package org.apache.gobblin.cluster;
 
 import java.util.List;
+import java.util.Map;
 
 import org.apache.helix.task.TaskCallbackContext;
 import org.apache.helix.task.TaskFactory;
 
+import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.Service;
 
 import lombok.extern.slf4j.Slf4j;
@@ -51,8 +53,13 @@ class TaskRunnerSuiteProcessModel extends TaskRunnerSuiteBase {
   }
 
   @Override
-  protected TaskFactory getTaskFactory() {
-    return this.taskFactory;
+  protected Map<String, TaskFactory> getTaskFactoryMap() {
+    Map<String, TaskFactory> taskFactoryMap = Maps.newHashMap();
+
+    taskFactoryMap.put(GobblinTaskRunner.GOBBLIN_TASK_FACTORY_NAME, taskFactory);
+
+    //TODO: taskFactoryMap.put(GOBBLIN_JOB_FACTORY_NAME, jobFactory);
+    return taskFactoryMap;
   }
 
   @Override

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/TaskRunnerSuiteThreadModel.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/TaskRunnerSuiteThreadModel.java
@@ -19,11 +19,13 @@ package org.apache.gobblin.cluster;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 import org.apache.helix.task.TaskFactory;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.Service;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigValueFactory;
@@ -46,6 +48,7 @@ class TaskRunnerSuiteThreadModel extends TaskRunnerSuiteBase {
     super(builder);
     this.taskExecutor = new TaskExecutor(ConfigUtils.configToProperties(builder.getConfig()));
     this.taskFactory = getInProcessTaskFactory(taskExecutor, builder);
+    this.jobFactory = new GobblinHelixJobFactory(builder);
     this.taskMetrics = new GobblinTaskRunnerMetrics.InProcessTaskRunnerMetrics(taskExecutor, metricContext);
   }
 
@@ -55,8 +58,11 @@ class TaskRunnerSuiteThreadModel extends TaskRunnerSuiteBase {
   }
 
   @Override
-  protected TaskFactory getTaskFactory() {
-    return this.taskFactory;
+  protected Map<String, TaskFactory> getTaskFactoryMap() {
+    Map<String, TaskFactory> taskFactoryMap = Maps.newHashMap();
+    taskFactoryMap.put(GobblinTaskRunner.GOBBLIN_TASK_FACTORY_NAME, taskFactory);
+    taskFactoryMap.put(GobblinTaskRunner.GOBBLIN_JOB_FACTORY_NAME, jobFactory);
+    return taskFactoryMap;
   }
 
   @Override

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/ClusterIntegrationTest.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/ClusterIntegrationTest.java
@@ -24,6 +24,7 @@ import org.testng.annotations.Test;
 
 import org.apache.gobblin.cluster.suite.IntegrationBasicSuite;
 import org.apache.gobblin.cluster.suite.IntegrationDedicatedManagerClusterSuite;
+import org.apache.gobblin.cluster.suite.IntegrationJobFactorySuite;
 import org.apache.gobblin.cluster.suite.IntegrationJobTagSuite;
 import org.apache.gobblin.cluster.suite.IntegrationSeparateProcessSuite;
 
@@ -56,6 +57,13 @@ public class ClusterIntegrationTest {
   public void testJobWithTag()
       throws Exception {
     this.suite = new IntegrationJobTagSuite();
+    runAndVerify();
+  }
+
+  @Test
+  public void testPlanningJobFactory()
+      throws Exception {
+    this.suite = new IntegrationJobFactorySuite();
     runAndVerify();
   }
 

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/TaskRunnerSuiteForJobFactoryTest.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/TaskRunnerSuiteForJobFactoryTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.gobblin.cluster;
 
 import java.io.IOException;
@@ -56,7 +73,11 @@ public class TaskRunnerSuiteForJobFactoryTest extends TaskRunnerSuiteThreadModel
 
     //TODO: change below to Helix UserConentStore
     protected void setResultToUserContent(Map<String, String> keyValues) throws IOException {
-      super.setResultToUserContent(keyValues);
+      Map<String, String> customizedKVs = Maps.newHashMap(keyValues);
+      customizedKVs.put("customizedKey_1", "customizedVal_1");
+      customizedKVs.put("customizedKey_2", "customizedVal_2");
+      customizedKVs.put("customizedKey_3", "customizedVal_3");
+      super.setResultToUserContent(customizedKVs);
     }
   }
 
@@ -71,7 +92,12 @@ public class TaskRunnerSuiteForJobFactoryTest extends TaskRunnerSuiteThreadModel
     protected DistributeJobResult getResultFromUserContent() {
       DistributeJobResult rst = super.getResultFromUserContent();
       Properties properties = rst.getProperties().get();
+      Assert.assertTrue(properties.containsKey(Partitioner.IS_EARLY_STOPPED));
       Assert.assertFalse(PropertiesUtils.getPropAsBoolean(properties, Partitioner.IS_EARLY_STOPPED, "false"));
+
+      Assert.assertTrue(properties.getProperty("customizedKey_1").equals("customizedVal_1"));
+      Assert.assertTrue(properties.getProperty("customizedKey_2").equals("customizedVal_2"));
+      Assert.assertTrue(properties.getProperty("customizedKey_3").equals("customizedVal_3"));
       IntegrationJobFactorySuite.completed.set(true);
       return rst;
     }

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/TaskRunnerSuiteForJobFactoryTest.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/TaskRunnerSuiteForJobFactoryTest.java
@@ -1,0 +1,87 @@
+package org.apache.gobblin.cluster;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Properties;
+
+import org.apache.helix.task.Task;
+import org.apache.helix.task.TaskCallbackContext;
+import org.apache.helix.task.TaskFactory;
+import org.testng.Assert;
+
+import com.google.common.collect.Maps;
+import com.typesafe.config.Config;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.gobblin.annotation.Alias;
+import org.apache.gobblin.cluster.suite.IntegrationJobFactorySuite;
+import org.apache.gobblin.runtime.util.StateStores;
+import org.apache.gobblin.source.extractor.partition.Partitioner;
+import org.apache.gobblin.util.PropertiesUtils;
+
+
+public class TaskRunnerSuiteForJobFactoryTest extends TaskRunnerSuiteThreadModel {
+  private TaskFactory testJobFactory;
+  public TaskRunnerSuiteForJobFactoryTest(IntegrationJobFactorySuite.TestJobFactorySuiteBuilder builder) {
+    super(builder);
+    this.testJobFactory = new TestJobFactory(builder);
+  }
+
+  @Override
+  protected Map<String, TaskFactory> getTaskFactoryMap() {
+    Map<String, TaskFactory> taskFactoryMap = Maps.newHashMap();
+    taskFactoryMap.put(GobblinTaskRunner.GOBBLIN_TASK_FACTORY_NAME, taskFactory);
+    taskFactoryMap.put(GobblinTaskRunner.GOBBLIN_JOB_FACTORY_NAME, testJobFactory);
+    return taskFactoryMap;
+  }
+
+  public class TestJobFactory extends GobblinHelixJobFactory {
+    public TestJobFactory(IntegrationJobFactorySuite.TestJobFactorySuiteBuilder builder) {
+      super (builder);
+    }
+
+    @Override
+    public Task createNewTask(TaskCallbackContext context) {
+      return new TestHelixJobTask(context, this.sysConfig, stateStores);
+    }
+  }
+
+  public class TestHelixJobTask extends GobblinHelixJobTask {
+    public TestHelixJobTask(TaskCallbackContext context,
+        Config sysConfig,
+        StateStores stateStores) {
+      super(context, sysConfig, stateStores);
+    }
+
+    //TODO: change below to Helix UserConentStore
+    protected void setResultToUserContent(Map<String, String> keyValues) throws IOException {
+      super.setResultToUserContent(keyValues);
+    }
+  }
+
+  @Slf4j
+  public static class TestDistributedExecutionLauncher extends GobblinHelixDistributeJobExecutionLauncher {
+
+    public TestDistributedExecutionLauncher(GobblinHelixDistributeJobExecutionLauncher.Builder builder) throws Exception {
+      super(builder);
+    }
+
+    //TODO: change below to Helix UserConentStore
+    protected DistributeJobResult getResultFromUserContent() {
+      DistributeJobResult rst = super.getResultFromUserContent();
+      Properties properties = rst.getProperties().get();
+      Assert.assertFalse(PropertiesUtils.getPropAsBoolean(properties, Partitioner.IS_EARLY_STOPPED, "false"));
+      IntegrationJobFactorySuite.completed.set(true);
+      return rst;
+    }
+
+
+    @Alias("TestDistributedExecutionLauncherBuilder")
+    public static class Builder extends GobblinHelixDistributeJobExecutionLauncher.Builder {
+      public TestDistributedExecutionLauncher build() throws Exception {
+        return new TestDistributedExecutionLauncher(this);
+      }
+    }
+  }
+}

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/TaskRunnerSuiteForJobTagTest.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/TaskRunnerSuiteForJobTagTest.java
@@ -25,6 +25,8 @@ import org.apache.helix.task.TaskCallbackContext;
 import org.apache.helix.task.TaskFactory;
 import org.testng.Assert;
 
+import com.google.common.collect.Maps;
+
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.gobblin.cluster.suite.IntegrationJobTagSuite;
@@ -45,8 +47,10 @@ public class TaskRunnerSuiteForJobTagTest extends TaskRunnerSuiteThreadModel {
   }
 
   @Override
-  protected TaskFactory getTaskFactory() {
-    return this.jobTagTestFactory;
+  protected Map<String, TaskFactory> getTaskFactoryMap() {
+    Map<String, TaskFactory> taskFactoryMap = Maps.newHashMap();
+    taskFactoryMap.put(GobblinTaskRunner.GOBBLIN_TASK_FACTORY_NAME, jobTagTestFactory);
+    return taskFactoryMap;
   }
 
 

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/suite/IntegrationJobFactorySuite.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/suite/IntegrationJobFactorySuite.java
@@ -1,0 +1,64 @@
+package org.apache.gobblin.cluster.suite;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.testng.collections.Lists;
+
+import com.google.common.collect.ImmutableMap;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.gobblin.annotation.Alias;
+import org.apache.gobblin.cluster.GobblinClusterConfigurationKeys;
+import org.apache.gobblin.cluster.TaskRunnerSuiteBase;
+import org.apache.gobblin.cluster.TaskRunnerSuiteForJobFactoryTest;
+
+@Slf4j
+public class IntegrationJobFactorySuite extends IntegrationBasicSuite {
+
+  public static AtomicBoolean completed = new AtomicBoolean(false);
+
+  @Override
+  protected Map<String, Config> overrideJobConfigs(Config rawJobConfig) {
+    Config newConfig = ConfigFactory.parseMap(ImmutableMap.of(
+        GobblinClusterConfigurationKeys.DISTRIBUTED_JOB_LAUNCHER_ENABLED, true,
+        GobblinClusterConfigurationKeys.DISTRIBUTED_JOB_LAUNCHER_BUILDER, "TestDistributedExecutionLauncherBuilder"));
+    return ImmutableMap.of("HelloWorldJob", newConfig);
+  }
+
+  @Override
+  public Collection<Config> getWorkerConfigs() {
+    Config rawConfig = super.getWorkerConfigs().iterator().next();
+    Config workerConfig = ConfigFactory.parseMap(ImmutableMap.of(GobblinClusterConfigurationKeys.TASK_RUNNER_SUITE_BUILDER, "TestJobFactorySuiteBuilder"))
+        .withFallback(rawConfig);
+
+    return Lists.newArrayList(workerConfig);
+  }
+
+  public void waitForAndVerifyOutputFiles() throws Exception {
+    while (true) {
+      Thread.sleep(1000);
+      if (completed.get()) {
+        break;
+      } else {
+        log.info("Waiting for job to be finished");
+      }
+    }
+  }
+
+  @Alias("TestJobFactorySuiteBuilder")
+  public static class TestJobFactorySuiteBuilder extends TaskRunnerSuiteBase.Builder {
+    public TestJobFactorySuiteBuilder(Config config) {
+      super(config);
+    }
+
+    @Override
+    public TaskRunnerSuiteBase build() {
+      return new TaskRunnerSuiteForJobFactoryTest(this);
+    }
+  }
+}

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/suite/IntegrationJobFactorySuite.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/suite/IntegrationJobFactorySuite.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.gobblin.cluster.suite;
 
 import java.util.Collection;

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/PropertiesUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/PropertiesUtils.java
@@ -61,6 +61,10 @@ public class PropertiesUtils {
     return Boolean.valueOf(properties.getProperty(key, defaultValue));
   }
 
+  public static long getPropAsLong(Properties properties, String key, long defaultValue) {
+    return Long.valueOf(properties.getProperty(key, Long.toString(defaultValue)));
+  }
+
   /**
    * Extract all the keys that start with a <code>prefix</code> in {@link Properties} to a new {@link Properties}
    * instance.


### PR DESCRIPTION
Allow jobs to be re-distributed to worker nodes and launch there

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-490] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-490


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
This new job launcher will forward original job to GobblinTaskRunner. The GobblinTaskRunner can run the original GobblinHelixJobLauncher. This PR only covers the first forwarding logic. The new GobblinHelixJobLauncher task driver logic on GobblinTaskRunner will be in a spearate PR.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

