### PR TITLE
Fixed GOBBLIN-551, re-using data connection in executeSql and execute…

### DIFF
--- a/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/source/jdbc/JdbcExtractor.java
+++ b/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/source/jdbc/JdbcExtractor.java
@@ -655,7 +655,9 @@ public abstract class JdbcExtractor extends QueryBasedExtractor<JsonArray, JsonE
     ResultSet resultSet = null;
     try {
       this.jdbcSource = createJdbcSource();
-      this.dataConnection = this.jdbcSource.getConnection();
+      if(this.dataConnection == null) {
+        this.dataConnection = this.jdbcSource.getConnection();
+      }
       Statement statement = this.dataConnection.createStatement();
 
       if (fetchSize != 0 && this.getExpectedRecordCount() > 2000) {
@@ -712,7 +714,9 @@ public abstract class JdbcExtractor extends QueryBasedExtractor<JsonArray, JsonE
     ResultSet resultSet = null;
     try {
       this.jdbcSource = createJdbcSource();
-      this.dataConnection = this.jdbcSource.getConnection();
+      if(this.dataConnection == null) {
+        this.dataConnection = this.jdbcSource.getConnection();
+      }
 
       PreparedStatement statement =
           this.dataConnection.prepareStatement(query, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);

--- a/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/source/jdbc/JdbcExtractor.java
+++ b/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/source/jdbc/JdbcExtractor.java
@@ -655,7 +655,7 @@ public abstract class JdbcExtractor extends QueryBasedExtractor<JsonArray, JsonE
     ResultSet resultSet = null;
     try {
       this.jdbcSource = createJdbcSource();
-      if(this.dataConnection == null) {
+      if (this.dataConnection == null) {
         this.dataConnection = this.jdbcSource.getConnection();
       }
       Statement statement = this.dataConnection.createStatement();
@@ -714,7 +714,7 @@ public abstract class JdbcExtractor extends QueryBasedExtractor<JsonArray, JsonE
     ResultSet resultSet = null;
     try {
       this.jdbcSource = createJdbcSource();
-      if(this.dataConnection == null) {
+      if (this.dataConnection == null) {
         this.dataConnection = this.jdbcSource.getConnection();
       }
 


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-551] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-551


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
JdbcExtractor code in gobblin-sql module uses separate data connection every time it uses executeSql & executePreparedSql. The issue manifested while using SQL Server over proxy as one of the connection is active/open when the JDBC source is closed. After closing the proxy tunnel it becomes a memory leak.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

