### PR TITLE
[GOBBLIN-537] Dump workunits to logs for debugging

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -178,6 +178,7 @@ public class ConfigurationKeys {
   public static final String WORK_UNIT_RETRY_ENABLED_KEY = "workunit.retry.enabled";
   public static final String WORK_UNIT_CREATION_TIME_IN_MILLIS = "workunit.creation.time.in.millis";
   public static final String WORK_UNIT_CREATION_AND_RUN_INTERVAL = "workunit.creation.and.run.interval";
+  public static final String WORK_UNIT_ENABLE_TRACKING_LOGS = "workunit.enableTrackingLogs";
 
   public static final String JOB_RUN_ONCE_KEY = "job.runonce";
   public static final String JOB_DISABLED_KEY = "job.disabled";

--- a/gobblin-api/src/main/java/org/apache/gobblin/source/workunit/MultiWorkUnit.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/source/workunit/MultiWorkUnit.java
@@ -26,6 +26,8 @@ import java.util.List;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
+import lombok.ToString;
+
 
 /**
  * A class that wraps multiple {@link WorkUnit}s so they can executed within a single task.
@@ -40,6 +42,7 @@ import com.google.common.collect.Lists;
  *
  * @author Yinan Li
  */
+@ToString(callSuper = true)
 public class MultiWorkUnit extends WorkUnit {
 
   private final List<WorkUnit> workUnits = Lists.newArrayList();

--- a/gobblin-api/src/main/java/org/apache/gobblin/source/workunit/WorkUnit.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/source/workunit/WorkUnit.java
@@ -45,7 +45,7 @@ import lombok.ToString;
  *
  * @author kgoodhop
  */
-@ToString
+@ToString(callSuper=true)
 public class WorkUnit extends State {
 
   private Extract extract;

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/AbstractJobLauncher.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/AbstractJobLauncher.java
@@ -433,6 +433,19 @@ public abstract class AbstractJobLauncher implements JobLauncher {
               jobState.addTaskState(new TaskState(new WorkUnitState(workUnit, jobState)));
             }
           });
+
+          // dump the work unit if tracking logs are enabled
+          if (jobState.getPropAsBoolean(ConfigurationKeys.WORK_UNIT_ENABLE_TRACKING_LOGS)) {
+            workUnitStream = workUnitStream.transform(new Function<WorkUnit, WorkUnit>() {
+              @Nullable
+              @Override
+              public WorkUnit apply(@Nullable WorkUnit input) {
+                LOG.info("Work unit tracking log: {}", input);
+                return input;
+              }
+            });
+          }
+
           workUnitsPreparationTimer.stop(this.eventMetadataGenerator.getMetadata(this.jobContext,
               EventName.WORK_UNITS_PREPARATION));
 

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/GobblinMultiTaskAttempt.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/GobblinMultiTaskAttempt.java
@@ -421,6 +421,13 @@ public class GobblinMultiTaskAttempt {
       StateStore<TaskState> taskStateStore,
       CommitPolicy multiTaskAttemptCommitPolicy, SharedResourcesBroker<GobblinScopeTypes> jobBroker)
       throws IOException, InterruptedException {
+
+    // dump the work unit if tracking logs are enabled
+    if (jobState.getPropAsBoolean(ConfigurationKeys.WORK_UNIT_ENABLE_TRACKING_LOGS)) {
+      Logger log = LoggerFactory.getLogger(GobblinMultiTaskAttempt.class.getName());
+      log.info("Work unit tracking log: {}", workUnits);
+    }
+
     GobblinMultiTaskAttempt multiTaskAttempt =
         new GobblinMultiTaskAttempt(workUnits.iterator(), jobId, jobState, taskStateTracker, taskExecutor,
             Optional.of(containerId), Optional.of(taskStateStore), jobBroker);


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-537


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
Added the `workunit.enableTrackingLogs` to dump the workunit to the logs.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tested locally.

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

