### PR TITLE
[GOBBLIN-562] Added HiveConfKey to reflect the metastoreURI

### DIFF
--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/HiveConfFactory.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/HiveConfFactory.java
@@ -55,8 +55,11 @@ public class HiveConfFactory<S extends ScopeType<S>> implements SharedResourceFa
       throws NotConfiguredException {
     SharedHiveConfKey sharedHiveConfKey = config.getKey();
     HiveConf rawConf = new HiveConf();
-    rawConf.setVar(HiveConf.ConfVars.METASTOREURIS, sharedHiveConfKey.hiveConfUri);
-    rawConf.set(HIVE_METASTORE_TOKEN_SIGNATURE, sharedHiveConfKey.hiveConfUri);
+    if (!sharedHiveConfKey.hiveConfUri.equals(SharedHiveConfKey.INSTANCE.toConfigurationKey()) && StringUtils
+        .isNotEmpty(sharedHiveConfKey.hiveConfUri)) {
+      rawConf.setVar(HiveConf.ConfVars.METASTOREURIS, sharedHiveConfKey.hiveConfUri);
+      rawConf.set(HIVE_METASTORE_TOKEN_SIGNATURE, sharedHiveConfKey.hiveConfUri);
+    }
 
     return new ResourceInstance<>(rawConf);
   }
@@ -72,7 +75,8 @@ public class HiveConfFactory<S extends ScopeType<S>> implements SharedResourceFa
       throws IOException {
     try {
       SharedHiveConfKey confKey =
-          hcatURI.isPresent() && StringUtils.isNotBlank(hcatURI.get()) ? new SharedHiveConfKey(hcatURI.get()) : SharedHiveConfKey.INSTANCE;
+          hcatURI.isPresent() && StringUtils.isNotBlank(hcatURI.get()) ? new SharedHiveConfKey(hcatURI.get())
+              : SharedHiveConfKey.INSTANCE;
       return broker.getSharedResource(new HiveConfFactory<>(), confKey);
     } catch (NotConfiguredException nce) {
       throw new IOException(nce);

--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/HiveMetaStoreClientFactory.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/HiveMetaStoreClientFactory.java
@@ -17,6 +17,8 @@
 
 package org.apache.gobblin.hive;
 
+import java.io.IOException;
+
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.pool2.BasePooledObjectFactory;
 import org.apache.commons.pool2.PooledObject;
@@ -65,14 +67,8 @@ public class HiveMetaStoreClientFactory extends BasePooledObjectFactory<IMetaSto
 
   private static HiveConf getHiveConf(Optional<String> hcatURI) {
     try {
-      HiveConf hiveConf = SharedResourcesBrokerFactory.getImplicitBroker()
-          .getSharedResource(new HiveConfFactory<>(), EmptyKey.INSTANCE);
-      if (hcatURI.isPresent() && StringUtils.isNotBlank(hcatURI.get())) {
-        hiveConf.setVar(HiveConf.ConfVars.METASTOREURIS, hcatURI.get());
-        hiveConf.set(HIVE_METASTORE_TOKEN_SIGNATURE, hcatURI.get());
-      }
-      return hiveConf;
-    } catch (NotConfiguredException nce) {
+      return HiveConfFactory.get(hcatURI, SharedResourcesBrokerFactory.getImplicitBroker());
+    } catch (IOException nce) {
       throw new RuntimeException("Implicit broker is not correctly configured, failed to fetch a HiveConf object", nce);
     }
   }

--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/SharedHiveConfKey.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/SharedHiveConfKey.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.hive;
+
+import lombok.EqualsAndHashCode;
+
+import org.apache.gobblin.broker.iface.SharedResourceKey;
+
+
+/**
+ * {@link SharedResourceKey} for {@link org.apache.gobblin.hive.HiveConfFactory}. Contains an identifier for
+ * a cluster's Hive Metastore URI.
+ */
+@EqualsAndHashCode
+public class SharedHiveConfKey implements SharedResourceKey {
+  public final String hiveConfUri;
+
+  /**
+   * A singleton instance used with empty hcatURI.
+   * */
+  public static final SharedHiveConfKey INSTANCE = new SharedHiveConfKey("");
+
+  public SharedHiveConfKey(String hiveConfUri) {
+    this.hiveConfUri = hiveConfUri;
+  }
+
+  @Override
+  public String toConfigurationKey() {
+    return this.hiveConfUri;
+  }
+}

--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/metastore/HiveMetaStoreUtils.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/metastore/HiveMetaStoreUtils.java
@@ -64,6 +64,7 @@ import org.apache.gobblin.hive.HivePartition;
 import org.apache.gobblin.hive.HiveRegistrationUnit;
 import org.apache.gobblin.hive.HiveRegistrationUnit.Column;
 import org.apache.gobblin.hive.HiveTable;
+import org.apache.gobblin.hive.SharedHiveConfKey;
 
 
 /**
@@ -378,7 +379,7 @@ public class HiveMetaStoreUtils {
     Deserializer deserializer;
     try {
       hiveConf = SharedResourcesBrokerFactory
-        .getImplicitBroker().getSharedResource(new HiveConfFactory<>(), EmptyKey.INSTANCE);
+        .getImplicitBroker().getSharedResource(new HiveConfFactory<>(), SharedHiveConfKey.INSTANCE);
       deserializer =
           ReflectionUtils.newInstance(hiveConf.getClassByName(serde).asSubclass(Deserializer.class), hiveConf);
     } catch (ClassNotFoundException e) {

--- a/gobblin-hive-registration/src/test/java/org/apache/gobblin/hive/HiveConfFactoryTest.java
+++ b/gobblin-hive-registration/src/test/java/org/apache/gobblin/hive/HiveConfFactoryTest.java
@@ -21,18 +21,25 @@ import org.apache.hadoop.hive.conf.HiveConf;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import com.google.common.base.Optional;
+
 import org.apache.gobblin.broker.EmptyKey;
 import org.apache.gobblin.broker.SharedResourcesBrokerFactory;
 
 
 public class HiveConfFactoryTest {
   @Test
-  public void testSameKey() throws Exception {
-    HiveConf hiveConf = SharedResourcesBrokerFactory
-        .getImplicitBroker().getSharedResource(new HiveConfFactory<>(), EmptyKey.INSTANCE);
-    HiveConf hiveConf1 = SharedResourcesBrokerFactory
-        .getImplicitBroker().getSharedResource(new HiveConfFactory<>(), EmptyKey.INSTANCE);
-
+  public void testHiveConfFactory() throws Exception {
+    HiveConf hiveConf = HiveConfFactory.get(Optional.absent(), SharedResourcesBrokerFactory.getImplicitBroker());
+    HiveConf hiveConf1 = HiveConfFactory.get(Optional.absent(), SharedResourcesBrokerFactory.getImplicitBroker());
     Assert.assertEquals(hiveConf, hiveConf1);
+
+    HiveConf hiveConf2 = HiveConfFactory.get(Optional.of("hcat1"), SharedResourcesBrokerFactory.getImplicitBroker());
+    HiveConf hiveConf3 = HiveConfFactory.get(Optional.of("hcat1"), SharedResourcesBrokerFactory.getImplicitBroker());
+    Assert.assertEquals(hiveConf2, hiveConf3);
+
+    HiveConf hiveConf4 = HiveConfFactory.get(Optional.of("hcat11"), SharedResourcesBrokerFactory.getImplicitBroker());
+    Assert.assertNotEquals(hiveConf3, hiveConf4);
+    Assert.assertNotEquals(hiveConf4, hiveConf);
   }
 }

--- a/gobblin-hive-registration/src/test/java/org/apache/gobblin/hive/HiveConfFactoryTest.java
+++ b/gobblin-hive-registration/src/test/java/org/apache/gobblin/hive/HiveConfFactoryTest.java
@@ -23,8 +23,10 @@ import org.testng.annotations.Test;
 
 import com.google.common.base.Optional;
 
-import org.apache.gobblin.broker.EmptyKey;
 import org.apache.gobblin.broker.SharedResourcesBrokerFactory;
+
+import static org.apache.gobblin.hive.HiveMetaStoreClientFactory.HIVE_METASTORE_TOKEN_SIGNATURE;
+import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTOREURIS;
 
 
 public class HiveConfFactoryTest {
@@ -33,6 +35,9 @@ public class HiveConfFactoryTest {
     HiveConf hiveConf = HiveConfFactory.get(Optional.absent(), SharedResourcesBrokerFactory.getImplicitBroker());
     HiveConf hiveConf1 = HiveConfFactory.get(Optional.absent(), SharedResourcesBrokerFactory.getImplicitBroker());
     Assert.assertEquals(hiveConf, hiveConf1);
+    // When there's no hcatURI specified, the default hive-site should be loaded.
+    Assert.assertTrue(hiveConf.getVar(METASTOREURIS).equals("file:///test"));
+    Assert.assertTrue(hiveConf.get(HIVE_METASTORE_TOKEN_SIGNATURE).equals("file:///test"));
 
     HiveConf hiveConf2 = HiveConfFactory.get(Optional.of("hcat1"), SharedResourcesBrokerFactory.getImplicitBroker());
     HiveConf hiveConf3 = HiveConfFactory.get(Optional.of("hcat1"), SharedResourcesBrokerFactory.getImplicitBroker());
@@ -41,5 +46,12 @@ public class HiveConfFactoryTest {
     HiveConf hiveConf4 = HiveConfFactory.get(Optional.of("hcat11"), SharedResourcesBrokerFactory.getImplicitBroker());
     Assert.assertNotEquals(hiveConf3, hiveConf4);
     Assert.assertNotEquals(hiveConf4, hiveConf);
+
+    // THe uri should be correctly set.
+    Assert.assertEquals(hiveConf3.getVar(METASTOREURIS), "hcat1");
+    Assert.assertEquals(hiveConf3.get(HIVE_METASTORE_TOKEN_SIGNATURE), "hcat1");
+    Assert.assertEquals(hiveConf4.getVar(METASTOREURIS), "hcat11");
+    Assert.assertEquals(hiveConf4.get(HIVE_METASTORE_TOKEN_SIGNATURE), "hcat11");
+
   }
 }

--- a/gobblin-hive-registration/src/test/java/org/apache/gobblin/hive/HiveMetaStoreClientFactoryTest.java
+++ b/gobblin-hive-registration/src/test/java/org/apache/gobblin/hive/HiveMetaStoreClientFactoryTest.java
@@ -23,12 +23,19 @@ import org.apache.thrift.TException;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import static org.apache.gobblin.hive.HiveMetaStoreClientFactory.HIVE_METASTORE_TOKEN_SIGNATURE;
+
 
 public class HiveMetaStoreClientFactoryTest {
   @Test
   public void testCreate() throws TException {
     HiveConf hiveConf = new HiveConf();
     HiveMetaStoreClientFactory factory = new HiveMetaStoreClientFactory(hiveConf);
+
+    // Since we havE a specified hive-site in the classpath, so have to null it out here to proceed the test
+    // The original value it will get if no local hive-site is placed, will be an empty string. 
+    hiveConf.setVar(HiveConf.ConfVars.METASTOREURIS, "");
+    hiveConf.set(HIVE_METASTORE_TOKEN_SIGNATURE, "");
     IMetaStoreClient msc = factory.create();
 
     String dbName = "test_db";

--- a/gobblin-hive-registration/src/test/resources/hive-site.xml
+++ b/gobblin-hive-registration/src/test/resources/hive-site.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
+<configuration>
+  <property>
+    <name>hive.metastore.uris</name>
+    <value>file:///test</value>
+  </property>
+
+  <property>
+    <name>hive.metastore.token.signature</name>
+    <value>file:///test</value>
+  </property>
+</configuration>


### PR DESCRIPTION
Dear Gobblin maintainers,


Originally we are using `EmptyKey` as the key for HiveConf as we assume that each Gobblin should only talk to single Hive Metastore, however this assumption is not fair in some of our internal jobs implementation.

Implemented `SharedHiveConfKey` to contain the HcatURI if specified and use the singleton key if not specified. 


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-562] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-562


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

