### PR TITLE
GOBBLIN-556: Gobblin AvroUtils reads and writes UTF rather than chars

### DIFF
--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/conversion/hive/avro/AvroSchemaManagerTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/conversion/hive/avro/AvroSchemaManagerTest.java
@@ -61,23 +61,6 @@ public class AvroSchemaManagerTest {
     Assert.assertEquals(actualSchema.toString(), expectedSchema);
   }
 
-  @Test(expectedExceptions = SchemaParseException.class)
-  public void testExceptionWhenReadingSchemaUsingParser()
-      throws IOException, HiveException {
-    FileSystem fs = FileSystem.getLocal(new Configuration());
-
-    String jobId = "123";
-    State state = new State();
-    state.setProp(ConfigurationKeys.JOB_ID_KEY, jobId);
-
-    AvroSchemaManager asm = new AvroSchemaManager(fs, state);
-    Partition partition = getTestPartition(new Table("testDb", "testTable"));
-    Path schemaPath = asm.getSchemaUrl(partition);
-    // parse operation tries to read using UTF-8 encoding and fails
-    // because schema is written using modified UTF-8 encoding
-    new Schema.Parser().parse(fs.open(schemaPath));
-  }
-
   private Partition getTestPartition(Table table) throws HiveException {
     Partition partition = new Partition(table, ImmutableMap.of("partition_key", "1"), null);
     StorageDescriptor sd = new StorageDescriptor();

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/AvroUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/AvroUtils.java
@@ -381,7 +381,7 @@ public class AvroUtils {
     Preconditions.checkArgument(fs.exists(filePath), filePath + " does not exist");
 
     try (FSDataInputStream in = fs.open(filePath)) {
-      return new Schema.Parser().parse(in.readUTF());
+      return new Schema.Parser().parse(in);
     }
   }
 
@@ -399,7 +399,7 @@ public class AvroUtils {
     }
 
     try (DataOutputStream dos = fs.create(filePath)) {
-      dos.writeUTF(schema.toString());
+      dos.writeChars(schema.toString());
     }
     fs.setPermission(filePath, perm);
   }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-556


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable): Changed writeUTF to writeChars and readUTF back to reading chars

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: Updated tests


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

