### PR TITLE
[GOBBLIN-536] Add user configured properties to mysql connection string

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -576,6 +576,7 @@ public class ConfigurationKeys {
   public static final String SOURCE_CONN_HOST_NAME = SOURCE_CONN_PREFIX + "host";
   public static final String SOURCE_CONN_VERSION = SOURCE_CONN_PREFIX + "version";
   public static final String SOURCE_CONN_TIMEOUT = SOURCE_CONN_PREFIX + "timeout";
+  public static final String SOURCE_CONN_PROPERTIES = SOURCE_CONN_PREFIX + "properties";
   public static final String SOURCE_CONN_REST_URL = SOURCE_CONN_PREFIX + "rest.url";
   public static final String SOURCE_CONN_USE_PROXY_URL = SOURCE_CONN_PREFIX + "use.proxy.url";
   public static final String SOURCE_CONN_USE_PROXY_PORT = SOURCE_CONN_PREFIX + "use.proxy.port";

--- a/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/source/jdbc/MysqlExtractor.java
+++ b/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/source/jdbc/MysqlExtractor.java
@@ -183,10 +183,16 @@ public class MysqlExtractor extends JdbcExtractor {
     String port = this.workUnitState.getProp(ConfigurationKeys.SOURCE_CONN_PORT);
     String database = this.workUnitState.getProp(ConfigurationKeys.SOURCE_QUERYBASED_SCHEMA);
     String url = "jdbc:mysql://" + host.trim() + ":" + port + "/" + database.trim();
+    String connProps = this.workUnitState.getProp(ConfigurationKeys.SOURCE_CONN_PROPERTIES, "");
 
     if (Boolean.valueOf(this.workUnitState.getProp(ConfigurationKeys.SOURCE_QUERYBASED_IS_COMPRESSION_ENABLED))) {
-      return url + "?useCompression=true";
+      connProps = connProps + (connProps.isEmpty() ? "" : "&" + "useCompression=true");
     }
+
+    if (!connProps.isEmpty()) {
+      url = url + "?" + connProps;
+    }
+
     return url;
   }
 


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-536


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
   Add user configured properties to mysql connection string

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

