### PR TITLE
[GOBBLIN-516] Fixing vague error message while checking Fs state in ConfigBased Entities

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/replication/HadoopFsEndPoint.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/replication/HadoopFsEndPoint.java
@@ -83,7 +83,7 @@ public abstract class HadoopFsEndPoint implements EndPoint {
   @Override
   public boolean isFileSystemAvailable() {
     try {
-      FileSystem.get(this.getFsURI(), new Configuration()).close();
+      FileSystem.get(this.getFsURI(), new Configuration());
     } catch (IOException ioe){
       log.error(String.format("FileSystem %s is not available", this.getFsURI()), ioe);
       return false;

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/replication/HadoopFsEndPoint.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/replication/HadoopFsEndPoint.java
@@ -61,7 +61,7 @@ public abstract class HadoopFsEndPoint implements EndPoint {
 
   /**
    * A helper utility for data/filesystem availability checking
-   * @param path The path to be checked. For fs availability checking, just use "/"
+   * @param path The path to be checked.
    * @return If the filesystem/path exists or not.
    */
   public boolean isPathAvailable(Path path) {
@@ -71,18 +71,24 @@ public abstract class HadoopFsEndPoint implements EndPoint {
       if (fs.exists(path)) {
         return true;
       } else {
-        log.warn("Skipped the problematic FileSystem " + this.getFsURI());
+        log.warn("The data path [" + path + "] is not available on FileSystem: " + this.getFsURI());
         return false;
       }
     } catch (IOException ioe) {
-      log.warn("Skipped the problematic FileSystem " + this.getFsURI());
+      log.warn("Errors occurred while checking path [" + path + "] existence " + this.getFsURI(), ioe);
       return false;
     }
   }
 
   @Override
   public boolean isFileSystemAvailable() {
-    return isPathAvailable(new Path("/"));
+    try {
+      FileSystem.get(new Configuration()).close();
+    } catch (IOException ioe){
+      log.error(String.format("FileSystem %s is not available", this.getFsURI()), ioe);
+      return false;
+    }
+    return true;
   }
 
   public boolean isDatasetAvailable(Path datasetPath) {

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/replication/HadoopFsEndPoint.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/replication/HadoopFsEndPoint.java
@@ -83,7 +83,7 @@ public abstract class HadoopFsEndPoint implements EndPoint {
   @Override
   public boolean isFileSystemAvailable() {
     try {
-      FileSystem.get(new Configuration()).close();
+      FileSystem.get(this.getFsURI(), new Configuration()).close();
     } catch (IOException ioe){
       log.error(String.format("FileSystem %s is not available", this.getFsURI()), ioe);
       return false;


### PR DESCRIPTION
Simply speaking, having exact exception information propagated in construction of `CopyRoute`. 
Further cleaning and testing-mechanism needs to be developed in this part of code, but this is a quick fix for internal requests.  


Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-516] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-516


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

