### PR TITLE
[GOBBLIN-494] Add configs to disable retryWriter

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/writer/DataWriterWrapperBuilder.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/writer/DataWriterWrapperBuilder.java
@@ -51,7 +51,9 @@ public class DataWriterWrapperBuilder<D> extends DataWriterBuilder<Void, D> {
         && state.contains(ThrottleWriter.WRITER_THROTTLE_TYPE_KEY)) {
       wrapped = new ThrottleWriter<>(wrapped, state);
     }
-    wrapped = new RetryWriter<>(wrapped, state);
+    if (state.getPropAsBoolean(RetryWriter.RETRY_WRITER_ENABLED, true)) {
+      wrapped = new RetryWriter<>(wrapped, state);
+    }
     return wrapped;
   }
 }

--- a/gobblin-core/src/main/java/org/apache/gobblin/writer/RetryWriter.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/writer/RetryWriter.java
@@ -51,6 +51,7 @@ import org.apache.gobblin.util.FinalState;
 public class RetryWriter<D> extends WatermarkAwareWriterWrapper<D> implements DataWriter<D>, FinalState, SpeculativeAttemptAwareConstruct {
   private static final Logger LOG = LoggerFactory.getLogger(RetryWriter.class);
   public static final String RETRY_CONF_PREFIX = "gobblin.writer.retry.";
+  public static final String RETRY_WRITER_ENABLED = RETRY_CONF_PREFIX + "enabled";
   public static final String FAILED_RETRY_WRITES_METER = RETRY_CONF_PREFIX + "failed_writes";
   public static final String RETRY_MULTIPLIER = RETRY_CONF_PREFIX + "multiplier";
   public static final String RETRY_MAX_WAIT_MS_PER_INTERVAL = RETRY_CONF_PREFIX + "max_wait_ms_per_interval";


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-494] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-494


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
  AsyncWriterManager cannot work with RetryWriter because the retrying record is the the actual failed record.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

