### PR TITLE
[ GOBBLIN-520] Add fileSetWorkUnitGenerator customization for CopySource

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -528,6 +528,11 @@ public class ConfigurationKeys {
   public static final String SQL_SERVER_CONNECTION_PARAMETERS = "source.querybased.sqlserver.connectionParameters";
 
   /**
+   * Configuration properties used by the CopySource.
+   */
+  public static final String COPY_SOURCE_FILESET_WU_GENERATOR = "copy.source.fileset.wu.generator";
+
+  /**
    * Configuration properties used by the FileBasedExtractor
    */
   public static final String SOURCE_FILEBASED_DATA_DIRECTORY = "source.filebased.data.directory";

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/CopySource.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/CopySource.java
@@ -46,6 +46,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Multimaps;
 import com.google.common.collect.SetMultimap;
 
+import org.apache.gobblin.annotation.Alias;
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.SourceState;
 import org.apache.gobblin.configuration.State;
@@ -78,6 +79,7 @@ import org.apache.gobblin.source.extractor.extract.AbstractSource;
 import org.apache.gobblin.source.workunit.Extract;
 import org.apache.gobblin.source.workunit.WorkUnit;
 import org.apache.gobblin.source.workunit.WorkUnitWeighter;
+import org.apache.gobblin.util.ClassAliasResolver;
 import org.apache.gobblin.util.ExecutorsUtils;
 import org.apache.gobblin.util.HadoopUtils;
 import org.apache.gobblin.util.WriterUtils;
@@ -86,6 +88,7 @@ import org.apache.gobblin.util.binpacking.WorstFitDecreasingBinPacking;
 import org.apache.gobblin.util.deprecation.DeprecationUtils;
 import org.apache.gobblin.util.executors.IteratorExecutor;
 import org.apache.gobblin.util.guid.Guid;
+import org.apache.gobblin.util.reflection.GobblinConstructorUtils;
 import org.apache.gobblin.util.request_allocation.GreedyAllocator;
 import org.apache.gobblin.util.request_allocation.HierarchicalAllocator;
 import org.apache.gobblin.util.request_allocation.HierarchicalPrioritizer;
@@ -205,13 +208,19 @@ public class CopySource extends AbstractSource<String, FileAwareInputStream> {
       //Submit alertable events for unfulfilled requests
       submitUnfulfilledRequestEvents(allocator);
 
+      String filesetWuGeneratorAlias = state.getProp(ConfigurationKeys.COPY_SOURCE_FILESET_WU_GENERATOR, FileSetWorkUnitGenerator.class.getName());
       Iterator<Callable<Void>> callableIterator =
           Iterators.transform(prioritizedFileSets, new Function<FileSet<CopyEntity>, Callable<Void>>() {
             @Nullable
             @Override
             public Callable<Void> apply(FileSet<CopyEntity> input) {
-              return new FileSetWorkUnitGenerator((CopyableDatasetBase) input.getDataset(), input, state, workUnitsMap,
-                  watermarkGenerator, minWorkUnitWeight);
+              try {
+                return GobblinConstructorUtils.<FileSetWorkUnitGenerator>invokeLongestConstructor(
+                    new ClassAliasResolver(FileSetWorkUnitGenerator.class).resolveClass(filesetWuGeneratorAlias),
+                    input.getDataset(), input, state, workUnitsMap, watermarkGenerator, minWorkUnitWeight, lineageInfo);
+              } catch (Exception e) {
+                throw new RuntimeException("Cannot create workunits generator", e);
+              }
             }
           });
 
@@ -315,15 +324,17 @@ public class CopySource extends AbstractSource<String, FileAwareInputStream> {
   /**
    * {@link Runnable} to generate copy listing for one {@link CopyableDataset}.
    */
+  @Alias("FileSetWorkUnitGenerator")
   @AllArgsConstructor
-  private class FileSetWorkUnitGenerator implements Callable<Void> {
+  public static class FileSetWorkUnitGenerator implements Callable<Void> {
 
-    private final CopyableDatasetBase copyableDataset;
-    private final FileSet<CopyEntity> fileSet;
-    private final State state;
-    private final SetMultimap<FileSet<CopyEntity>, WorkUnit> workUnitList;
-    private final Optional<CopyableFileWatermarkGenerator> watermarkGenerator;
-    private final long minWorkUnitWeight;
+    protected final CopyableDatasetBase copyableDataset;
+    protected final FileSet<CopyEntity> fileSet;
+    protected final State state;
+    protected final SetMultimap<FileSet<CopyEntity>, WorkUnit> workUnitList;
+    protected final Optional<CopyableFileWatermarkGenerator> watermarkGenerator;
+    protected final long minWorkUnitWeight;
+    protected final Optional<LineageInfo> lineageInfo;
 
     @Override
     public Void call() {
@@ -362,19 +373,31 @@ public class CopySource extends AbstractSource<String, FileAwareInputStream> {
             ioe);
       }
     }
-  }
 
-  private void addLineageInfo(CopyEntity copyEntity, WorkUnit workUnit) {
-    if (copyEntity instanceof CopyableFile) {
-      CopyableFile copyableFile = (CopyableFile) copyEntity;
+    private void setWorkUnitWatermark(WorkUnit workUnit, Optional<CopyableFileWatermarkGenerator> watermarkGenerator,
+        CopyEntity copyEntity)
+        throws IOException {
+      if (copyEntity instanceof CopyableFile) {
+        Optional<WatermarkInterval> watermarkIntervalOptional =
+            CopyableFileWatermarkHelper.getCopyableFileWatermark((CopyableFile) copyEntity, watermarkGenerator);
+        if (watermarkIntervalOptional.isPresent()) {
+          workUnit.setWatermarkInterval(watermarkIntervalOptional.get());
+        }
+      }
+    }
+
+    private void addLineageInfo(CopyEntity copyEntity, WorkUnit workUnit) {
+      if (copyEntity instanceof CopyableFile) {
+        CopyableFile copyableFile = (CopyableFile) copyEntity;
       /*
        * In Gobblin Distcp, the source and target path info of a CopyableFile are determined by its dataset found by
        * a DatasetFinder. Consequently, the source and destination dataset for the CopyableFile lineage are expected
        * to be set by the same logic
        */
-      if (lineageInfo.isPresent() && copyableFile.getSourceDataset() != null
-          && copyableFile.getDestinationDataset() != null) {
-        lineageInfo.get().setSource(copyableFile.getSourceDataset(), workUnit);
+        if (lineageInfo.isPresent() && copyableFile.getSourceDataset() != null
+            && copyableFile.getDestinationDataset() != null) {
+          lineageInfo.get().setSource(copyableFile.getSourceDataset(), workUnit);
+        }
       }
     }
   }
@@ -504,17 +527,5 @@ public class CopySource extends AbstractSource<String, FileAwareInputStream> {
    */
   public static CopyableDatasetMetadata deserializeCopyableDataset(State state) {
     return CopyableDatasetMetadata.deserialize(state.getProp(SERIALIZED_COPYABLE_DATASET));
-  }
-
-  private void setWorkUnitWatermark(WorkUnit workUnit, Optional<CopyableFileWatermarkGenerator> watermarkGenerator,
-      CopyEntity copyEntity)
-      throws IOException {
-    if (copyEntity instanceof CopyableFile) {
-      Optional<WatermarkInterval> watermarkIntervalOptional =
-          CopyableFileWatermarkHelper.getCopyableFileWatermark((CopyableFile) copyEntity, watermarkGenerator);
-      if (watermarkIntervalOptional.isPresent()) {
-        workUnit.setWatermarkInterval(watermarkIntervalOptional.get());
-      }
-    }
   }
 }

--- a/gobblin-example/src/main/resources/stressTest.conf
+++ b/gobblin-example/src/main/resources/stressTest.conf
@@ -1,0 +1,19 @@
+job.name=stressTest1
+job.group=GobblinSamples
+
+stressTest.numWorkUnits=2
+stressTest.numRecords=20000
+stressTest.computeTimeMicro=900
+stressTest.sleepTimeMicro=2100
+
+source.class=org.apache.gobblin.util.test.StressTestingSource
+
+writer.builder.class=org.apache.gobblin.writer.test.GobblinTestEventBusWriter$Builder
+writer.output.format=txt
+data.publisher.type=org.apache.gobblin.publisher.NoopPublisher
+
+# Work paths
+state.store.enabled=false
+
+# Miscellaneous
+job.lock.enabled=false


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-520


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
  In CopySource, user can have different fileSetWorkUnitGenerator implementation.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

