### PR TITLE
[GOBBLIN-538] move adding flow execution id from compiler to flowConfigResourceHandler

### DIFF
--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-api/src/main/idl/org.apache.gobblin.service.flowconfigs.restspec.json
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-api/src/main/idl/org.apache.gobblin.service.flowconfigs.restspec.json
@@ -8,7 +8,7 @@
     "identifier" : {
       "name" : "id",
       "type" : "org.apache.gobblin.service.FlowId",
-      "params" : "com.linkedin.restli.common.EmptyRecord"
+      "params" : "org.apache.gobblin.service.FlowStatusId"
     },
     "supports" : [ "create", "delete", "get", "update" ],
     "methods" : [ {

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-client/src/test/java/org/apache/gobblin/service/FlowConfigTest.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-client/src/test/java/org/apache/gobblin/service/FlowConfigTest.java
@@ -163,22 +163,42 @@ public class FlowConfigTest {
   public void testCheckFlowExecutionId() throws Exception {
     Map<String, String> flowProperties = Maps.newHashMap();
     flowProperties.put("param1", "value1");
+    flowProperties.put(ConfigurationKeys.FLOW_EXECUTION_ID_KEY, "1234567890");
 
     FlowConfig flowConfig = new FlowConfig().setId(new FlowId().setFlowGroup(TEST_GROUP_NAME).setFlowName(TEST_FLOW_NAME))
-        .setTemplateUris(TEST_TEMPLATE_URI).setSchedule(new Schedule().setCronSchedule(TEST_SCHEDULE).
-            setRunImmediately(true))
-        .setProperties(new StringMap(flowProperties));
+        .setTemplateUris(TEST_TEMPLATE_URI).setProperties(new StringMap(flowProperties))
+        .setSchedule(new Schedule().setCronSchedule("").setRunImmediately(true));
 
     Assert.assertEquals(TEST_GROUP_NAME, _client.createFlowConfig(flowConfig).getFlowGroup());
     Assert.assertEquals(TEST_FLOW_NAME, _client.createFlowConfig(flowConfig).getFlowName());
-    Assert.assertTrue(_client.createFlowConfig(flowConfig).hasFlowExecutionId());
+    Assert.assertEquals(_client.createFlowConfig(flowConfig).getFlowExecutionId().longValue(), 1234567890L);
 
     flowConfig = new FlowConfig().setId(new FlowId().setFlowGroup(TEST_GROUP_NAME).setFlowName(TEST_FLOW_NAME))
-        .setTemplateUris(TEST_TEMPLATE_URI).setSchedule(new Schedule().setCronSchedule(TEST_SCHEDULE).
-            setRunImmediately(false))
-        .setProperties(new StringMap(flowProperties));
+        .setTemplateUris(TEST_TEMPLATE_URI).setProperties(new StringMap(flowProperties))
+        .setSchedule(new Schedule().setCronSchedule("").setRunImmediately(false));
 
     Assert.assertFalse(_client.createFlowConfig(flowConfig).hasFlowExecutionId());
+
+    flowProperties.remove(ConfigurationKeys.FLOW_EXECUTION_ID_KEY);
+    flowConfig = new FlowConfig().setId(new FlowId().setFlowGroup(TEST_GROUP_NAME).setFlowName(TEST_FLOW_NAME))
+        .setTemplateUris(TEST_TEMPLATE_URI).setProperties(new StringMap(flowProperties))
+        .setSchedule(new Schedule().setCronSchedule("").setRunImmediately(true));
+
+    Assert.assertFalse(_client.createFlowConfig(flowConfig).hasFlowExecutionId());
+
+    flowProperties.put(ConfigurationKeys.FLOW_EXECUTION_ID_KEY, "1234567890");
+    flowConfig = new FlowConfig().setId(new FlowId().setFlowGroup(TEST_GROUP_NAME).setFlowName(TEST_FLOW_NAME))
+        .setTemplateUris(TEST_TEMPLATE_URI).setProperties(new StringMap(flowProperties))
+        .setSchedule(new Schedule().setCronSchedule(TEST_SCHEDULE));
+
+    try {
+      _client.createFlowConfig(flowConfig);
+    } catch (RestLiResponseException e) {
+      Assert.assertEquals(e.getStatus(), HttpStatus.S_400_BAD_REQUEST.getCode());
+      return;
+    }
+
+    Assert.fail();
   }
 
   @Test (dependsOnMethods = "testCreate")

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-client/src/test/java/org/apache/gobblin/service/FlowConfigTest.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-client/src/test/java/org/apache/gobblin/service/FlowConfigTest.java
@@ -159,6 +159,27 @@ public class FlowConfigTest {
     _client.createFlowConfig(flowConfig);
   }
 
+  @Test
+  public void testCheckFlowExecutionId() throws Exception {
+    Map<String, String> flowProperties = Maps.newHashMap();
+    flowProperties.put("param1", "value1");
+
+    FlowConfig flowConfig = new FlowConfig().setId(new FlowId().setFlowGroup(TEST_GROUP_NAME).setFlowName(TEST_FLOW_NAME))
+        .setTemplateUris(TEST_TEMPLATE_URI).setSchedule(new Schedule().setCronSchedule(TEST_SCHEDULE).
+            setRunImmediately(true))
+        .setProperties(new StringMap(flowProperties));
+
+    Long.parseLong(_client.createFlowConfig(flowConfig));
+
+    flowConfig = new FlowConfig().setId(new FlowId().setFlowGroup(TEST_GROUP_NAME).setFlowName(TEST_FLOW_NAME))
+        .setTemplateUris(TEST_TEMPLATE_URI).setSchedule(new Schedule().setCronSchedule(TEST_SCHEDULE).
+            setRunImmediately(false))
+        .setProperties(new StringMap(flowProperties));
+
+    Assert.assertNull(_client.createFlowConfig(flowConfig));
+
+  }
+
   @Test (dependsOnMethods = "testCreate")
   public void testCreateAgain() throws Exception {
     Map<String, String> flowProperties = Maps.newHashMap();

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-client/src/test/java/org/apache/gobblin/service/FlowConfigTest.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-client/src/test/java/org/apache/gobblin/service/FlowConfigTest.java
@@ -169,15 +169,16 @@ public class FlowConfigTest {
             setRunImmediately(true))
         .setProperties(new StringMap(flowProperties));
 
-    Long.parseLong(_client.createFlowConfig(flowConfig));
+    Assert.assertEquals(TEST_GROUP_NAME, _client.createFlowConfig(flowConfig).getFlowGroup());
+    Assert.assertEquals(TEST_FLOW_NAME, _client.createFlowConfig(flowConfig).getFlowName());
+    Assert.assertTrue(_client.createFlowConfig(flowConfig).hasFlowExecutionId());
 
     flowConfig = new FlowConfig().setId(new FlowId().setFlowGroup(TEST_GROUP_NAME).setFlowName(TEST_FLOW_NAME))
         .setTemplateUris(TEST_TEMPLATE_URI).setSchedule(new Schedule().setCronSchedule(TEST_SCHEDULE).
             setRunImmediately(false))
         .setProperties(new StringMap(flowProperties));
 
-    Assert.assertNull(_client.createFlowConfig(flowConfig));
-
+    Assert.assertFalse(_client.createFlowConfig(flowConfig).hasFlowExecutionId());
   }
 
   @Test (dependsOnMethods = "testCreate")

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowConfigResourceLocalHandler.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowConfigResourceLocalHandler.java
@@ -108,15 +108,32 @@ public class FlowConfigResourceLocalHandler implements FlowConfigsResourceHandle
    */
   public CreateResponse createFlowConfig(FlowConfig flowConfig, boolean triggerListener) throws FlowConfigLoggedException {
     log.info("[GAAS-REST] Create called with flowGroup " + flowConfig.getId().getFlowGroup() + " flowName " + flowConfig.getId().getFlowName());
-    FlowSpec flowSpec = createFlowSpecForConfig(flowConfig);
-    this.flowCatalog.put(flowSpec, triggerListener);
-    FlowStatusId flowStatusId = new FlowStatusId().setFlowGroup(flowSpec.getConfigAsProperties().getProperty(ConfigurationKeys.FLOW_GROUP_KEY))
-        .setFlowName(flowSpec.getConfigAsProperties().getProperty(ConfigurationKeys.FLOW_NAME_KEY));
-    if (flowSpec.getConfigAsProperties().containsKey(ConfigurationKeys.FLOW_EXECUTION_ID_KEY)) {
-      flowStatusId.setFlowExecutionId(
-          Long.parseLong(flowSpec.getConfigAsProperties().getProperty(ConfigurationKeys.FLOW_EXECUTION_ID_KEY)));
+    FlowSpec flowSpec;
+
+    if (!isValidFlowConfig(flowConfig)) {
+      throw new FlowConfigLoggedException(HttpStatus.S_400_BAD_REQUEST,
+          "FlowExecutionId cannot be passed for a scheduled job", null);
+    } else if (flowConfig.hasSchedule() && flowConfig.getSchedule().isRunImmediately() &&
+        flowConfig.getProperties().containsKey(ConfigurationKeys.FLOW_EXECUTION_ID_KEY)) {
+      flowSpec = createFlowSpecForConfig(flowConfig, flowConfig.getProperties().get(ConfigurationKeys.FLOW_EXECUTION_ID_KEY));
+      this.flowCatalog.put(flowSpec, triggerListener);
+      FlowStatusId flowStatusId = new FlowStatusId()
+          .setFlowName(flowSpec.getConfigAsProperties().getProperty(ConfigurationKeys.FLOW_NAME_KEY))
+          .setFlowGroup(flowSpec.getConfigAsProperties().getProperty(ConfigurationKeys.FLOW_GROUP_KEY))
+          .setFlowExecutionId(Long.parseLong(flowSpec.getConfigAsProperties().getProperty(ConfigurationKeys.FLOW_EXECUTION_ID_KEY)));
+      return new CreateResponse(new ComplexResourceKey<>(flowConfig.getId(), flowStatusId), HttpStatus.S_201_CREATED);
+    } else {
+      flowSpec = createFlowSpecForConfig(flowConfig);
+      this.flowCatalog.put(flowSpec, triggerListener);
+      FlowStatusId flowStatusId = new FlowStatusId().setFlowGroup(flowSpec.getConfigAsProperties().getProperty(ConfigurationKeys.FLOW_GROUP_KEY))
+          .setFlowName(flowSpec.getConfigAsProperties().getProperty(ConfigurationKeys.FLOW_NAME_KEY));
+      return new CreateResponse(new ComplexResourceKey<>(flowConfig.getId(), flowStatusId), HttpStatus.S_202_ACCEPTED);
     }
-    return new CreateResponse(new ComplexResourceKey<>(flowConfig.getId(), flowStatusId), HttpStatus.S_201_CREATED);
+  }
+
+  private static boolean isValidFlowConfig(FlowConfig flowConfig) {
+    return !flowConfig.hasSchedule() || StringUtils.isEmpty(flowConfig.getSchedule().getCronSchedule()) ||
+        !flowConfig.getProperties().containsKey(ConfigurationKeys.FLOW_EXECUTION_ID_KEY);
   }
 
   /**
@@ -185,6 +202,10 @@ public class FlowConfigResourceLocalHandler implements FlowConfigsResourceHandle
    * @return {@link FlowSpec} created with attributes from flowConfig
    */
   public static FlowSpec createFlowSpecForConfig(FlowConfig flowConfig) {
+    return createFlowSpecForConfig(flowConfig, null);
+  }
+
+  private static FlowSpec createFlowSpecForConfig(FlowConfig flowConfig, String flowExecutionId) {
     ConfigBuilder configBuilder = ConfigBuilder.create()
         .addPrimitive(ConfigurationKeys.FLOW_GROUP_KEY, flowConfig.getId().getFlowGroup())
         .addPrimitive(ConfigurationKeys.FLOW_NAME_KEY, flowConfig.getId().getFlowName());
@@ -194,8 +215,8 @@ public class FlowConfigResourceLocalHandler implements FlowConfigsResourceHandle
       configBuilder.addPrimitive(ConfigurationKeys.JOB_SCHEDULE_KEY, schedule.getCronSchedule());
       configBuilder.addPrimitive(ConfigurationKeys.FLOW_RUN_IMMEDIATELY, schedule.isRunImmediately());
 
-      if (schedule.isRunImmediately()) {
-        configBuilder.addPrimitive(ConfigurationKeys.FLOW_EXECUTION_ID_KEY, System.currentTimeMillis());
+      if (flowExecutionId != null) {
+        configBuilder.addPrimitive(ConfigurationKeys.FLOW_EXECUTION_ID_KEY, flowExecutionId);
       }
     }
 

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/validator/CronValidator.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/validator/CronValidator.java
@@ -17,6 +17,7 @@
 
 package org.apache.gobblin.service.validator;
 
+import org.apache.commons.lang.StringUtils;
 import org.quartz.CronExpression;
 
 import com.linkedin.data.DataMap;
@@ -43,7 +44,7 @@ public class CronValidator extends AbstractValidator
     Object value = element.getValue();
     String str = String.valueOf(value);
 
-    if (!CronExpression.isValidExpression(str))
+    if (!StringUtils.isEmpty(str) && !CronExpression.isValidExpression(str))
     {
       ctx.addResult(new Message(element.path(), "\"%1$s\" is not in Cron format", str));
     }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/BaseFlowToJobSpecCompiler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/BaseFlowToJobSpecCompiler.java
@@ -250,9 +250,10 @@ public abstract class BaseFlowToJobSpecCompiler implements SpecCompiler {
     }
 
     // Add flow execution id for this compilation
-    long flowExecutionId = System.currentTimeMillis();
-    jobSpec.setConfig(jobSpec.getConfig().withValue(ConfigurationKeys.FLOW_EXECUTION_ID_KEY,
-        ConfigValueFactory.fromAnyRef(flowExecutionId)));
+    if (!jobSpec.getConfig().hasPath(ConfigurationKeys.FLOW_EXECUTION_ID_KEY)) {
+      long flowExecutionId = System.currentTimeMillis();
+      jobSpec.setConfig(jobSpec.getConfig().withValue(ConfigurationKeys.FLOW_EXECUTION_ID_KEY, ConfigValueFactory.fromAnyRef(flowExecutionId)));
+    }
 
     // Reset properties in Spec from Config
     jobSpec.setConfigAsProperties(ConfigUtils.configToProperties(jobSpec.getConfig()));

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/MultiHopsFlowToJobSpecCompiler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/MultiHopsFlowToJobSpecCompiler.java
@@ -300,9 +300,10 @@ public class MultiHopsFlowToJobSpecCompiler extends BaseFlowToJobSpecCompiler {
     }
 
     // Add flow execution id for this compilation
-    long flowExecutionId = System.currentTimeMillis();
-    jobSpec.setConfig(jobSpec.getConfig().withValue(ConfigurationKeys.FLOW_EXECUTION_ID_KEY,
-        ConfigValueFactory.fromAnyRef(flowExecutionId)));
+    if (!jobSpec.getConfig().hasPath(ConfigurationKeys.FLOW_EXECUTION_ID_KEY)) {
+      long flowExecutionId = System.currentTimeMillis();
+      jobSpec.setConfig(jobSpec.getConfig().withValue(ConfigurationKeys.FLOW_EXECUTION_ID_KEY, ConfigValueFactory.fromAnyRef(flowExecutionId)));
+    }
 
     // Reset properties in Spec from Config
     jobSpec.setConfigAsProperties(ConfigUtils.configToProperties(jobSpec.getConfig()));


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title.
@htran1 Sudarshan please review

### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
returning flow execution id is the first step to make flow status queryable. this pr will make submit new flow return flow execution id if it is 'runImmediate' flow.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
added tests in FlowConfigTest.java

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

