### PR TITLE
[GOBBLIN-564] Implement partition descriptor

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/dataset/DatasetDescriptor.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/dataset/DatasetDescriptor.java
@@ -25,13 +25,13 @@ import com.google.common.collect.Maps;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import sun.security.krb5.internal.crypto.Des;
 
 
 /**
  * A {@link DatasetDescriptor} identifies and provides metadata to describe a dataset
  */
-@RequiredArgsConstructor
-public final class DatasetDescriptor {
+public class DatasetDescriptor extends Descriptor {
   private static final String PLATFORM_KEY = "platform";
   private static final String NAME_KEY = "name";
 
@@ -40,20 +40,24 @@ public final class DatasetDescriptor {
    */
   @Getter
   private final String platform;
-  /**
-   * name of the dataset
-   */
-  @Getter
-  private final String name;
 
   /**
    * metadata about the dataset
    */
   private final Map<String, String> metadata = Maps.newHashMap();
 
+  public DatasetDescriptor(String platform, String name) {
+    super(name);
+    this.platform = platform;
+  }
+
+  /**
+   * @deprecated use {@link #copy()}
+   */
+  @Deprecated
   public DatasetDescriptor(DatasetDescriptor copy) {
+    super(copy.getName());
     platform = copy.getPlatform();
-    name = copy.getName();
     metadata.putAll(copy.getMetadata());
   }
 
@@ -63,17 +67,25 @@ public final class DatasetDescriptor {
         .build();
   }
 
+  @Override
+  public DatasetDescriptor copy() {
+    return new DatasetDescriptor(this);
+  }
+
   public void addMetadata(String key, String value) {
     metadata.put(key, value);
   }
 
   /**
    * Serialize to a string map
+   *
+   * @deprecated use {@link Descriptor#serialize(Descriptor)}
    */
+  @Deprecated
   public Map<String, String> toDataMap() {
     Map<String, String> map = Maps.newHashMap();
     map.put(PLATFORM_KEY, platform);
-    map.put(NAME_KEY, name);
+    map.put(NAME_KEY, getName());
     map.putAll(metadata);
     return map;
   }
@@ -88,20 +100,23 @@ public final class DatasetDescriptor {
     }
 
     DatasetDescriptor that = (DatasetDescriptor) o;
-    return platform.equals(that.platform) && name.equals(that.name) && metadata.equals(that.metadata);
+    return platform.equals(that.platform) && getName().equals(that.getName()) && metadata.equals(that.metadata);
   }
 
   @Override
   public int hashCode() {
     int result = platform.hashCode();
-    result = 31 * result + name.hashCode();
+    result = 31 * result + getName().hashCode();
     result = 31 * result + metadata.hashCode();
     return result;
   }
 
   /**
    * Deserialize a {@link DatasetDescriptor} from a string map
+   *
+   * @deprecated use {@link Descriptor#deserialize(String)}
    */
+  @Deprecated
   public static DatasetDescriptor fromDataMap(Map<String, String> dataMap) {
     DatasetDescriptor descriptor = new DatasetDescriptor(dataMap.get(PLATFORM_KEY), dataMap.get(NAME_KEY));
     dataMap.forEach((key, value) -> {

--- a/gobblin-api/src/main/java/org/apache/gobblin/dataset/DatasetDescriptor.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/dataset/DatasetDescriptor.java
@@ -17,19 +17,16 @@
 
 package org.apache.gobblin.dataset;
 
-
 import java.util.Map;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import sun.security.krb5.internal.crypto.Des;
 
 
 /**
- * A {@link DatasetDescriptor} identifies and provides metadata to describe a dataset
+ * A {@link Descriptor} identifies and provides metadata to describe a dataset
  */
 public class DatasetDescriptor extends Descriptor {
   private static final String PLATFORM_KEY = "platform";

--- a/gobblin-api/src/main/java/org/apache/gobblin/dataset/DatasetResolver.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/dataset/DatasetResolver.java
@@ -22,8 +22,11 @@ import org.apache.gobblin.configuration.State;
 
 /**
  * A {@link DatasetResolver} resolves job specific dataset
+ *
+ * @deprecated use the more general {@link DescriptorResolver}
  */
-public interface DatasetResolver {
+@Deprecated
+public interface DatasetResolver extends DescriptorResolver {
   /**
    * Given raw Gobblin dataset, resolve job specific dataset
    *
@@ -32,4 +35,20 @@ public interface DatasetResolver {
    * @return resolved dataset for the job
    */
   DatasetDescriptor resolve(DatasetDescriptor raw, State state);
+
+  @Override
+  default Descriptor resolve(Descriptor raw, State state) {
+    DatasetDescriptor rawDataset;
+
+    if (raw instanceof DatasetDescriptor) {
+      rawDataset = (DatasetDescriptor) raw;
+    } else if (raw instanceof PartitionDescriptor) {
+      rawDataset = ((PartitionDescriptor) raw).getDataset();
+    } else {
+      // type not supported
+      return null;
+    }
+
+    return resolve(rawDataset, state);
+  }
 }

--- a/gobblin-api/src/main/java/org/apache/gobblin/dataset/DatasetResolverFactory.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/dataset/DatasetResolverFactory.java
@@ -19,10 +19,15 @@ package org.apache.gobblin.dataset;
 
 import com.typesafe.config.Config;
 
+
 /**
  * A factory that creates an instance of {@link DatasetResolver}
+ *
+ * @deprecated use {@link DescriptorResolverFactory} as {@link DatasetResolver} is deprecated
+ * with {@link DescriptorResolver}
  */
-public interface DatasetResolverFactory {
+@Deprecated
+public interface DatasetResolverFactory extends DescriptorResolverFactory {
   /**
    * Create a {@link DatasetResolver} instance
    */

--- a/gobblin-api/src/main/java/org/apache/gobblin/dataset/Descriptor.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/dataset/Descriptor.java
@@ -1,0 +1,91 @@
+package org.apache.gobblin.dataset;
+
+import java.lang.reflect.Type;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+
+/**
+ * A descriptor is a simplified representation of a resource, which could be a dataset, dataset partition, file, etc.
+ * It is a digest or abstract, which contains identification properties of the actual resource object, such as ID, name
+ * primary keys, version, etc
+ *
+ * <p>
+ *   The class provides {@link #serialize(Descriptor)} and {@link #deserialize(String)} util methods pair to send
+ *   a descriptor object over the wire
+ * </p>
+ *
+ * <p>
+ *   When the original object has complicated inner structure and there is a requirement to send it over the wire,
+ *   it's a time to define a corresponding {@link Descriptor} becomes. In this case, the {@link Descriptor} can just
+ *   have minimal information enough to construct the original object on the other side of the wire
+ * </p>
+ *
+ * <p>
+ *   When the cost to instantiate the complete original object is high, for example, network calls are required, but
+ *   the use cases are limited to the identification properties, define a corresponding {@link Descriptor} becomes
+ *   handy
+ * </p>
+ */
+@RequiredArgsConstructor
+public class Descriptor {
+
+  /** Use gson for ser/de */
+  private static final Gson GSON = new Gson();
+
+  /** Name of the resource */
+  @Getter
+  private final String name;
+
+  @Override
+  public String toString() {
+    return GSON.toJson(this);
+  }
+
+  public Descriptor copy() {
+    return new Descriptor(name);
+  }
+
+  /**
+   * A helper class for ser/de of a {@link Descriptor}
+   */
+  @RequiredArgsConstructor
+  private static class Wrap {
+    /** The actual class name of the {@link Descriptor} */
+    private final String clazz;
+    /** A json representation of the {@link Descriptor}*/
+    private final JsonObject data;
+  }
+
+  /**
+   * Serialize any {@link Descriptor} object to a string
+   */
+  public static String serialize(Descriptor descriptor) {
+    if (descriptor == null) {
+      return GSON.toJson(null);
+    }
+    JsonObject data = GSON.toJsonTree(descriptor).getAsJsonObject();
+    return GSON.toJson(new Wrap(descriptor.getClass().getName(), data));
+  }
+
+  /**
+   * Deserialize a string, which results from {@link #serialize(Descriptor)}, into the original
+   * {@link Descriptor} object
+   */
+  public static Descriptor deserialize(String serialized) {
+    Wrap wrap = GSON.fromJson(serialized, Wrap.class);
+    if (wrap == null) {
+      return null;
+    }
+
+    try {
+      return GSON.fromJson(wrap.data, (Type) Class.forName(wrap.clazz));
+    } catch (ClassNotFoundException e) {
+      return null;
+    }
+  }
+}

--- a/gobblin-api/src/main/java/org/apache/gobblin/dataset/Descriptor.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/dataset/Descriptor.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.gobblin.dataset;
 
 import java.lang.reflect.Type;

--- a/gobblin-api/src/main/java/org/apache/gobblin/dataset/DescriptorResolver.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/dataset/DescriptorResolver.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.gobblin.dataset;
 
 import org.apache.gobblin.configuration.State;

--- a/gobblin-api/src/main/java/org/apache/gobblin/dataset/DescriptorResolver.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/dataset/DescriptorResolver.java
@@ -1,0 +1,18 @@
+package org.apache.gobblin.dataset;
+
+import org.apache.gobblin.configuration.State;
+
+
+/**
+ * A resolver transforms an existing {@link Descriptor} to a new one
+ */
+public interface DescriptorResolver {
+  /**
+   * Given raw Gobblin descriptor, resolve a job specific descriptor
+   *
+   * @param raw the original descriptor
+   * @param state configuration that helps resolve job specific descriptor
+   * @return resolved descriptor for the job or {@code null} if failed to resolve
+   */
+  Descriptor resolve(Descriptor raw, State state);
+}

--- a/gobblin-api/src/main/java/org/apache/gobblin/dataset/DescriptorResolverFactory.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/dataset/DescriptorResolverFactory.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.gobblin.dataset;
 
 import com.typesafe.config.Config;

--- a/gobblin-api/src/main/java/org/apache/gobblin/dataset/DescriptorResolverFactory.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/dataset/DescriptorResolverFactory.java
@@ -1,0 +1,14 @@
+package org.apache.gobblin.dataset;
+
+import com.typesafe.config.Config;
+
+
+/**
+ * Factory to create a {@link DescriptorResolver} instance
+ */
+public interface DescriptorResolverFactory {
+  /**
+   * @param config configurations only about {@link DescriptorResolver}
+   */
+  DescriptorResolver createResolver(Config config);
+}

--- a/gobblin-api/src/main/java/org/apache/gobblin/dataset/NoopDatasetResolver.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/dataset/NoopDatasetResolver.java
@@ -33,4 +33,9 @@ public class NoopDatasetResolver implements DatasetResolver {
   public DatasetDescriptor resolve(DatasetDescriptor raw, State state) {
     return raw;
   }
+
+  @Override
+  public Descriptor resolve(Descriptor raw, State state) {
+    return raw;
+  }
 }

--- a/gobblin-api/src/main/java/org/apache/gobblin/dataset/PartitionDescriptor.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/dataset/PartitionDescriptor.java
@@ -1,8 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.gobblin.dataset;
 
 import lombok.Getter;
 
 
+/**
+ * A {@link Descriptor} to identifies a partition of a dataset
+ */
 public class PartitionDescriptor extends Descriptor {
   @Getter
   private final DatasetDescriptor dataset;

--- a/gobblin-api/src/main/java/org/apache/gobblin/dataset/PartitionDescriptor.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/dataset/PartitionDescriptor.java
@@ -1,0 +1,39 @@
+package org.apache.gobblin.dataset;
+
+import lombok.Getter;
+
+
+public class PartitionDescriptor extends Descriptor {
+  @Getter
+  private final DatasetDescriptor dataset;
+
+  public PartitionDescriptor(String name, DatasetDescriptor dataset) {
+    super(name);
+    this.dataset = dataset;
+  }
+
+  @Override
+  public PartitionDescriptor copy() {
+    return new PartitionDescriptor(getName(), dataset);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    PartitionDescriptor that = (PartitionDescriptor) o;
+    return dataset.equals(that.dataset) && getName().equals(that.getName());
+  }
+
+  @Override
+  public int hashCode() {
+    int result = dataset.hashCode();
+    result = 31 * result + getName().hashCode();
+    return result;
+  }
+}

--- a/gobblin-api/src/test/java/org/apache/gobblin/dataset/DatasetResolverTest.java
+++ b/gobblin-api/src/test/java/org/apache/gobblin/dataset/DatasetResolverTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.gobblin.dataset;
 
 import org.testng.Assert;

--- a/gobblin-api/src/test/java/org/apache/gobblin/dataset/DatasetResolverTest.java
+++ b/gobblin-api/src/test/java/org/apache/gobblin/dataset/DatasetResolverTest.java
@@ -1,0 +1,49 @@
+package org.apache.gobblin.dataset;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import org.apache.gobblin.configuration.State;
+
+
+public class DatasetResolverTest {
+
+  @Test
+  public void testAsDescriptorResolver() {
+    DescriptorResolver resolver = new TestDatasetResolver();
+    State state = new State();
+
+    // Test dataset descriptor
+    DatasetDescriptor dataset = new DatasetDescriptor("hdfs", "/data/tracking/PageViewEvent");
+    Descriptor descriptor = resolver.resolve(dataset, state);
+    Assert.assertTrue(descriptor.getClass().isAssignableFrom(DatasetDescriptor.class));
+    Assert.assertEquals(descriptor.getName(), TestDatasetResolver.DATASET_NAME);
+
+    // Test partition descriptor
+    String partitionName = "hourly/2018/08/14/18";
+    PartitionDescriptor partition = new PartitionDescriptor(partitionName, dataset);
+    descriptor = resolver.resolve(partition, state);
+    Assert.assertTrue(descriptor.getClass().isAssignableFrom(DatasetDescriptor.class));
+    Assert.assertEquals(descriptor.getName(), TestDatasetResolver.DATASET_NAME);
+
+    // Test unsupported descriptor
+    Assert.assertEquals(resolver.resolve(new MockDescriptor("test"), state), null);
+  }
+
+  private static class TestDatasetResolver implements DatasetResolver {
+    static final String DATASET_NAME = "TEST";
+
+    @Override
+    public DatasetDescriptor resolve(DatasetDescriptor raw, State state) {
+      DatasetDescriptor descriptor = new DatasetDescriptor(raw.getPlatform(), DATASET_NAME);
+      raw.getMetadata().forEach(descriptor::addMetadata);
+      return descriptor;
+    }
+  }
+
+  private static class MockDescriptor extends Descriptor {
+    public MockDescriptor(String name) {
+      super(name);
+    }
+  }
+}

--- a/gobblin-api/src/test/java/org/apache/gobblin/dataset/DescriptorTest.java
+++ b/gobblin-api/src/test/java/org/apache/gobblin/dataset/DescriptorTest.java
@@ -1,0 +1,44 @@
+package org.apache.gobblin.dataset;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class DescriptorTest {
+
+  @Test
+  public void testDatasetDescriptor() {
+    DatasetDescriptor dataset = new DatasetDescriptor("hdfs", "/data/tracking/PageViewEvent");
+    dataset.addMetadata("fsUri", "hdfs://test.com:2018");
+
+    DatasetDescriptor copy = dataset.copy();
+    Assert.assertEquals(copy.getName(), dataset.getName());
+    Assert.assertEquals(copy.getPlatform(), dataset.getPlatform());
+    Assert.assertEquals(copy.getMetadata(), dataset.getMetadata());
+    Assert.assertEquals(dataset, copy);
+    Assert.assertEquals(dataset.hashCode(), copy.hashCode());
+  }
+
+  @Test
+  public void testPartitionDescriptor() {
+    // Test serialization
+    String partitionJson = "{\"clazz\":\"org.apache.gobblin.dataset.PartitionDescriptor\",\"data\":{\"dataset\":{\"platform\":\"hdfs\",\"metadata\":{},\"name\":\"/data/tracking/PageViewEvent\"},\"name\":\"hourly/2018/08/14/18\"}}";
+
+    DatasetDescriptor dataset = new DatasetDescriptor("hdfs", "/data/tracking/PageViewEvent");
+    String partitionName = "hourly/2018/08/14/18";
+    PartitionDescriptor partition = new PartitionDescriptor(partitionName, dataset);
+    Assert.assertEquals(Descriptor.serialize(partition), partitionJson);
+    System.out.println(partitionJson);
+
+    Descriptor partition2 = Descriptor.deserialize(partitionJson);
+    Assert.assertEquals(partition2.getName(), partition.getName());
+    Assert.assertEquals(((PartitionDescriptor)partition2).getDataset(), partition.getDataset());
+    Assert.assertEquals(partition, partition2);
+    Assert.assertEquals(partition.hashCode(), partition2.hashCode());
+
+    // Test copy
+    PartitionDescriptor partition3 = partition.copy();
+    Assert.assertEquals(partition3.getDataset(), dataset);
+    Assert.assertEquals(partition3.getName(), partitionName);
+  }
+}

--- a/gobblin-api/src/test/java/org/apache/gobblin/dataset/DescriptorTest.java
+++ b/gobblin-api/src/test/java/org/apache/gobblin/dataset/DescriptorTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.gobblin.dataset;
 
 import org.testng.Assert;

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/conversion/hive/dataset/ConvertibleHiveDatasetTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/conversion/hive/dataset/ConvertibleHiveDatasetTest.java
@@ -35,6 +35,7 @@ import org.apache.gobblin.data.management.conversion.hive.source.HiveAvroToOrcSo
 import org.apache.gobblin.data.management.conversion.hive.source.HiveWorkUnit;
 import org.apache.gobblin.data.management.conversion.hive.utils.LineageUtils;
 import org.apache.gobblin.dataset.DatasetDescriptor;
+import org.apache.gobblin.dataset.Descriptor;
 import org.apache.gobblin.dataset.HiveToHdfsDatasetResolver;
 import org.apache.gobblin.dataset.HiveToHdfsDatasetResolverFactory;
 import org.apache.gobblin.metrics.event.lineage.LineageEventBuilder;
@@ -103,7 +104,7 @@ public class ConvertibleHiveDatasetTest {
     // Assert that source is correct for lineage event
     Assert.assertTrue(props.containsKey("gobblin.event.lineage.source"));
     DatasetDescriptor sourceDD =
-        GSON.fromJson(props.getProperty("gobblin.event.lineage.source"), DatasetDescriptor.class);
+        (DatasetDescriptor) Descriptor.deserialize(props.getProperty("gobblin.event.lineage.source"));
     Assert.assertEquals(sourceDD.getPlatform(), "file");
     Assert.assertEquals(sourceDD.getName(), "/tmp/test");
     Assert.assertEquals(sourceDD.getMetadata().get(HiveToHdfsDatasetResolver.HIVE_TABLE), "db1.tb1");
@@ -111,7 +112,7 @@ public class ConvertibleHiveDatasetTest {
     // Assert that first dest is correct for lineage event
     Assert.assertTrue(props.containsKey("gobblin.event.lineage.branch.1.destination"));
     DatasetDescriptor destDD1 =
-        GSON.fromJson(props.getProperty("gobblin.event.lineage.branch.1.destination"), DatasetDescriptor.class);
+        (DatasetDescriptor) Descriptor.deserialize(props.getProperty("gobblin.event.lineage.branch.1.destination"));
     Assert.assertEquals(destDD1.getPlatform(), "file");
     Assert.assertEquals(destDD1.getName(), "/tmp/data_nestedOrc/db1/tb1/final");
     Assert.assertEquals(destDD1.getMetadata().get(HiveToHdfsDatasetResolver.HIVE_TABLE),
@@ -120,7 +121,7 @@ public class ConvertibleHiveDatasetTest {
     // Assert that second dest is correct for lineage event
     Assert.assertTrue(props.containsKey("gobblin.event.lineage.branch.2.destination"));
     DatasetDescriptor destDD2 =
-        GSON.fromJson(props.getProperty("gobblin.event.lineage.branch.2.destination"), DatasetDescriptor.class);
+        (DatasetDescriptor) Descriptor.deserialize(props.getProperty("gobblin.event.lineage.branch.2.destination"));
     Assert.assertEquals(destDD2.getPlatform(), "file");
     Assert.assertEquals(destDD2.getName(), "/tmp/data_flattenedOrc/db1/tb1/final");
     Assert.assertEquals(destDD2.getMetadata().get(HiveToHdfsDatasetResolver.HIVE_TABLE),

--- a/gobblin-salesforce/src/test/java/org/apache/gobblin/salesforce/SalesforceSourceTest.java
+++ b/gobblin-salesforce/src/test/java/org/apache/gobblin/salesforce/SalesforceSourceTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.SourceState;
 import org.apache.gobblin.dataset.DatasetDescriptor;
+import org.apache.gobblin.dataset.Descriptor;
 import org.apache.gobblin.metrics.event.lineage.LineageInfo;
 import org.apache.gobblin.source.extractor.extract.QueryBasedSource;
 import org.apache.gobblin.source.extractor.partition.Partitioner;
@@ -49,8 +50,7 @@ public class SalesforceSourceTest {
     Assert.assertEquals(workUnits.size(), 1);
 
     DatasetDescriptor sourceDataset = new DatasetDescriptor("salesforce", "contacts");
-    Gson gson = new Gson();
-    Assert.assertEquals(gson.toJson(sourceDataset), workUnits.get(0).getProp("gobblin.event.lineage.source"));
+    Assert.assertEquals(Descriptor.serialize(sourceDataset), workUnits.get(0).getProp("gobblin.event.lineage.source"));
     Assert.assertEquals(workUnits.get(0).getProp("gobblin.event.lineage.name"), "contacts");
   }
 


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/GOBBLIN-564


### Description
- [x] Here are some details about my PR:
  - A partition descriptor refers to a partition of a dataset. The task to implement partition level lineage depends on this. 
  - For example, a dataset descriptor points to a hdfs dataset `/data/tracking/PageViewEvent`. A partition descriptor points to `/data/tracking/PageViewEvent/hourly/2018/08/15/16`

### Tests
- [x] My PR adds the following unit tests:
  - `DescriptorTest`
  - `DatasetResolverTest`
  - `LineageEventTest#testEventForPartitionedDataset`


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

