### PR TITLE
[GOBBLIN-493] Fix build issue in GithubDataEventTypesPartitioner

### DIFF
--- a/gobblin-example/src/main/java/org/apache/gobblin/example/githubjsontoparquet/GithubDataEventTypesPartitioner.java
+++ b/gobblin-example/src/main/java/org/apache/gobblin/example/githubjsontoparquet/GithubDataEventTypesPartitioner.java
@@ -33,7 +33,7 @@ public class GithubDataEventTypesPartitioner implements WriterPartitioner<Parque
 
   private static final String PARTITION_KEY = "type";
   private static final Schema SCHEMA =
-      SchemaBuilder.record("Schema").namespace("gobblin.writer.partitioner").fields().name(PARTITION_KEY))
+      SchemaBuilder.record("Schema").namespace("gobblin.writer.partitioner").fields().name(PARTITION_KEY)
           .type(Schema.create(Schema.Type.STRING)).noDefault().endRecord();
 
   public GithubDataEventTypesPartitioner(State state, int numBranches, int branchId) {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/GOBBLIN-493


### Description
- [x] Here are some details about my PR:
Fix build issue

### Tests
- [x] My PR does not need testing for this extremely good reason:
Fix build issue

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

