### PR TITLE
[GOBBLIN-514] AvroUtils#parseSchemaFromFile should use modified UTF-8 encoding to read file

### DIFF
--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/AvroUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/AvroUtils.java
@@ -20,7 +20,6 @@ package org.apache.gobblin.util;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -51,6 +50,7 @@ import org.apache.avro.mapred.FsInput;
 import org.apache.avro.util.Utf8;
 import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -380,8 +380,8 @@ public class AvroUtils {
   public static Schema parseSchemaFromFile(Path filePath, FileSystem fs) throws IOException {
     Preconditions.checkArgument(fs.exists(filePath), filePath + " does not exist");
 
-    try (InputStream in = fs.open(filePath)) {
-      return new Schema.Parser().parse(in);
+    try (FSDataInputStream in = fs.open(filePath)) {
+      return new Schema.Parser().parse(in.readUTF());
     }
   }
 


### PR DESCRIPTION


Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-514


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Changed AvroUtils#parseSchemaFromFile to read file with encoding modified UTF-8 and then parse the string json to create Avro Schema object.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Unit test added

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

