### PR TITLE
[GOBBLIN-510] Decouple JobExecutionLauncher and JobExecutionDriver

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/JobState.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/JobState.java
@@ -54,6 +54,7 @@ import org.apache.gobblin.rest.Metric;
 import org.apache.gobblin.rest.MetricArray;
 import org.apache.gobblin.rest.MetricTypeEnum;
 import org.apache.gobblin.rest.TaskExecutionInfoArray;
+import org.apache.gobblin.runtime.api.MonitoredObject;
 import org.apache.gobblin.runtime.util.JobMetrics;
 import org.apache.gobblin.runtime.util.MetricGroup;
 import org.apache.gobblin.source.extractor.JobCommitPolicy;
@@ -85,7 +86,7 @@ public class JobState extends SourceState {
    *    <li> SUCCESSFUL => CANCELLED  (cancelled before committing)
    * </ul>
    */
-  public enum RunningState {
+  public enum RunningState implements MonitoredObject {
     /** Pending creation of {@link WorkUnit}s. */
     PENDING,
     /** Starting the execution of {@link WorkUnit}s. */

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/ExecutionResult.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/ExecutionResult.java
@@ -14,14 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.gobblin.runtime.api;
 
-public interface JobExecutionStatus {
-  public static final String UKNOWN_STAGE = "unkown";
-  JobExecution getJobExecution();
-
-  MonitoredObject getRunningState();
-
-  /** Arbitrary execution stage, e.g. setup, workUnitGeneration, taskExecution, publishing */
-  String getStage();
+/**
+ * An object which describes the result after job completion. This can be retrieved by {@link JobExecutionFuture#get()}
+ *
+ * @see JobExecutionResult as a derived class.
+ */
+public interface ExecutionResult {
 }

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/JobExecutionDriver.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/JobExecutionDriver.java
@@ -16,8 +16,6 @@
  */
 package org.apache.gobblin.runtime.api;
 
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 import java.util.concurrent.RunnableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/JobExecutionLauncher.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/JobExecutionLauncher.java
@@ -16,6 +16,8 @@
  */
 package org.apache.gobblin.runtime.api;
 
+import java.util.concurrent.Future;
+
 import com.codahale.metrics.Gauge;
 
 import org.apache.gobblin.annotation.Alpha;
@@ -30,10 +32,24 @@ import lombok.Getter;
  */
 @Alpha
 public interface JobExecutionLauncher extends Instrumentable {
-  JobExecutionDriver launchJob(JobSpec jobSpec);
+  /**
+   * This method is to launch the job specified by {@param jobSpec}
+   * The simplest way is to run a {@link JobExecutionDriver} and upon completion return a
+   * {@link org.apache.gobblin.runtime.job_exec.JobLauncherExecutionDriver.JobExecutionFutureAndDriver}.
+   *
+   * If {@link JobExecutionDriver} does not run within the same process/node of {@link JobExecutionLauncher}, a simple monitoring
+   * future object ({@link JobExecutionMonitor}) is returned. This object can do two things:
+   *
+   * 1) Wait for computation of final {@link ExecutionResult} by invoking {@link Future#get()}.
+   * 2) Monitor current job running status by invoking {@link JobExecutionMonitor#getRunningState()}.
+   *
+   * @see JobExecutionMonitor
+   */
+  JobExecutionMonitor launchJob(JobSpec jobSpec);
 
   /**
-   * Common metrics for all launcher implementations. */
+   * Common metrics for all launcher implementations.
+   */
   StandardMetrics getMetrics();
 
   public static class StandardMetrics {

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/JobExecutionLauncher.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/JobExecutionLauncher.java
@@ -35,10 +35,10 @@ public interface JobExecutionLauncher extends Instrumentable {
   /**
    * This method is to launch the job specified by {@param jobSpec}
    * The simplest way is to run a {@link JobExecutionDriver} and upon completion return a
-   * {@link org.apache.gobblin.runtime.job_exec.JobLauncherExecutionDriver.JobExecutionFutureAndDriver}.
+   * {@link org.apache.gobblin.runtime.job_exec.JobLauncherExecutionDriver.JobExecutionMonitorAndDriver}.
    *
    * If {@link JobExecutionDriver} does not run within the same process/node of {@link JobExecutionLauncher}, a simple monitoring
-   * future object ({@link JobExecutionMonitor}) is returned. This object can do two things:
+   * future object ({@link JobExecutionMonitor}) can be returned. This object can do two things:
    *
    * 1) Wait for computation of final {@link ExecutionResult} by invoking {@link Future#get()}.
    * 2) Monitor current job running status by invoking {@link JobExecutionMonitor#getRunningState()}.

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/JobExecutionMonitor.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/JobExecutionMonitor.java
@@ -14,14 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.gobblin.runtime.api;
 
-public interface JobExecutionStatus {
-  public static final String UKNOWN_STAGE = "unkown";
-  JobExecution getJobExecution();
+import java.util.concurrent.Future;
 
+/**
+ * A simple monitoring and future object. This object can be used as a normal {@link Future} object to get {@link ExecutionResult}.
+ *
+ * It can also be used to get current job running status, which is described by {@link MonitoredObject}.
+ */
+public interface JobExecutionMonitor extends Future<ExecutionResult> {
   MonitoredObject getRunningState();
-
-  /** Arbitrary execution stage, e.g. setup, workUnitGeneration, taskExecution, publishing */
-  String getStage();
 }

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/JobExecutionResult.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/JobExecutionResult.java
@@ -29,7 +29,7 @@ import lombok.Getter;
  */
 @AllArgsConstructor(access=AccessLevel.PROTECTED)
 @Getter
-public class JobExecutionResult {
+public class JobExecutionResult implements ExecutionResult {
   private final RunningState finalState;
   private final Throwable errorCause;
   // TODO add TaskExecutionResults

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/MonitoredObject.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/MonitoredObject.java
@@ -14,14 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.gobblin.runtime.api;
 
-public interface JobExecutionStatus {
-  public static final String UKNOWN_STAGE = "unkown";
-  JobExecution getJobExecution();
-
-  MonitoredObject getRunningState();
-
-  /** Arbitrary execution stage, e.g. setup, workUnitGeneration, taskExecution, publishing */
-  String getStage();
+/**
+ * An object which is currently monitored. This object can be retrieved by {@link JobExecutionMonitor}
+ */
+public interface MonitoredObject {
 }

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/instance/DefaultGobblinInstanceDriverImpl.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/instance/DefaultGobblinInstanceDriverImpl.java
@@ -36,17 +36,20 @@ import org.apache.gobblin.metrics.MetricContext;
 import org.apache.gobblin.metrics.Tag;
 import org.apache.gobblin.runtime.JobState.RunningState;
 import org.apache.gobblin.runtime.api.Configurable;
+import org.apache.gobblin.runtime.api.ExecutionResult;
 import org.apache.gobblin.runtime.api.GobblinInstanceDriver;
 import org.apache.gobblin.runtime.api.GobblinInstanceLauncher.ConfigAccessor;
 import org.apache.gobblin.runtime.api.JobCatalog;
 import org.apache.gobblin.runtime.api.JobExecutionDriver;
 import org.apache.gobblin.runtime.api.JobExecutionLauncher;
+import org.apache.gobblin.runtime.api.JobExecutionMonitor;
 import org.apache.gobblin.runtime.api.JobExecutionState;
 import org.apache.gobblin.runtime.api.JobLifecycleListener;
 import org.apache.gobblin.runtime.api.JobSpec;
 import org.apache.gobblin.runtime.api.JobSpecMonitorFactory;
 import org.apache.gobblin.runtime.api.JobSpecScheduler;
 import org.apache.gobblin.runtime.api.MutableJobCatalog;
+import org.apache.gobblin.runtime.job_exec.JobLauncherExecutionDriver;
 import org.apache.gobblin.runtime.job_spec.ResolvedJobSpec;
 import org.apache.gobblin.runtime.std.DefaultJobCatalogListenerImpl;
 import org.apache.gobblin.runtime.std.DefaultJobExecutionStateListenerImpl;
@@ -206,9 +209,13 @@ public class DefaultGobblinInstanceDriverImpl extends AbstractIdleService
     @Override
     public void run() {
       try {
-         JobExecutionDriver driver = _jobLauncher.launchJob(new ResolvedJobSpec(_jobSpec, _instanceDriver));
-         _callbacksDispatcher.onJobLaunch(driver);
-         driver.registerStateListener(new JobStateTracker());
+        JobExecutionMonitor monitor = _jobLauncher.launchJob(new ResolvedJobSpec(_jobSpec, _instanceDriver));
+        if (!(monitor instanceof JobLauncherExecutionDriver.JobExecutionFutureAndDriver)) {
+          throw new UnsupportedOperationException(JobLauncherExecutionDriver.JobExecutionFutureAndDriver.class.getName() + " is expected.");
+        }
+        JobExecutionDriver driver = ((JobLauncherExecutionDriver.JobExecutionFutureAndDriver) monitor).getDrvier();
+        _callbacksDispatcher.onJobLaunch(driver);
+        driver.registerStateListener(new JobStateTracker());
         ExecutorsUtils.newThreadFactory(Optional.of(_log), Optional.of("gobblin-instance-driver")).newThread(driver).start();
       }
       catch (Throwable t) {

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/instance/DefaultGobblinInstanceDriverImpl.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/instance/DefaultGobblinInstanceDriverImpl.java
@@ -210,10 +210,10 @@ public class DefaultGobblinInstanceDriverImpl extends AbstractIdleService
     public void run() {
       try {
         JobExecutionMonitor monitor = _jobLauncher.launchJob(new ResolvedJobSpec(_jobSpec, _instanceDriver));
-        if (!(monitor instanceof JobLauncherExecutionDriver.JobExecutionFutureAndDriver)) {
-          throw new UnsupportedOperationException(JobLauncherExecutionDriver.JobExecutionFutureAndDriver.class.getName() + " is expected.");
+        if (!(monitor instanceof JobLauncherExecutionDriver.JobExecutionMonitorAndDriver)) {
+          throw new UnsupportedOperationException(JobLauncherExecutionDriver.JobExecutionMonitorAndDriver.class.getName() + " is expected.");
         }
-        JobExecutionDriver driver = ((JobLauncherExecutionDriver.JobExecutionFutureAndDriver) monitor).getDrvier();
+        JobExecutionDriver driver = ((JobLauncherExecutionDriver.JobExecutionMonitorAndDriver) monitor).getDriver();
         _callbacksDispatcher.onJobLaunch(driver);
         driver.registerStateListener(new JobStateTracker());
         ExecutorsUtils.newThreadFactory(Optional.of(_log), Optional.of("gobblin-instance-driver")).newThread(driver).start();

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/job_exec/JobLauncherExecutionDriver.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/job_exec/JobLauncherExecutionDriver.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Properties;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
@@ -53,20 +54,22 @@ import org.apache.gobblin.runtime.JobException;
 import org.apache.gobblin.runtime.JobLauncher;
 import org.apache.gobblin.runtime.JobLauncherFactory;
 import org.apache.gobblin.runtime.JobLauncherFactory.JobLauncherType;
+import org.apache.gobblin.runtime.JobState;
 import org.apache.gobblin.runtime.JobState.RunningState;
 import org.apache.gobblin.runtime.api.Configurable;
 import org.apache.gobblin.runtime.api.GobblinInstanceEnvironment;
 import org.apache.gobblin.runtime.api.JobExecution;
 import org.apache.gobblin.runtime.api.JobExecutionDriver;
 import org.apache.gobblin.runtime.api.JobExecutionLauncher;
+import org.apache.gobblin.runtime.api.JobExecutionMonitor;
 import org.apache.gobblin.runtime.api.JobExecutionResult;
 import org.apache.gobblin.runtime.api.JobExecutionState;
 import org.apache.gobblin.runtime.api.JobExecutionStateListener;
 import org.apache.gobblin.runtime.api.JobExecutionStatus;
 import org.apache.gobblin.runtime.api.JobSpec;
 import org.apache.gobblin.runtime.api.JobTemplate;
+import org.apache.gobblin.runtime.api.MonitoredObject;
 import org.apache.gobblin.runtime.api.SpecNotFoundException;
-import org.apache.gobblin.runtime.instance.StandardGobblinInstanceLauncher;
 import org.apache.gobblin.runtime.job_spec.ResolvedJobSpec;
 import org.apache.gobblin.runtime.listeners.AbstractJobListener;
 import org.apache.gobblin.runtime.std.DefaultConfigurableImpl;
@@ -95,16 +98,18 @@ public class JobLauncherExecutionDriver extends FutureTask<JobExecutionResult> i
 
   /**
    * Creates a new JobExecutionDriver which acts as an adapter to the legacy {@link JobLauncher} API.
-   * @param sysConfig             the system/environment config
-   * @param jobSpec               the JobSpec to be executed
-   * @param jobLauncherType       an optional jobLauncher type; the value follows the convention of
-   *        {@link JobLauncherFactory#newJobLauncher(java.util.Properties, java.util.Properties, String).
+   * @param sysConfig               the system/environment config
+   * @param jobSpec                 the JobSpec to be executed
+   * @param jobLauncherType         an optional jobLauncher type; the value follows the convention of
+   *        {@link JobLauncherFactory#newJobLauncher(Properties, Properties)}.
    *        If absent, {@link JobLauncherFactory#newJobLauncher(java.util.Properties, java.util.Properties)}
    *        will be used which looks for the {@link ConfigurationKeys#JOB_LAUNCHER_TYPE_KEY}
    *        in the system configuration.
-   * @param jobExecStateListener  an optional listener to listen for state changes in the execution.
-   * @param log                   an optional logger to be used; if none is specified, a default one
-   *                              will be instantiated.
+   * @param log                     an optional logger to be used; if none is specified, a default one
+   *                                will be instantiated.
+   * @param instrumentationEnabled  a flag to control if metrics should be enabled.
+   * @param launcherMetrics         an object to contain metrics related to jobLauncher.
+   * @param instanceBroker          a broker to create difference resources from the same instance scope.
    */
   public static JobLauncherExecutionDriver create(Configurable sysConfig, JobSpec jobSpec,
       Optional<JobLauncherFactory.JobLauncherType> jobLauncherType,
@@ -441,7 +446,8 @@ public class JobLauncherExecutionDriver extends FutureTask<JobExecutionResult> i
       return res;
     }
 
-    @Override public JobExecutionDriver launchJob(JobSpec jobSpec) {
+    @Override
+    public JobExecutionMonitor launchJob(JobSpec jobSpec) {
       Preconditions.checkNotNull(jobSpec);
       if (!(jobSpec instanceof ResolvedJobSpec)) {
         try {
@@ -450,8 +456,10 @@ public class JobLauncherExecutionDriver extends FutureTask<JobExecutionResult> i
           throw new RuntimeException("Can't launch job " + jobSpec.getUri(), exc);
         }
       }
-      return JobLauncherExecutionDriver.create(getSysConfig(), jobSpec, _jobLauncherType,
+
+      JobLauncherExecutionDriver driver = JobLauncherExecutionDriver.create(getSysConfig(), jobSpec, _jobLauncherType,
           Optional.of(getLog(jobSpec)), isInstrumentationEnabled(), getMetrics(), getInstanceBroker());
+      return new JobExecutionFutureAndDriver(driver);
     }
 
     @Override public List<Tag<?>> generateTags(org.apache.gobblin.configuration.State state) {
@@ -519,20 +527,75 @@ public class JobLauncherExecutionDriver extends FutureTask<JobExecutionResult> i
 
   }
 
+  /**
+   * Old {@link JobExecutionLauncher#launchJob(JobSpec)} returns a {@link JobExecutionDriver} but new API returns a {@link JobExecutionMonitor}.
+   * For backward compatibility we wraps {@link JobExecutionDriver} inside of a new {@link JobExecutionFutureAndDriver}.
+   */
+  @AllArgsConstructor
+  public static class JobExecutionFutureAndDriver implements JobExecutionMonitor {
+    @Getter
+    JobLauncherExecutionDriver drvier;
+
+    @Override
+    public boolean cancel(boolean mayInterruptIfRunning) {
+      return this.drvier.cancel(mayInterruptIfRunning);
+    }
+
+    @Override
+    public boolean isCancelled() {
+      return this.drvier.isCancelled();
+    }
+
+    @Override
+    public boolean isDone() {
+      return this.drvier.isDone();
+    }
+
+    @Override
+    public JobExecutionResult get()
+        throws InterruptedException, ExecutionException {
+      return this.drvier.get();
+    }
+
+    @Override
+    public JobExecutionResult get(long timeout, TimeUnit unit)
+        throws InterruptedException, ExecutionException, TimeoutException {
+      return this.drvier.get(timeout, unit);
+    }
+
+    @Override
+    public MonitoredObject getRunningState() {
+      return this.drvier._jobState.getRunningState();
+    }
+  }
+
   @Override public void registerWeakStateListener(JobExecutionStateListener listener) {
     _callbackDispatcher.registerWeakStateListener(listener);
   }
 
   @Override public boolean isDone() {
-    RunningState runState = getJobExecutionStatus().getRunningState();
+    RunningState runState = fetchRunningState();
+
     return runState == null ? false : runState.isDone() ;
+  }
+
+  private RunningState fetchRunningState() {
+    MonitoredObject monitoredObject = getJobExecutionStatus().getRunningState();
+    if (monitoredObject == null) {
+      return null;
+    }
+    if (!(monitoredObject instanceof RunningState)) {
+      throw new UnsupportedOperationException("Cannot process monitored object other than " + JobState.RunningState.class.getName());
+    }
+
+    return (RunningState) monitoredObject;
   }
 
   @Override public boolean cancel(boolean mayInterruptIfRunning) {
     // FIXME there is a race condition here as the job may complete successfully before we
     // call cancelJob() below. There isn't an easy way to fix that right now.
+    RunningState runState = fetchRunningState();
 
-    RunningState runState = getJobExecutionStatus().getRunningState();
     if (runState.isCancelled()) {
       return true;
     }
@@ -549,7 +612,7 @@ public class JobLauncherExecutionDriver extends FutureTask<JobExecutionResult> i
   }
 
   @Override public boolean isCancelled() {
-    return getJobExecutionStatus().getRunningState().isCancelled();
+    return fetchRunningState().isCancelled();
   }
 
   @Override

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/job_exec/JobLauncherExecutionDriver.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/job_exec/JobLauncherExecutionDriver.java
@@ -459,7 +459,7 @@ public class JobLauncherExecutionDriver extends FutureTask<JobExecutionResult> i
 
       JobLauncherExecutionDriver driver = JobLauncherExecutionDriver.create(getSysConfig(), jobSpec, _jobLauncherType,
           Optional.of(getLog(jobSpec)), isInstrumentationEnabled(), getMetrics(), getInstanceBroker());
-      return new JobExecutionFutureAndDriver(driver);
+      return new JobExecutionMonitorAndDriver(driver);
     }
 
     @Override public List<Tag<?>> generateTags(org.apache.gobblin.configuration.State state) {
@@ -529,43 +529,43 @@ public class JobLauncherExecutionDriver extends FutureTask<JobExecutionResult> i
 
   /**
    * Old {@link JobExecutionLauncher#launchJob(JobSpec)} returns a {@link JobExecutionDriver} but new API returns a {@link JobExecutionMonitor}.
-   * For backward compatibility we wraps {@link JobExecutionDriver} inside of a new {@link JobExecutionFutureAndDriver}.
+   * For backward compatibility we wraps {@link JobExecutionDriver} inside of a new {@link JobExecutionMonitorAndDriver}.
    */
   @AllArgsConstructor
-  public static class JobExecutionFutureAndDriver implements JobExecutionMonitor {
+  public static class JobExecutionMonitorAndDriver implements JobExecutionMonitor {
     @Getter
-    JobLauncherExecutionDriver drvier;
+    JobLauncherExecutionDriver driver;
 
     @Override
     public boolean cancel(boolean mayInterruptIfRunning) {
-      return this.drvier.cancel(mayInterruptIfRunning);
+      return this.driver.cancel(mayInterruptIfRunning);
     }
 
     @Override
     public boolean isCancelled() {
-      return this.drvier.isCancelled();
+      return this.driver.isCancelled();
     }
 
     @Override
     public boolean isDone() {
-      return this.drvier.isDone();
+      return this.driver.isDone();
     }
 
     @Override
     public JobExecutionResult get()
         throws InterruptedException, ExecutionException {
-      return this.drvier.get();
+      return this.driver.get();
     }
 
     @Override
     public JobExecutionResult get(long timeout, TimeUnit unit)
         throws InterruptedException, ExecutionException, TimeoutException {
-      return this.drvier.get(timeout, unit);
+      return this.driver.get(timeout, unit);
     }
 
     @Override
     public MonitoredObject getRunningState() {
-      return this.drvier._jobState.getRunningState();
+      return this.driver._jobState.getRunningState();
     }
   }
 

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/JobBrokerInjectionTest.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/JobBrokerInjectionTest.java
@@ -155,15 +155,6 @@ public class JobBrokerInjectionTest {
     Assert.assertEquals(seenTaskObjectIds.size(), 10);
   }
 
-  private void launchJob(StandardGobblinInstanceLauncher instanceLauncher, JobSpec js1,
-      GobblinInstanceDriver instance) throws TimeoutException, InterruptedException, ExecutionException {
-    JobExecutionDriver jobDriver = instance.getJobLauncher().launchJob(js1);
-    new Thread(jobDriver).run();
-    JobExecutionResult jobResult = jobDriver.get(5, TimeUnit.SECONDS);
-
-    Assert.assertTrue(jobResult.isSuccessful());
-  }
-
   public static class JobBrokerConverter extends Converter<String, String, String, MyRecord> {
 
     private MySharedObject instanceSharedObject;

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/instance/TestStandardGobblinInstanceLauncher.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/instance/TestStandardGobblinInstanceLauncher.java
@@ -104,8 +104,8 @@ public class TestStandardGobblinInstanceLauncher {
       GobblinInstanceDriver instance) throws TimeoutException, InterruptedException, ExecutionException {
     JobExecutionDriver jobDriver = null;
     JobExecutionMonitor monitor = instance.getJobLauncher().launchJob(js1);
-    if (monitor instanceof JobLauncherExecutionDriver.JobExecutionFutureAndDriver) {
-      jobDriver = ((JobLauncherExecutionDriver.JobExecutionFutureAndDriver) monitor).getDrvier();
+    if (monitor instanceof JobLauncherExecutionDriver.JobExecutionMonitorAndDriver) {
+      jobDriver = ((JobLauncherExecutionDriver.JobExecutionMonitorAndDriver) monitor).getDriver();
     }
 
     new Thread(jobDriver).run();

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/instance/TestStandardGobblinInstanceLauncher.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/instance/TestStandardGobblinInstanceLauncher.java
@@ -33,10 +33,12 @@ import com.typesafe.config.ConfigFactory;
 import org.apache.gobblin.runtime.api.GobblinInstanceDriver;
 import org.apache.gobblin.runtime.api.JobExecutionDriver;
 import org.apache.gobblin.runtime.api.JobExecutionLauncher;
+import org.apache.gobblin.runtime.api.JobExecutionMonitor;
 import org.apache.gobblin.runtime.api.JobExecutionResult;
 import org.apache.gobblin.runtime.api.JobLifecycleListener;
 import org.apache.gobblin.runtime.api.JobSpec;
 import org.apache.gobblin.runtime.instance.DefaultGobblinInstanceDriverImpl.JobSpecRunnable;
+import org.apache.gobblin.runtime.job_exec.JobLauncherExecutionDriver;
 import org.apache.gobblin.runtime.job_spec.ResolvedJobSpec;
 import org.apache.gobblin.runtime.std.DefaultJobLifecycleListenerImpl;
 import org.apache.gobblin.runtime.std.FilteredJobLifecycleListener;
@@ -100,7 +102,12 @@ public class TestStandardGobblinInstanceLauncher {
 
   private void checkLaunchJob(StandardGobblinInstanceLauncher instanceLauncher, JobSpec js1,
       GobblinInstanceDriver instance) throws TimeoutException, InterruptedException, ExecutionException {
-    JobExecutionDriver jobDriver = instance.getJobLauncher().launchJob(js1);
+    JobExecutionDriver jobDriver = null;
+    JobExecutionMonitor monitor = instance.getJobLauncher().launchJob(js1);
+    if (monitor instanceof JobLauncherExecutionDriver.JobExecutionFutureAndDriver) {
+      jobDriver = ((JobLauncherExecutionDriver.JobExecutionFutureAndDriver) monitor).getDrvier();
+    }
+
     new Thread(jobDriver).run();
     JobExecutionResult jobResult = jobDriver.get(5, TimeUnit.SECONDS);
 

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/job_exec/TestJobLauncherExecutionDriver.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/job_exec/TestJobLauncherExecutionDriver.java
@@ -73,8 +73,8 @@ public class TestJobLauncherExecutionDriver {
 
       JobLauncherExecutionDriver jled = null;
       JobExecutionMonitor monitor = launcher.launchJob(jobSpec1);
-      if (monitor instanceof JobLauncherExecutionDriver.JobExecutionFutureAndDriver) {
-        jled = ((JobLauncherExecutionDriver.JobExecutionFutureAndDriver) monitor).getDrvier();
+      if (monitor instanceof JobLauncherExecutionDriver.JobExecutionMonitorAndDriver) {
+        jled = ((JobLauncherExecutionDriver.JobExecutionMonitorAndDriver) monitor).getDriver();
       }
 
       Assert.assertTrue(jled.getLegacyLauncher() instanceof LocalJobLauncher);
@@ -105,8 +105,8 @@ public class TestJobLauncherExecutionDriver {
       monitor = launcher
           .withJobLauncherType(JobLauncherFactory.JobLauncherType.MAPREDUCE)
           .launchJob(jobSpec2);
-      if (monitor instanceof JobLauncherExecutionDriver.JobExecutionFutureAndDriver) {
-        jled = ((JobLauncherExecutionDriver.JobExecutionFutureAndDriver)monitor).getDrvier();
+      if (monitor instanceof JobLauncherExecutionDriver.JobExecutionMonitorAndDriver) {
+        jled = ((JobLauncherExecutionDriver.JobExecutionMonitorAndDriver) monitor).getDriver();
       }
 
       Assert.assertTrue(jled.getLegacyLauncher() instanceof MRJobLauncher);

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/job_exec/TestJobLauncherExecutionDriver.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/job_exec/TestJobLauncherExecutionDriver.java
@@ -33,6 +33,7 @@ import com.typesafe.config.ConfigValueFactory;
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.runtime.JobLauncherFactory;
 import org.apache.gobblin.runtime.api.JobExecution;
+import org.apache.gobblin.runtime.api.JobExecutionMonitor;
 import org.apache.gobblin.runtime.api.JobSpec;
 import org.apache.gobblin.runtime.local.LocalJobLauncher;
 import org.apache.gobblin.runtime.mapreduce.MRJobLauncher;
@@ -70,7 +71,12 @@ public class TestJobLauncherExecutionDriver {
               .withJobLauncherType(JobLauncherFactory.JobLauncherType.LOCAL)
               .withLog(log);
 
-      JobLauncherExecutionDriver jled = (JobLauncherExecutionDriver)launcher.launchJob(jobSpec1);
+      JobLauncherExecutionDriver jled = null;
+      JobExecutionMonitor monitor = launcher.launchJob(jobSpec1);
+      if (monitor instanceof JobLauncherExecutionDriver.JobExecutionFutureAndDriver) {
+        jled = ((JobLauncherExecutionDriver.JobExecutionFutureAndDriver) monitor).getDrvier();
+      }
+
       Assert.assertTrue(jled.getLegacyLauncher() instanceof LocalJobLauncher);
       JobExecution jex1 = jled.getJobExecution();
       Assert.assertEquals(jex1.getJobSpecURI(), jobSpec1.getUri());
@@ -95,10 +101,14 @@ public class TestJobLauncherExecutionDriver {
           .withValue(ConfigurationKeys.JOB_LOCK_ENABLED_KEY, ConfigValueFactory.fromAnyRef(false));
 
       JobSpec jobSpec2 = JobSpec.builder().withConfig(jobConf2).build();
-
-      jled = (JobLauncherExecutionDriver)launcher
+      jled = null;
+      monitor = launcher
           .withJobLauncherType(JobLauncherFactory.JobLauncherType.MAPREDUCE)
           .launchJob(jobSpec2);
+      if (monitor instanceof JobLauncherExecutionDriver.JobExecutionFutureAndDriver) {
+        jled = ((JobLauncherExecutionDriver.JobExecutionFutureAndDriver)monitor).getDrvier();
+      }
+
       Assert.assertTrue(jled.getLegacyLauncher() instanceof MRJobLauncher);
       JobExecution jex2 = jled.getJobExecution();
 


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-510] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-510
Today JobExecutionLauncher and JobExecutionDriver is coupled. It means when JobExecutionLauncher invokes launchJob, a JobExecutionDriver is immediately return. This is not good for gobblin cluster because the Launcher might running in manager node but the actual driver logic is running on worker node. We need some refactoring to allow us decouple these two.

### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
   - Introduced ExecutionResult, JobExecutionFuture, JobExecutionMonitor and MonitoredObject.
   - Changed JobExecutionLauncher#launcJob interface

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

