### PR TITLE
[GOBBLIN-547] Make calculation of bytesWritten in AsyncRequest more efficient and make DatePartitionedNestedRetriever extensible

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/source/DatePartitionedNestedRetriever.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/DatePartitionedNestedRetriever.java
@@ -68,12 +68,13 @@ public class DatePartitionedNestedRetriever implements PartitionAwareFileRetriev
   private String sourcePartitionPrefix;
   private String sourcePartitionSuffix;
   private Path sourceDir;
-  private FileSystem fs;
   private HadoopFsHelper helper;
   private final String expectedExtension;
   private Duration leadTimeDuration;
   private boolean schemaInSourceDir;
   private String schemaFile;
+
+  protected FileSystem fs;
 
   public DatePartitionedNestedRetriever(String expectedExtension) {
     this.expectedExtension = expectedExtension;
@@ -120,7 +121,7 @@ public class DatePartitionedNestedRetriever implements PartitionAwareFileRetriev
       Path sourcePath = constructSourcePath(date);
 
       if (this.fs.exists(sourcePath)) {
-        for (FileStatus fileStatus : this.fs.listStatus(sourcePath, getFileFilter())) {
+        for (FileStatus fileStatus : getFilteredFileStatuses(sourcePath, getFileFilter())) {
           LOG.info("Will process file " + fileStatus.getPath());
           filesToProcess.add(new FileInfo(fileStatus.getPath().toString(), fileStatus.getLen(), date.getMillis()));
         }
@@ -128,6 +129,14 @@ public class DatePartitionedNestedRetriever implements PartitionAwareFileRetriev
     }
 
     return filesToProcess;
+  }
+
+  /**
+   * This method could be overwritten to support more complicated file-loading scheme,
+   * e.g. recursively browsing of the source path.
+   */
+  protected FileStatus[] getFilteredFileStatuses(Path sourcePath, PathFilter pathFilter) throws IOException {
+    return this.fs.listStatus(sourcePath, pathFilter);
   }
 
   @Override


### PR DESCRIPTION
- Make calculation of bytesWritten in AsyncRequest more efficient by having a instance variable to count that in a accumulation way.
- Make DatePartitionedNestedRetriever extended for method partially

I didn't choose to implement `byteSize` using atomic data type because it is not expected to have frequent query on `getBytesWritten ()` while the `markRecord` are being called. For here we are mostly focusing on ensuring the atomicity of `markRecord` method. 

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-547] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-547


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

