### PR TITLE
[GOBBLIN-504] Fix multithreading issue when HiveMetastoreClientPool is initialized

### DIFF
--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/HiveMetastoreClientPool.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/HiveMetastoreClientPool.java
@@ -59,7 +59,7 @@ public class HiveMetastoreClientPool {
 
   public static final String POOL_CACHE_TTL_MINUTES_KEY = "hive.metaStorePoolCache.ttl";
 
-  public static Cache<Optional<String>, HiveMetastoreClientPool> poolCache = null;
+  private static Cache<Optional<String>, HiveMetastoreClientPool> poolCache = null;
 
   private static final Cache<Optional<String>, HiveMetastoreClientPool> createPoolCache(final Properties properties) {
     long duration = properties.containsKey(POOL_CACHE_TTL_MINUTES_KEY)
@@ -88,8 +88,10 @@ public class HiveMetastoreClientPool {
    */
   public static HiveMetastoreClientPool get(final Properties properties, final Optional<String> metastoreURI)
       throws IOException {
-    if (poolCache == null) {
-      poolCache = createPoolCache(properties);
+    synchronized (HiveMetastoreClientPool.class) {
+      if (poolCache == null) {
+        poolCache = createPoolCache(properties);
+      }
     }
     try {
       return poolCache.get(metastoreURI, new Callable<HiveMetastoreClientPool>() {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-504] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-504


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
  Fix the unprotected null check when HiveMetastoreClientPool is initialized. This also caused the findbugsMain failed.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

