### PR TITLE
GOBBLIN-559: Implement FlowGraph as a concurrent data structure.

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/BaseFlowGraph.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/BaseFlowGraph.java
@@ -21,8 +21,15 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import org.apache.gobblin.annotation.Alpha;
+import org.apache.gobblin.runtime.api.FlowSpec;
+import org.apache.gobblin.service.modules.flow.FlowGraphPath;
+import org.apache.gobblin.service.modules.flowgraph.pathfinder.PathFinder;
+import org.apache.gobblin.util.ConfigUtils;
+import org.apache.gobblin.util.reflection.GobblinConstructorUtils;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -32,10 +39,14 @@ import lombok.extern.slf4j.Slf4j;
  *   <p>dataNodeMap - the mapping from a node identifier to the {@link DataNode} instance</p>
  *   <p>nodesToEdges - the mapping from each {@link DataNode} to its outgoing {@link FlowEdge}s</p>
  *   <p>flowEdgeMap - the mapping from a edge label to the {@link FlowEdge} instance</p>
+ *
+ *   Read/Write Access to the {@link FlowGraph} is synchronized via a {@link ReentrantReadWriteLock}.
  */
 @Alpha
 @Slf4j
 public class BaseFlowGraph implements FlowGraph {
+  private final ReadWriteLock rwLock = new ReentrantReadWriteLock(true);
+
   private Map<DataNode, Set<FlowEdge>> nodesToEdges = new HashMap<>();
   private Map<String, DataNode> dataNodeMap = new HashMap<>();
   private Map<String, FlowEdge> flowEdgeMap = new HashMap<>();
@@ -58,11 +69,16 @@ public class BaseFlowGraph implements FlowGraph {
    * @return true if node is successfully added to the {@link FlowGraph}.
    */
   @Override
-  public synchronized boolean addDataNode(DataNode node) {
-    //Get edges adjacent to the node if it already exists
-    Set<FlowEdge> edges = this.nodesToEdges.getOrDefault(node, new HashSet<>());
-    this.nodesToEdges.put(node, edges);
-    this.dataNodeMap.put(node.getId(), node);
+  public boolean addDataNode(DataNode node) {
+    try {
+      rwLock.writeLock().lock();
+      //Get edges adjacent to the node if it already exists
+      Set<FlowEdge> edges = this.nodesToEdges.getOrDefault(node, new HashSet<>());
+      this.nodesToEdges.put(node, edges);
+      this.dataNodeMap.put(node.getId(), node);
+    } finally {
+      rwLock.writeLock().unlock();
+    }
     return true;
   }
 
@@ -74,25 +90,30 @@ public class BaseFlowGraph implements FlowGraph {
    * @return true if addition of {@FlowEdge} is successful.
    */
   @Override
-  public synchronized boolean addFlowEdge(FlowEdge edge) {
-    String srcNode = edge.getSrc();
-    String dstNode = edge.getDest();
-    if(!dataNodeMap.containsKey(srcNode) || !dataNodeMap.containsKey(dstNode)) {
-      return false;
-    }
-    DataNode dataNode = getNode(srcNode);
-    if(dataNode != null) {
-      Set<FlowEdge> adjacentEdges = this.nodesToEdges.get(dataNode);
-      if(!adjacentEdges.add(edge)) {
-        adjacentEdges.remove(edge);
-        adjacentEdges.add(edge);
+  public boolean addFlowEdge(FlowEdge edge) {
+    try {
+      rwLock.writeLock().lock();
+      String srcNode = edge.getSrc();
+      String dstNode = edge.getDest();
+      if (!dataNodeMap.containsKey(srcNode) || !dataNodeMap.containsKey(dstNode)) {
+        return false;
       }
-      this.nodesToEdges.put(dataNode, adjacentEdges);
-      String edgeId = edge.getId();
-      this.flowEdgeMap.put(edgeId, edge);
-      return true;
-    } else {
-      return false;
+      DataNode dataNode = getNode(srcNode);
+      if (dataNode != null) {
+        Set<FlowEdge> adjacentEdges = this.nodesToEdges.get(dataNode);
+        if (!adjacentEdges.add(edge)) {
+          adjacentEdges.remove(edge);
+          adjacentEdges.add(edge);
+        }
+        this.nodesToEdges.put(dataNode, adjacentEdges);
+        String edgeId = edge.getId();
+        this.flowEdgeMap.put(edgeId, edge);
+        return true;
+      } else {
+        return false;
+      }
+    } finally {
+      rwLock.writeLock().unlock();
     }
   }
 
@@ -102,11 +123,12 @@ public class BaseFlowGraph implements FlowGraph {
    * @return true if {@link DataNode} is successfully deleted.
    */
   @Override
-  public synchronized boolean deleteDataNode(String nodeId) {
-    if(this.dataNodeMap.containsKey(nodeId) && deleteDataNode(this.dataNodeMap.get(nodeId))) {
-      return true;
-    } else {
-      return false;
+  public boolean deleteDataNode(String nodeId) {
+    try {
+      rwLock.writeLock().lock();
+      return this.dataNodeMap.containsKey(nodeId) && deleteDataNode(this.dataNodeMap.get(nodeId));
+    } finally {
+      rwLock.writeLock().unlock();
     }
   }
 
@@ -115,20 +137,25 @@ public class BaseFlowGraph implements FlowGraph {
    * @param node to be deleted.
    * @return true if {@link DataNode} is successfully deleted.
    */
-  public synchronized boolean deleteDataNode(DataNode node) {
-    if(dataNodeMap.containsKey(node.getId())) {
-      //Delete node from dataNodeMap
-      dataNodeMap.remove(node.getId());
+  public boolean deleteDataNode(DataNode node) {
+    try {
+      rwLock.writeLock().lock();
+      if (dataNodeMap.containsKey(node.getId())) {
+        //Delete node from dataNodeMap
+        dataNodeMap.remove(node.getId());
 
-      //Delete all the edges adjacent to the node. First, delete edges from flowEdgeMap and next, remove the edges
-      // from nodesToEdges
-      for(FlowEdge edge: nodesToEdges.get(node)) {
-        flowEdgeMap.remove(edge.getId());
+        //Delete all the edges adjacent to the node. First, delete edges from flowEdgeMap and next, remove the edges
+        // from nodesToEdges
+        for (FlowEdge edge : nodesToEdges.get(node)) {
+          flowEdgeMap.remove(edge.getId());
+        }
+        nodesToEdges.remove(node);
+        return true;
+      } else {
+        return false;
       }
-      nodesToEdges.remove(node);
-      return true;
-    } else {
-      return false;
+    } finally {
+      rwLock.writeLock().unlock();
     }
   }
 
@@ -138,11 +165,12 @@ public class BaseFlowGraph implements FlowGraph {
    * @return true if {@link FlowEdge} is successfully deleted.
    */
   @Override
-  public synchronized boolean deleteFlowEdge(String edgeId) {
-    if(flowEdgeMap.containsKey(edgeId) && deleteFlowEdge(flowEdgeMap.get(edgeId))) {
-      return true;
-    } else {
-      return false;
+  public boolean deleteFlowEdge(String edgeId) {
+    try {
+      rwLock.writeLock().lock();
+      return flowEdgeMap.containsKey(edgeId) && deleteFlowEdge(flowEdgeMap.get(edgeId));
+    } finally {
+      rwLock.writeLock().unlock();
     }
   }
 
@@ -152,17 +180,22 @@ public class BaseFlowGraph implements FlowGraph {
    * @return true if {@link FlowEdge} is successfully deleted. If the source of a {@link FlowEdge} does not exist or
    * if the {@link FlowEdge} is not in the graph, return false.
    */
-  public synchronized boolean deleteFlowEdge(FlowEdge edge) {
-    if(!dataNodeMap.containsKey(edge.getSrc())) {
-      return false;
+  public boolean deleteFlowEdge(FlowEdge edge) {
+    try {
+      rwLock.writeLock().lock();
+      if (!dataNodeMap.containsKey(edge.getSrc())) {
+        return false;
+      }
+      DataNode node = dataNodeMap.get(edge.getSrc());
+      if (!nodesToEdges.get(node).contains(edge)) {
+        return false;
+      }
+      this.nodesToEdges.get(node).remove(edge);
+      this.flowEdgeMap.remove(edge.getId());
+      return true;
+    } finally {
+      rwLock.writeLock().unlock();
     }
-    DataNode node = dataNodeMap.get(edge.getSrc());
-    if(!nodesToEdges.get(node).contains(edge)) {
-      return false;
-    }
-    this.nodesToEdges.get(node).remove(edge);
-    this.flowEdgeMap.remove(edge.getId());
-    return true;
   }
 
   /**
@@ -172,8 +205,13 @@ public class BaseFlowGraph implements FlowGraph {
    */
   @Override
   public Set<FlowEdge> getEdges(String nodeId) {
-    DataNode dataNode = this.dataNodeMap.getOrDefault(nodeId, null);
-    return getEdges(dataNode);
+    try {
+      rwLock.readLock().lock();
+      DataNode dataNode = this.dataNodeMap.getOrDefault(nodeId, null);
+      return getEdges(dataNode);
+    } finally {
+      rwLock.readLock().unlock();
+    }
   }
 
   /**
@@ -183,7 +221,28 @@ public class BaseFlowGraph implements FlowGraph {
    */
   @Override
   public Set<FlowEdge> getEdges(DataNode node) {
-    return (node != null)? this.nodesToEdges.getOrDefault(node, null) : null;
+    try {
+      rwLock.readLock().lock();
+      return (node != null) ? this.nodesToEdges.getOrDefault(node, null) : null;
+    } finally {
+      rwLock.readLock().unlock();
+    }
   }
 
+  /**{@inheritDoc}**/
+  @Override
+  public FlowGraphPath findPath(FlowSpec flowSpec) throws PathFinder.PathFinderException, ReflectiveOperationException {
+    try {
+      rwLock.readLock().lock();
+      //Instantiate a PathFinder.
+      Class pathFinderClass = Class.forName(ConfigUtils
+          .getString(flowSpec.getConfig(), FlowGraphConfigurationKeys.FLOW_GRAPH_PATH_FINDER_CLASS,
+              FlowGraphConfigurationKeys.DEFAULT_FLOW_GRAPH_PATH_FINDER_CLASS));
+      PathFinder pathFinder =
+          (PathFinder) GobblinConstructorUtils.invokeLongestConstructor(pathFinderClass, this, flowSpec);
+      return pathFinder.findPath();
+    } finally {
+      rwLock.readLock().unlock();
+    }
+  }
 }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/FlowGraph.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/FlowGraph.java
@@ -19,7 +19,13 @@ package org.apache.gobblin.service.modules.flowgraph;
 
 import java.util.Collection;
 
+import com.typesafe.config.Config;
+
 import org.apache.gobblin.annotation.Alpha;
+import org.apache.gobblin.runtime.api.FlowSpec;
+import org.apache.gobblin.runtime.api.Spec;
+import org.apache.gobblin.service.modules.flow.FlowGraphPath;
+import org.apache.gobblin.service.modules.flowgraph.pathfinder.PathFinder;
 
 
 /**
@@ -80,4 +86,17 @@ public interface FlowGraph {
    * @return a collection of edges adjacent to the {@link DataNode}
    */
   public Collection<FlowEdge> getEdges(DataNode node);
+
+  /**
+   * A method that takes a {@link FlowSpec} containing the source and destination {@link DataNode}s, as well as the
+   * source and target {@link org.apache.gobblin.service.modules.dataset.DatasetDescriptor}s, and returns a sequence
+   * of fully resolved {@link org.apache.gobblin.runtime.api.JobSpec}s that will move the source dataset
+   * from the source datanode, perform any necessary transformations and land the dataset at the destination node
+   * in the format described by the target {@link org.apache.gobblin.service.modules.dataset.DatasetDescriptor}.
+   *
+   * @param flowSpec a {@link org.apache.gobblin.runtime.api.Spec} containing a high-level description of input flow.
+   * @return an instance of {@link FlowGraphPath} that encapsulates a sequence of {@link org.apache.gobblin.runtime.api.JobSpec}s
+   * satisfying flowSpec.
+   */
+  public FlowGraphPath findPath(FlowSpec flowSpec) throws PathFinder.PathFinderException, ReflectiveOperationException;
 }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/FlowGraphConfigurationKeys.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/FlowGraphConfigurationKeys.java
@@ -20,7 +20,7 @@ package org.apache.gobblin.service.modules.flowgraph;
 public class FlowGraphConfigurationKeys {
   public static final String DATA_NODE_PREFIX = "data.node.";
   public static final String FLOW_EDGE_PREFIX = "flow.edge.";
-
+  public static final String FLOW_GRAPH_PREFIX = "flow.graph.";
   /**
    *   {@link DataNode} related configuration keys.
    */
@@ -42,4 +42,10 @@ public class FlowGraphConfigurationKeys {
   public static final String FLOW_EDGE_TEMPLATE_DIR_URI_KEY = FLOW_EDGE_PREFIX + "flowTemplateDirUri";
   public static final String FLOW_EDGE_SPEC_EXECUTORS_KEY = FLOW_EDGE_PREFIX + "specExecutors";
   public static final String FLOW_EDGE_SPEC_EXECUTOR_CLASS_KEY = "specExecInstance.class";
+
+  /**
+   * {@link org.apache.gobblin.service.modules.flowgraph.pathfinder.PathFinder} related configuration keys.
+   */
+  public static final String FLOW_GRAPH_PATH_FINDER_CLASS = FLOW_GRAPH_PREFIX + "pathfinder.class";
+  public static final String DEFAULT_FLOW_GRAPH_PATH_FINDER_CLASS = "org.apache.gobblin.service.modules.flowgraph.pathfinder.BFSPathFinder";
 }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/pathfinder/BFSPathFinder.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/pathfinder/BFSPathFinder.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.service.modules.flowgraph.pathfinder;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.gobblin.annotation.Alpha;
+import org.apache.gobblin.runtime.api.FlowSpec;
+import org.apache.gobblin.runtime.api.JobTemplate;
+import org.apache.gobblin.runtime.api.SpecNotFoundException;
+import org.apache.gobblin.service.modules.dataset.DatasetDescriptor;
+import org.apache.gobblin.service.modules.flow.FlowEdgeContext;
+import org.apache.gobblin.service.modules.flowgraph.DataNode;
+import org.apache.gobblin.service.modules.flowgraph.FlowEdge;
+import org.apache.gobblin.service.modules.flowgraph.FlowGraph;
+
+
+/**
+ * An implementation of {@link PathFinder} that assumes an unweighted {@link FlowGraph} and computes the
+ * shortest path using a variant of the BFS path-finding algorithm. This implementation has two key differences from the
+ * traditional BFS implementations:
+ *  <ul>
+ *    <p> the input graph is a multi-graph i.e. there could be multiple edges between each pair of nodes, and </p>
+ *    <p> each edge has a label associated with it. In our case, the label corresponds to the set of input/output
+ *    dataset descriptors that are accepted by the edge.</p>
+ *  </ul>
+ *  Given these differences, we maintain:
+ *    <p> a {@link HashMap} of list of visited edges, as opposed to list of visited
+ *  vertices as in the case of traditional BFS, and </p>
+ *    <p> for each edge, we maintain additional state that includes the input/output dataset descriptor
+ *  associated with the particular visitation of that edge. </p>
+ *  This additional information allows us to accurately mark edges as visited and guarantee termination of the algorithm.
+ */
+@Alpha
+@Slf4j
+public class BFSPathFinder extends AbstractPathFinder {
+  /**
+   * Constructor.
+   * @param flowGraph
+   */
+  public BFSPathFinder(FlowGraph flowGraph, FlowSpec flowSpec) throws ReflectiveOperationException {
+    super(flowGraph, flowSpec);
+  }
+
+  /**
+   * A simple path finding algorithm based on Breadth-First Search. At every step the algorithm adds the adjacent {@link FlowEdge}s
+   * to a queue. The {@link FlowEdge}s whose output {@link DatasetDescriptor} matches the destDatasetDescriptor are
+   * added first to the queue. This ensures that dataset transformations are always performed closest to the source.
+   * @return a path of {@link FlowEdgeContext}s starting at the srcNode and ending at the destNode.
+   */
+  public List<FlowEdgeContext> findPathUnicast(DataNode destNode) throws PathFinderException {
+    try {
+      //Initialization of auxiliary data structures used for path computation
+      this.pathMap = new HashMap<>();
+
+      // Generate flow execution id for this compilation
+      this.flowExecutionId = System.currentTimeMillis();
+
+      //Path computation must be thread-safe to guarantee read consistency. In other words, we prevent concurrent read/write access to the
+      // flow graph.
+        //Base condition 1: Source Node or Dest Node is inactive; return null
+        if (!srcNode.isActive() || !destNode.isActive()) {
+          log.warn("Either source node {} or destination node {} is inactive; skipping path computation.", this.srcNode.getId(),
+              destNode.getId());
+          return null;
+        }
+
+        //Base condition 2: Check if we are already at the target. If so, return an empty path.
+        if ((srcNode.equals(destNode)) && destDatasetDescriptor.contains(srcDatasetDescriptor)) {
+          return new ArrayList<>();
+        }
+
+        LinkedList<FlowEdgeContext> edgeQueue = new LinkedList<>();
+        edgeQueue.addAll(getNextEdges(srcNode, srcDatasetDescriptor, destDatasetDescriptor));
+        for (FlowEdgeContext flowEdgeContext : edgeQueue) {
+          this.pathMap.put(flowEdgeContext, flowEdgeContext);
+        }
+
+        //At every step, pop an edge E from the edge queue. Mark the edge E as visited. Generate the list of adjacent edges
+        // to the edge E. For each adjacent edge E', do the following:
+        //    1. check if the FlowTemplate described by E' is resolvable using the flowConfig, and
+        //    2. check if the output dataset descriptor of edge E is compatible with the input dataset descriptor of the
+        //       edge E'. If yes, add the edge E' to the edge queue.
+        // If the edge E' satisfies 1 and 2, add it to the edge queue for further consideration.
+        while (!edgeQueue.isEmpty()) {
+          FlowEdgeContext flowEdgeContext = edgeQueue.pop();
+
+          DataNode currentNode = this.flowGraph.getNode(flowEdgeContext.getEdge().getDest());
+          DatasetDescriptor currentOutputDatasetDescriptor = flowEdgeContext.getOutputDatasetDescriptor();
+
+          //Are we done?
+          if (isPathFound(currentNode, destNode, currentOutputDatasetDescriptor, destDatasetDescriptor)) {
+            return constructPath(flowEdgeContext);
+          }
+
+          //Expand the currentNode to its adjacent edges and add them to the queue.
+          List<FlowEdgeContext> nextEdges =
+              getNextEdges(currentNode, currentOutputDatasetDescriptor, destDatasetDescriptor);
+          for (FlowEdgeContext childFlowEdgeContext : nextEdges) {
+            //Add a pointer from the child edge to the parent edge, if the child edge is not already in the
+            // queue.
+            if (!this.pathMap.containsKey(childFlowEdgeContext)) {
+              edgeQueue.add(childFlowEdgeContext);
+              this.pathMap.put(childFlowEdgeContext, flowEdgeContext);
+            }
+          }
+        }
+      //No path found. Return null.
+      return null;
+    } catch (SpecNotFoundException | JobTemplate.TemplateException | IOException | URISyntaxException e) {
+      throw new PathFinder.PathFinderException(
+          "Exception encountered when computing path from src: " + this.srcNode.getId() + " to dest: " + destNode.getId(), e);
+    }
+  }
+}
+

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/pathfinder/PathFinder.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/pathfinder/PathFinder.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.service.modules.flowgraph.pathfinder;
+
+import org.apache.gobblin.annotation.Alpha;
+import org.apache.gobblin.service.modules.flow.FlowGraphPath;
+
+
+/**
+ * An interface for computing a path in a {@link org.apache.gobblin.service.modules.flowgraph.FlowGraph}. Each
+ * implementation of {@link PathFinder} implements a specific path finding algorithm such as Breadth-First Search (BFS),
+ * Dijkstra's shortest-path algorithm etc.
+ */
+@Alpha
+public interface PathFinder {
+
+  public FlowGraphPath findPath() throws PathFinderException;
+
+  public static class PathFinderException extends Exception {
+    public PathFinderException(String message, Throwable cause) {
+      super(message, cause);
+    }
+
+    public PathFinderException(String message) {
+      super(message);
+    }
+  }
+
+}


### PR DESCRIPTION
GOBBLIN-559: Implement FlowGraph as a concurrent data structure.

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-559.


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Current implementation of FlowGraph only allows a single-threaded access to the data structure for reads and writes. We improve the implementation by allowing the readers to not block on other readers, and only block on a write.



### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Existing unit tests in MultiHopFlowCompilerTest class.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

