### PR TITLE
[GOBBLIN-501] Fix NPE thrown from read after EOF of LazyMaterializeDecryptorInputStream

### DIFF
--- a/gobblin-modules/gobblin-crypto/src/main/java/org/apache/gobblin/crypto/GPGFileDecryptor.java
+++ b/gobblin-modules/gobblin-crypto/src/main/java/org/apache/gobblin/crypto/GPGFileDecryptor.java
@@ -178,6 +178,10 @@ public class GPGFileDecryptor {
     @Override
     public int read()
         throws IOException {
+      if (this.currentUnderlyingStream == null) {
+        return -1;
+      }
+
       int value = this.currentUnderlyingStream.read();
 
       if (value != -1) {

--- a/gobblin-modules/gobblin-crypto/src/test/java/org/apache/gobblin/crypto/GPGFileDecryptorTest.java
+++ b/gobblin-modules/gobblin-crypto/src/test/java/org/apache/gobblin/crypto/GPGFileDecryptorTest.java
@@ -86,6 +86,9 @@ public class GPGFileDecryptorTest {
 
       Assert.assertEquals(bytesRead, 1041981183L);
 
+      // Make sure no error thrown if read again after reaching EOF
+      Assert.assertEquals(is.read(), -1);
+
       System.gc();
       System.gc();
       long endHeapSize = Runtime.getRuntime().totalMemory();


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/GOBBLIN-501


### Description
- [x] Here are some details about my PR:
A `read` call to a LazyMaterializeDecryptorInputStream when it reaches EOF will throw a NPE. The fix is to return `-1` for any read after EOF.

### Tests
- [x] My PR adds the following unit tests :
`GPGFileDecryptorTest#decryptLargeFileSym`

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

