### PR TITLE
GOBBLIN-412 Compression parameters are not propagated to Hadoop

### DIFF
--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/CliOptions.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/CliOptions.java
@@ -80,6 +80,11 @@ public class CliOptions {
         jobConfig = JobConfigurationUtils.fileToProperties(cmd.getOptionValue(jobConfigLocation));
       } else {
         jobConfig = JobConfigurationUtils.fileToProperties(cmd.getOptionValue(jobConfigLocation), conf);
+        for (String configKey : jobConfig.stringPropertyNames()) {
+          if (conf.get(configKey) != null) {
+            conf.unset(configKey);
+          }
+        }
         JobConfigurationUtils.putConfigurationIntoProperties(conf, jobConfig);
       }
       return jobConfig;


### PR DESCRIPTION
Resubmitted the PR as per the suggestions in the PR, https://github.com/apache/incubator-gobblin/pull/2294

### JIRA
https://issues.apache.org/jira/browse/GOBBLIN-412

### Description
Parameters to control compression-

**1. mapreduce.output.fileoutputformat.compress
2. mapreduce.output.fileoutputformat.compress.codec
3. mapreduce.output.fileoutputformat.compress.type**

are not passed on to Hadoop from compaction job configuration file as Job config parameters are being overwritten with the hadoop config parameters.

As part of fix, unset the job config parameter in hadoop config( before adding the hadoop config into the job config) if it is already set in job config.

### Tests
1. Set mapreduce.output.fileoutputformat.compress and verify output of compaction job. Output should be compressed with default codec.
2. Reset mapreduce.output.fileoutputformat.compress and verify output of compaction job. Output shouldn't be compressed.
3. Set mapreduce.output.fileoutputformat.compress and set mapreduce.output.fileoutputformat.compress to org.apache.hadoop.io.compress.SnappyCodec and mapreduce.output.fileoutputformat.compress.type set to RECORD verify output of compaction job. Output should be compressed with Snappy codec and record level.
4. Set mapreduce.output.fileoutputformat.compress and set mapreduce.output.fileoutputformat.compress to org.apache.hadoop.io.compress.DefaultCodec mapreduce.output.fileoutputformat.compress.type set to BLOCK and verify output of compaction job. Output should be compressed with Deflate codec and block level.
