### PR TITLE
[GOBBLIN-534] switched from helix job queue to work flow

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixDistributeJobExecutionLauncher.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixDistributeJobExecutionLauncher.java
@@ -199,7 +199,7 @@ class GobblinHelixDistributeJobExecutionLauncher implements JobExecutionLauncher
    */
   private void submitJobToHelix(String jobName, String jobId, JobConfig.Builder jobConfigBuilder) throws Exception {
     TaskDriver taskDriver = new TaskDriver(this.helixManager);
-    HelixUtils.submitJobToQueue(jobConfigBuilder,
+    HelixUtils.submitJobToWorkFlow(jobConfigBuilder,
         jobName,
         jobId,
         taskDriver,
@@ -243,7 +243,7 @@ class GobblinHelixDistributeJobExecutionLauncher implements JobExecutionLauncher
           GobblinHelixDistributeJobExecutionLauncher.this.helixManager,
           planningName,
           planningId,
-          timeoutEnabled? Optional.of(timeoutInSeconds) : Optional.empty());
+          timeoutEnabled ? Optional.of(timeoutInSeconds) : Optional.empty());
       return getResultFromUserContent();
     } catch (TimeoutException te) {
       helixTaskDriver.waitToStop(planningName, 10L);

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobLauncher.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobLauncher.java
@@ -106,7 +106,7 @@ public class GobblinHelixJobLauncher extends AbstractJobLauncher {
 
   private final HelixManager helixManager;
   private final TaskDriver helixTaskDriver;
-  private final String helixworkFlowName;
+  private final String helixWorkFlowName;
   private final String jobResourceName;
   private JobListener jobListener;
 
@@ -141,8 +141,8 @@ public class GobblinHelixJobLauncher extends AbstractJobLauncher {
     this.outputTaskStateDir = new Path(this.appWorkDir, GobblinClusterConfigurationKeys.OUTPUT_TASK_STATE_DIR_NAME
         + Path.SEPARATOR + this.jobContext.getJobId());
 
-    this.helixworkFlowName = this.jobContext.getJobName();
-    this.jobResourceName = TaskUtil.getNamespacedJobName(this.helixworkFlowName, this.jobContext.getJobId());
+    this.helixWorkFlowName = this.jobContext.getJobName();
+    this.jobResourceName = TaskUtil.getNamespacedJobName(this.helixWorkFlowName, this.jobContext.getJobId());
 
     this.jobContext.getJobState().setJobLauncherType(LauncherTypeEnum.CLUSTER);
 
@@ -214,8 +214,8 @@ public class GobblinHelixJobLauncher extends AbstractJobLauncher {
   protected void executeCancellation() {
     if (this.jobSubmitted) {
       try {
-        log.info("[DELETE] workflow {}", this.helixworkFlowName);
-        this.helixTaskDriver.delete(this.helixworkFlowName);
+        log.info("[DELETE] workflow {}", this.helixWorkFlowName);
+        this.helixTaskDriver.delete(this.helixWorkFlowName);
       } catch (IllegalArgumentException e) {
         LOGGER.warn("Failed to cancel job {} in Helix", this.jobContext.getJobId(), e);
       }
@@ -282,7 +282,7 @@ public class GobblinHelixJobLauncher extends AbstractJobLauncher {
    * Submit a job to run.
    */
   private void submitJobToHelix(JobConfig.Builder jobConfigBuilder) throws Exception {
-    HelixUtils.submitJobToWorkFlow(jobConfigBuilder, this.helixworkFlowName, this.jobContext.getJobId(),
+    HelixUtils.submitJobToWorkFlow(jobConfigBuilder, this.helixWorkFlowName, this.jobContext.getJobId(),
         this.helixTaskDriver, this.helixManager, this.jobQueueDeleteTimeoutSeconds);
   }
 
@@ -368,17 +368,17 @@ public class GobblinHelixJobLauncher extends AbstractJobLauncher {
     try {
       HelixUtils.waitJobCompletion(
           this.helixManager,
-          this.helixworkFlowName,
+          this.helixWorkFlowName,
           this.jobContext.getJobId(),
           timeoutEnabled? Optional.of(timeoutInSeconds) : Optional.empty());
     } catch (TimeoutException te) {
-      helixTaskDriver.waitToStop(helixworkFlowName, 10L);
+      helixTaskDriver.waitToStop(helixWorkFlowName, 10L);
       try {
         cancelJob(this.jobListener);
       } catch (JobException e) {
         throw new RuntimeException("Unable to cancel job " + jobContext.getJobName() + ": ", e);
       }
-      this.helixTaskDriver.resume(this.helixworkFlowName);
+      this.helixTaskDriver.resume(this.helixWorkFlowName);
       LOGGER.info("stopped the queue, deleted the job");
     }
   }

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobLauncher.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobLauncher.java
@@ -282,7 +282,7 @@ public class GobblinHelixJobLauncher extends AbstractJobLauncher {
    * Submit a job to run.
    */
   private void submitJobToHelix(JobConfig.Builder jobConfigBuilder) throws Exception {
-    HelixUtils.submitJobToQueue(jobConfigBuilder, this.helixQueueName, this.jobContext.getJobId(),
+    HelixUtils.submitJobToWorkFlow(jobConfigBuilder, this.helixQueueName, this.jobContext.getJobId(),
         this.helixTaskDriver, this.helixManager, this.jobQueueDeleteTimeoutSeconds);
   }
 

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobLauncher.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobLauncher.java
@@ -106,7 +106,7 @@ public class GobblinHelixJobLauncher extends AbstractJobLauncher {
 
   private final HelixManager helixManager;
   private final TaskDriver helixTaskDriver;
-  private final String helixQueueName;
+  private final String helixworkFlowName;
   private final String jobResourceName;
   private JobListener jobListener;
 
@@ -141,8 +141,8 @@ public class GobblinHelixJobLauncher extends AbstractJobLauncher {
     this.outputTaskStateDir = new Path(this.appWorkDir, GobblinClusterConfigurationKeys.OUTPUT_TASK_STATE_DIR_NAME
         + Path.SEPARATOR + this.jobContext.getJobId());
 
-    this.helixQueueName = this.jobContext.getJobName();
-    this.jobResourceName = TaskUtil.getNamespacedJobName(this.helixQueueName, this.jobContext.getJobId());
+    this.helixworkFlowName = this.jobContext.getJobName();
+    this.jobResourceName = TaskUtil.getNamespacedJobName(this.helixworkFlowName, this.jobContext.getJobId());
 
     this.jobContext.getJobState().setJobLauncherType(LauncherTypeEnum.CLUSTER);
 
@@ -214,8 +214,8 @@ public class GobblinHelixJobLauncher extends AbstractJobLauncher {
   protected void executeCancellation() {
     if (this.jobSubmitted) {
       try {
-        log.info("[DELETE] workflow {}", this.helixQueueName);
-        this.helixTaskDriver.delete(this.helixQueueName);
+        log.info("[DELETE] workflow {}", this.helixworkFlowName);
+        this.helixTaskDriver.delete(this.helixworkFlowName);
       } catch (IllegalArgumentException e) {
         LOGGER.warn("Failed to cancel job {} in Helix", this.jobContext.getJobId(), e);
       }
@@ -282,7 +282,7 @@ public class GobblinHelixJobLauncher extends AbstractJobLauncher {
    * Submit a job to run.
    */
   private void submitJobToHelix(JobConfig.Builder jobConfigBuilder) throws Exception {
-    HelixUtils.submitJobToWorkFlow(jobConfigBuilder, this.helixQueueName, this.jobContext.getJobId(),
+    HelixUtils.submitJobToWorkFlow(jobConfigBuilder, this.helixworkFlowName, this.jobContext.getJobId(),
         this.helixTaskDriver, this.helixManager, this.jobQueueDeleteTimeoutSeconds);
   }
 
@@ -368,17 +368,17 @@ public class GobblinHelixJobLauncher extends AbstractJobLauncher {
     try {
       HelixUtils.waitJobCompletion(
           this.helixManager,
-          this.helixQueueName,
+          this.helixworkFlowName,
           this.jobContext.getJobId(),
           timeoutEnabled? Optional.of(timeoutInSeconds) : Optional.empty());
     } catch (TimeoutException te) {
-      helixTaskDriver.waitToStop(helixQueueName, 10L);
+      helixTaskDriver.waitToStop(helixworkFlowName, 10L);
       try {
         cancelJob(this.jobListener);
       } catch (JobException e) {
         throw new RuntimeException("Unable to cancel job " + jobContext.getJobName() + ": ", e);
       }
-      this.helixTaskDriver.resume(this.helixQueueName);
+      this.helixTaskDriver.resume(this.helixworkFlowName);
       LOGGER.info("stopped the queue, deleted the job");
     }
   }

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/HelixUtils.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/HelixUtils.java
@@ -18,7 +18,6 @@
 package org.apache.gobblin.cluster;
 
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import org.apache.helix.HelixManager;
@@ -108,12 +107,13 @@ public class HelixUtils {
       TaskDriver helixTaskDriver,
       HelixManager helixManager,
       long jobQueueDeleteTimeoutSeconds) throws Exception {
+
     WorkflowConfig workflowConfig = helixTaskDriver.getWorkflowConfig(helixManager, workFlowName);
 
     log.info("[DELETE] workflow {} in the beginning", workFlowName);
     // If the queue is present, but in delete state then wait for cleanup before recreating the queue
     if (workflowConfig != null && workflowConfig.getTargetState() == TargetState.DELETE) {
-      // We want synchronous delete otherwise state can be deleted due to race condition after we create it below.
+      // We want synchronous delete otherwise state can be deleted after we create it below due to race condition.
       new TaskDriver(helixManager).deleteAndWaitForCompletion(workFlowName, jobQueueDeleteTimeoutSeconds);
       // if we get here then the workflow was successfully deleted
       workflowConfig = null;

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/HelixUtils.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/HelixUtils.java
@@ -113,6 +113,7 @@ public class HelixUtils {
     log.info("[DELETE] workflow {} in the beginning", workFlowName);
     // If the queue is present, but in delete state then wait for cleanup before recreating the queue
     if (workflowConfig != null && workflowConfig.getTargetState() == TargetState.DELETE) {
+      // We want synchronous delete otherwise state can be deleted due to race condition after we create it below.
       new TaskDriver(helixManager).deleteAndWaitForCompletion(workFlowName, jobQueueDeleteTimeoutSeconds);
       // if we get here then the workflow was successfully deleted
       workflowConfig = null;


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below! @htran1 @yukuai518  please review


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. 


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Gobblin Helix Jobs are more suitable for Helix Work Flow instead of JobQueue, because work flow automatic cleanup after job completion and we submit only one job per work flow. More details and differences between the two can be found at http://helix.apache.org/0.8.0-docs/tutorial_task_framework.html section 'Creating a Queue'.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
tests already present

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

