### PR TITLE
[GOBBLIN-512]Add containers to hold unchecked exceptions from closing resources in broker

### DIFF
--- a/gobblin-utility/src/main/java/org/apache/gobblin/broker/DefaultBrokerCache.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/broker/DefaultBrokerCache.java
@@ -206,7 +206,7 @@ class DefaultBrokerCache<S extends ScopeType<S>> {
    */
   public void close(ScopeWrapper<S> scope)
       throws IOException {
-    Set<Exception> exceptionsSet  = new HashSet<>();
+    List<Throwable> exceptionsList = Lists.newArrayList();
     List<Service> awaitShutdown = Lists.newArrayList();
 
     for (Map.Entry<RawJobBrokerKey, Object> entry : Maps.filterKeys(this.sharedResourceCache.asMap(),
@@ -219,8 +219,8 @@ class DefaultBrokerCache<S extends ScopeType<S>> {
         // Catch unchecked exception while closing resources, make sure all resources managed by cache are closed.
         try {
           SharedResourcesBrokerUtils.shutdownObject(obj, log);
-        } catch (Exception e) {
-          exceptionsSet.add(e);
+        } catch (Throwable t) {
+          exceptionsList.add(t);
         }
         if (obj instanceof Service) {
           awaitShutdown.add((Service) obj);
@@ -237,8 +237,8 @@ class DefaultBrokerCache<S extends ScopeType<S>> {
     }
 
     // log exceptions while closing resources up.
-    if (exceptionsSet.size() > 0) {
-      log.error(exceptionsSet.stream()
+    if (exceptionsList.size() > 0) {
+      log.error(exceptionsList.stream()
           .map(Throwables::getStackTraceAsString).collect(Collectors.joining("\n")));
     }
   }

--- a/gobblin-utility/src/main/java/org/apache/gobblin/broker/DefaultBrokerCache.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/broker/DefaultBrokerCache.java
@@ -19,15 +19,19 @@ package org.apache.gobblin.broker;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.Lock;
+import java.util.stream.Collectors;
 
 import com.google.common.base.Predicate;
+import com.google.common.base.Throwables;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.Lists;
@@ -202,6 +206,7 @@ class DefaultBrokerCache<S extends ScopeType<S>> {
    */
   public void close(ScopeWrapper<S> scope)
       throws IOException {
+    Set<Exception> exceptionsSet  = new HashSet<>();
     List<Service> awaitShutdown = Lists.newArrayList();
 
     for (Map.Entry<RawJobBrokerKey, Object> entry : Maps.filterKeys(this.sharedResourceCache.asMap(),
@@ -211,8 +216,12 @@ class DefaultBrokerCache<S extends ScopeType<S>> {
 
       if (entry.getValue() instanceof ResourceInstance) {
         Object obj = ((ResourceInstance) entry.getValue()).getResource();
-
-        SharedResourcesBrokerUtils.shutdownObject(obj, log);
+        // Catch unchecked exception while closing resources, make sure all resources managed by cache are closed.
+        try {
+          SharedResourcesBrokerUtils.shutdownObject(obj, log);
+        } catch (Exception e) {
+          exceptionsSet.add(e);
+        }
         if (obj instanceof Service) {
           awaitShutdown.add((Service) obj);
         }
@@ -225,6 +234,12 @@ class DefaultBrokerCache<S extends ScopeType<S>> {
       } catch (TimeoutException te) {
         log.error("Failed to shutdown {}.", service);
       }
+    }
+
+    // log exceptions while closing resources up.
+    if (exceptionsSet.size() > 0) {
+      log.error(exceptionsSet.stream()
+          .map(Throwables::getStackTraceAsString).collect(Collectors.joining("\n")));
     }
   }
 


### PR DESCRIPTION
Add containers to hold unchecked exceptions from closing resources in broker, to make sure all resources are correctly handled, and log exceptions afterwards.

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-512] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-512


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

