### PR TITLE
[GOBBLIN-538] move adding flow execution id from compiler to flowConfigResourceHandler

### DIFF
--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-api/src/main/idl/org.apache.gobblin.service.flowconfigsV2.restspec.json
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-api/src/main/idl/org.apache.gobblin.service.flowconfigsV2.restspec.json
@@ -1,0 +1,31 @@
+{
+  "name" : "flowconfigsV2",
+  "namespace" : "org.apache.gobblin.service",
+  "path" : "/flowconfigsV2",
+  "schema" : "org.apache.gobblin.service.FlowConfig",
+  "doc" : "Resource for handling flow configuration requests\n\ngenerated from: org.apache.gobblin.service.FlowConfigsV2Resource",
+  "collection" : {
+    "identifier" : {
+      "name" : "id",
+      "type" : "org.apache.gobblin.service.FlowId",
+      "params" : "com.linkedin.restli.common.EmptyRecord"
+    },
+    "supports" : [ "create", "delete", "get", "update" ],
+    "methods" : [ {
+      "method" : "create",
+      "doc" : "Create a flow configuration that the service will forward to execution instances for execution"
+    }, {
+      "method" : "get",
+      "doc" : "Retrieve the flow configuration with the given key"
+    }, {
+      "method" : "update",
+      "doc" : "Update the flow configuration with the specified key. Running flows are not affected.\n An error is raised if the flow configuration does not exist."
+    }, {
+      "method" : "delete",
+      "doc" : "Delete a configured flow. Running flows are not affected. The schedule will be removed for scheduled flows."
+    } ],
+    "entity" : {
+      "path" : "/flowconfigsV2/{id}"
+    }
+  }
+}

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowConfigResourceLocalHandler.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowConfigResourceLocalHandler.java
@@ -173,6 +173,11 @@ public class FlowConfigResourceLocalHandler implements FlowConfigsResourceHandle
     return flowUri;
   }
 
+  /**
+   * Build a {@link FlowSpec} from a {@link FlowConfig}
+   * @param flowConfig flow configuration
+   * @return {@link FlowSpec} created with attributes from flowConfig
+   */
   public static FlowSpec createFlowSpecForConfig(FlowConfig flowConfig) {
     ConfigBuilder configBuilder = ConfigBuilder.create()
         .addPrimitive(ConfigurationKeys.FLOW_GROUP_KEY, flowConfig.getId().getFlowGroup())
@@ -182,8 +187,7 @@ public class FlowConfigResourceLocalHandler implements FlowConfigsResourceHandle
       Schedule schedule = flowConfig.getSchedule();
       configBuilder.addPrimitive(ConfigurationKeys.JOB_SCHEDULE_KEY, schedule.getCronSchedule());
       configBuilder.addPrimitive(ConfigurationKeys.FLOW_RUN_IMMEDIATELY, schedule.isRunImmediately());
-      if (flowConfig.getSchedule().isRunImmediately() &&
-          StringUtils.isEmpty(flowConfig.getSchedule().getCronSchedule())) {
+      if (isRunOnceFlow(flowConfig)) {
         configBuilder.addPrimitive(ConfigurationKeys.FLOW_EXECUTION_ID_KEY, String.valueOf(System.currentTimeMillis()));
       }
     }
@@ -197,5 +201,13 @@ public class FlowConfigResourceLocalHandler implements FlowConfigsResourceHandle
     } catch (URISyntaxException e) {
       throw new FlowConfigLoggedException(HttpStatus.S_400_BAD_REQUEST, "bad URI " + flowConfig.getTemplateUris(), e);
     }
+  }
+
+  /**
+   * @param flowConfig flowConfig
+   * @return returns true if it is a runOnce flow, i.e. runImmediately is true and cron schedule is empty
+   */
+  private static boolean isRunOnceFlow(FlowConfig flowConfig) {
+    return flowConfig.getSchedule().isRunImmediately() && StringUtils.isEmpty(flowConfig.getSchedule().getCronSchedule());
   }
 }

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowConfigResourceLocalHandler.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowConfigResourceLocalHandler.java
@@ -48,7 +48,7 @@ import org.apache.gobblin.runtime.spec_catalog.FlowCatalog;
 @Slf4j
 public class FlowConfigResourceLocalHandler implements FlowConfigsResourceHandler {
   @Getter
-  private FlowCatalog flowCatalog;
+  protected FlowCatalog flowCatalog;
   public FlowConfigResourceLocalHandler(FlowCatalog flowCatalog) {
     this.flowCatalog = flowCatalog;
   }
@@ -108,31 +108,9 @@ public class FlowConfigResourceLocalHandler implements FlowConfigsResourceHandle
    */
   public CreateResponse createFlowConfig(FlowConfig flowConfig, boolean triggerListener) throws FlowConfigLoggedException {
     log.info("[GAAS-REST] Create called with flowGroup " + flowConfig.getId().getFlowGroup() + " flowName " + flowConfig.getId().getFlowName());
-    FlowSpec flowSpec;
-    if (!isValidFlowConfig(flowConfig)) {
-      throw new FlowConfigLoggedException(HttpStatus.S_400_BAD_REQUEST,
-          "FlowExecutionId cannot be passed for a scheduled job", null);
-    } else if (flowConfig.hasSchedule() && flowConfig.getSchedule().isRunImmediately() &&
-        flowConfig.getProperties().containsKey(ConfigurationKeys.FLOW_EXECUTION_ID_KEY)) {
-      flowSpec = createFlowSpecForConfig(flowConfig, flowConfig.getProperties().get(ConfigurationKeys.FLOW_EXECUTION_ID_KEY));
-      this.flowCatalog.put(flowSpec, triggerListener);
-      FlowStatusId flowStatusId = new FlowStatusId()
-          .setFlowName(flowSpec.getConfigAsProperties().getProperty(ConfigurationKeys.FLOW_NAME_KEY))
-          .setFlowGroup(flowSpec.getConfigAsProperties().getProperty(ConfigurationKeys.FLOW_GROUP_KEY))
-          .setFlowExecutionId(Long.parseLong(flowSpec.getConfigAsProperties().getProperty(ConfigurationKeys.FLOW_EXECUTION_ID_KEY)));
-      return new CreateResponse(new ComplexResourceKey<>(flowStatusId, new EmptyRecord()), HttpStatus.S_201_CREATED);
-    } else {
-      flowSpec = createFlowSpecForConfig(flowConfig);
-      this.flowCatalog.put(flowSpec, triggerListener);
-      FlowStatusId flowStatusId = new FlowStatusId().setFlowGroup(flowSpec.getConfigAsProperties().getProperty(ConfigurationKeys.FLOW_GROUP_KEY))
-          .setFlowName(flowSpec.getConfigAsProperties().getProperty(ConfigurationKeys.FLOW_NAME_KEY));
-      return new CreateResponse(new ComplexResourceKey<>(flowStatusId, new EmptyRecord()), HttpStatus.S_202_ACCEPTED);
-    }
-  }
-
-  private static boolean isValidFlowConfig(FlowConfig flowConfig) {
-    return !flowConfig.hasSchedule() || StringUtils.isEmpty(flowConfig.getSchedule().getCronSchedule()) ||
-        !flowConfig.getProperties().containsKey(ConfigurationKeys.FLOW_EXECUTION_ID_KEY);
+    FlowSpec flowSpec = createFlowSpecForConfig(flowConfig);
+    this.flowCatalog.put(flowSpec, triggerListener);
+    return new CreateResponse(new ComplexResourceKey<>(flowConfig.getId(), new EmptyRecord()), HttpStatus.S_201_CREATED);
   }
 
   /**
@@ -195,16 +173,7 @@ public class FlowConfigResourceLocalHandler implements FlowConfigsResourceHandle
     return flowUri;
   }
 
-  /**
-   * Build a {@link FlowSpec} from a {@link FlowConfig}
-   * @param flowConfig flow configuration
-   * @return {@link FlowSpec} created with attributes from flowConfig
-   */
   public static FlowSpec createFlowSpecForConfig(FlowConfig flowConfig) {
-    return createFlowSpecForConfig(flowConfig, null);
-  }
-
-  private static FlowSpec createFlowSpecForConfig(FlowConfig flowConfig, String flowExecutionId) {
     ConfigBuilder configBuilder = ConfigBuilder.create()
         .addPrimitive(ConfigurationKeys.FLOW_GROUP_KEY, flowConfig.getId().getFlowGroup())
         .addPrimitive(ConfigurationKeys.FLOW_NAME_KEY, flowConfig.getId().getFlowName());
@@ -213,8 +182,9 @@ public class FlowConfigResourceLocalHandler implements FlowConfigsResourceHandle
       Schedule schedule = flowConfig.getSchedule();
       configBuilder.addPrimitive(ConfigurationKeys.JOB_SCHEDULE_KEY, schedule.getCronSchedule());
       configBuilder.addPrimitive(ConfigurationKeys.FLOW_RUN_IMMEDIATELY, schedule.isRunImmediately());
-      if (flowExecutionId != null) {
-        configBuilder.addPrimitive(ConfigurationKeys.FLOW_EXECUTION_ID_KEY, flowExecutionId);
+      if (flowConfig.getSchedule().isRunImmediately() &&
+          StringUtils.isEmpty(flowConfig.getSchedule().getCronSchedule())) {
+        configBuilder.addPrimitive(ConfigurationKeys.FLOW_EXECUTION_ID_KEY, String.valueOf(System.currentTimeMillis()));
       }
     }
 

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowConfigV2ResourceLocalHandler.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowConfigV2ResourceLocalHandler.java
@@ -21,9 +21,7 @@ import com.linkedin.restli.common.ComplexResourceKey;
 import com.linkedin.restli.common.EmptyRecord;
 import com.linkedin.restli.common.HttpStatus;
 import com.linkedin.restli.server.CreateResponse;
-
 import lombok.extern.slf4j.Slf4j;
-
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.runtime.api.FlowSpec;
 import org.apache.gobblin.runtime.spec_catalog.FlowCatalog;
@@ -34,7 +32,6 @@ public class FlowConfigV2ResourceLocalHandler extends FlowConfigResourceLocalHan
   public FlowConfigV2ResourceLocalHandler(FlowCatalog flowCatalog) {
     super(flowCatalog);
   }
-
   @Override
   /**
    * Add flowConfig locally and trigger all listeners iff @param triggerListener is set to true
@@ -46,11 +43,9 @@ public class FlowConfigV2ResourceLocalHandler extends FlowConfigResourceLocalHan
     FlowStatusId flowStatusId = new FlowStatusId()
         .setFlowName(flowSpec.getConfigAsProperties().getProperty(ConfigurationKeys.FLOW_NAME_KEY))
         .setFlowGroup(flowSpec.getConfigAsProperties().getProperty(ConfigurationKeys.FLOW_GROUP_KEY));
-
     if (flowSpec.getConfigAsProperties().containsKey(ConfigurationKeys.FLOW_EXECUTION_ID_KEY)) {
       flowStatusId.setFlowExecutionId(Long.valueOf(flowSpec.getConfigAsProperties().getProperty(ConfigurationKeys.FLOW_EXECUTION_ID_KEY)));
     }
-
     return new CreateResponse(new ComplexResourceKey<>(flowStatusId, new EmptyRecord()), HttpStatus.S_201_CREATED);
   }
 }

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowConfigV2resourceLocalHandler.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowConfigV2resourceLocalHandler.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.service;
+
+import com.linkedin.restli.common.ComplexResourceKey;
+import com.linkedin.restli.common.EmptyRecord;
+import com.linkedin.restli.common.HttpStatus;
+import com.linkedin.restli.server.CreateResponse;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.runtime.api.FlowSpec;
+import org.apache.gobblin.runtime.spec_catalog.FlowCatalog;
+
+@Slf4j
+
+public class FlowConfigV2ResourceLocalHandler extends FlowConfigResourceLocalHandler implements FlowConfigsResourceHandler {
+  public FlowConfigV2ResourceLocalHandler(FlowCatalog flowCatalog) {
+    super(flowCatalog);
+  }
+
+  @Override
+  /**
+   * Add flowConfig locally and trigger all listeners iff @param triggerListener is set to true
+   */
+  public CreateResponse createFlowConfig(FlowConfig flowConfig, boolean triggerListener) throws FlowConfigLoggedException {
+    log.info("[GAAS-REST] Create called with flowGroup " + flowConfig.getId().getFlowGroup() + " flowName " + flowConfig.getId().getFlowName());
+    FlowSpec flowSpec = createFlowSpecForConfig(flowConfig);
+    this.flowCatalog.put(flowSpec, triggerListener);
+    FlowStatusId flowStatusId = new FlowStatusId()
+        .setFlowName(flowSpec.getConfigAsProperties().getProperty(ConfigurationKeys.FLOW_NAME_KEY))
+        .setFlowGroup(flowSpec.getConfigAsProperties().getProperty(ConfigurationKeys.FLOW_GROUP_KEY));
+
+    if (flowSpec.getConfigAsProperties().containsKey(ConfigurationKeys.FLOW_EXECUTION_ID_KEY)) {
+      flowStatusId.setFlowExecutionId(Long.valueOf(flowSpec.getConfigAsProperties().getProperty(ConfigurationKeys.FLOW_EXECUTION_ID_KEY)));
+    }
+
+    return new CreateResponse(new ComplexResourceKey<>(flowStatusId, new EmptyRecord()), HttpStatus.S_201_CREATED);
+  }
+}

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowConfigsV2Resource.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowConfigsV2Resource.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.service;
+
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+import com.linkedin.restli.common.ComplexResourceKey;
+import com.linkedin.restli.common.EmptyRecord;
+import com.linkedin.restli.server.CreateResponse;
+import com.linkedin.restli.server.UpdateResponse;
+import com.linkedin.restli.server.annotations.RestLiCollection;
+import com.linkedin.restli.server.resources.ComplexKeyResourceTemplate;
+
+
+/**
+ * Resource for handling flow configuration requests
+ */
+@RestLiCollection(name = "flowconfigsV2", namespace = "org.apache.gobblin.service", keyName = "id")
+public class FlowConfigsV2Resource extends ComplexKeyResourceTemplate<FlowId, EmptyRecord, FlowConfig> {
+  private static final Logger LOG = LoggerFactory.getLogger(FlowConfigsV2Resource.class);
+  private static final Set<String> ALLOWED_METADATA = ImmutableSet.of("delete.state.store");
+
+
+  @edu.umd.cs.findbugs.annotations.SuppressWarnings("MS_SHOULD_BE_FINAL")
+  public static FlowConfigsResourceHandler global_flowConfigsResourceHandler = null;
+
+  @Inject
+  @Named("flowConfigsResourceHandler")
+  private FlowConfigsResourceHandler flowConfigsResourceHandler;
+
+  // For blocking use of this resource until it is ready
+  @Inject
+  @Named("readyToUse")
+  private Boolean readyToUse = Boolean.FALSE;
+
+  public FlowConfigsV2Resource() {
+  }
+
+  /**
+   * Retrieve the flow configuration with the given key
+   * @param key flow config id key containing group name and flow name
+   * @return {@link FlowConfig} with flow configuration
+   */
+  @Override
+  public FlowConfig get(ComplexResourceKey<FlowId, EmptyRecord> key) {
+    String flowGroup = key.getKey().getFlowGroup();
+    String flowName = key.getKey().getFlowName();
+    FlowId flowId = new FlowId().setFlowGroup(flowGroup).setFlowName(flowName);
+    return this.getFlowConfigResourceHandler().getFlowConfig(flowId);
+  }
+
+  /**
+   * Create a flow configuration that the service will forward to execution instances for execution
+   * @param flowConfig flow configuration
+   * @return {@link CreateResponse}
+   */
+  @Override
+  public CreateResponse create(FlowConfig flowConfig) {
+    return this.getFlowConfigResourceHandler().createFlowConfig(flowConfig);
+  }
+
+  /**
+   * Update the flow configuration with the specified key. Running flows are not affected.
+   * An error is raised if the flow configuration does not exist.
+   * @param key composite key containing group name and flow name that identifies the flow to update
+   * @param flowConfig new flow configuration
+   * @return {@link UpdateResponse}
+   */
+  @Override
+  public UpdateResponse update(ComplexResourceKey<FlowId, EmptyRecord> key, FlowConfig flowConfig) {
+    String flowGroup = key.getKey().getFlowGroup();
+    String flowName = key.getKey().getFlowName();
+    FlowId flowId = new FlowId().setFlowGroup(flowGroup).setFlowName(flowName);
+    return this.getFlowConfigResourceHandler().updateFlowConfig(flowId, flowConfig);
+  }
+
+  /**
+   * Delete a configured flow. Running flows are not affected. The schedule will be removed for scheduled flows.
+   * @param key composite key containing flow group and flow name that identifies the flow to remove from the flow catalog
+   * @return {@link UpdateResponse}
+   */
+  @Override
+  public UpdateResponse delete(ComplexResourceKey<FlowId, EmptyRecord> key) {
+    String flowGroup = key.getKey().getFlowGroup();
+    String flowName = key.getKey().getFlowName();
+    FlowId flowId = new FlowId().setFlowGroup(flowGroup).setFlowName(flowName);
+    return this.getFlowConfigResourceHandler().deleteFlowConfig(flowId, getHeaders());
+  }
+
+  private FlowConfigsResourceHandler getFlowConfigResourceHandler() {
+    if (global_flowConfigsResourceHandler != null) {
+      return global_flowConfigsResourceHandler;
+    }
+
+    return flowConfigsResourceHandler;
+  }
+
+  private Properties getHeaders() {
+    Properties headerProperties = new Properties();
+    for (Map.Entry<String, String> entry : getContext().getRequestHeaders().entrySet()) {
+      if (ALLOWED_METADATA.contains(entry.getKey())) {
+        headerProperties.put(entry.getKey(), entry.getValue());
+      }
+    }
+    return headerProperties;
+  }
+}
+

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/validator/CronValidator.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/validator/CronValidator.java
@@ -17,6 +17,7 @@
 
 package org.apache.gobblin.service.validator;
 
+import org.apache.commons.lang.StringUtils;
 import org.quartz.CronExpression;
 
 import com.linkedin.data.DataMap;
@@ -43,7 +44,7 @@ public class CronValidator extends AbstractValidator
     Object value = element.getValue();
     String str = String.valueOf(value);
 
-    if (!CronExpression.isValidExpression(str))
+    if (!StringUtils.isEmpty(str) && !CronExpression.isValidExpression(str))
     {
       ctx.addResult(new Message(element.path(), "\"%1$s\" is not in Cron format", str));
     }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GobblinServiceManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GobblinServiceManager.java
@@ -78,6 +78,7 @@ import org.apache.gobblin.scheduler.SchedulerService;
 import org.apache.gobblin.service.FlowConfig;
 import org.apache.gobblin.service.FlowConfigClient;
 import org.apache.gobblin.service.FlowConfigResourceLocalHandler;
+import org.apache.gobblin.service.FlowConfigV2resourceLocalHandler;
 import org.apache.gobblin.service.FlowConfigsResource;
 import org.apache.gobblin.service.FlowConfigsResourceHandler;
 import org.apache.gobblin.service.FlowId;
@@ -122,6 +123,8 @@ public class GobblinServiceManager implements ApplicationLauncher, StandardMetri
   protected GobblinServiceJobScheduler scheduler;
   @Getter
   protected GobblinServiceFlowConfigResourceHandler resourceHandler;
+  @Getter
+  protected GobblinServiceFlowConfigResourceHandler v2ResourceHandler;
 
   protected boolean flowCatalogLocalCommit;
   protected Orchestrator orchestrator;
@@ -216,6 +219,12 @@ public class GobblinServiceManager implements ApplicationLauncher, StandardMetri
     this.resourceHandler = new GobblinServiceFlowConfigResourceHandler(serviceName,
         this.flowCatalogLocalCommit,
         new FlowConfigResourceLocalHandler(this.flowCatalog),
+        this.helixManager,
+        this.scheduler);
+
+    this.v2ResourceHandler = new GobblinServiceFlowConfigResourceHandler(serviceName,
+        this.flowCatalogLocalCommit,
+        new FlowConfigV2ResourceLocalHandler(this.flowCatalog),
         this.helixManager,
         this.scheduler);
 

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GobblinServiceManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GobblinServiceManager.java
@@ -78,7 +78,7 @@ import org.apache.gobblin.scheduler.SchedulerService;
 import org.apache.gobblin.service.FlowConfig;
 import org.apache.gobblin.service.FlowConfigClient;
 import org.apache.gobblin.service.FlowConfigResourceLocalHandler;
-import org.apache.gobblin.service.FlowConfigV2resourceLocalHandler;
+import org.apache.gobblin.service.FlowConfigV2ResourceLocalHandler;
 import org.apache.gobblin.service.FlowConfigsResource;
 import org.apache.gobblin.service.FlowConfigsResourceHandler;
 import org.apache.gobblin.service.FlowId;

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/BaseFlowToJobSpecCompiler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/BaseFlowToJobSpecCompiler.java
@@ -250,9 +250,10 @@ public abstract class BaseFlowToJobSpecCompiler implements SpecCompiler {
     }
 
     // Add flow execution id for this compilation
-    long flowExecutionId = System.currentTimeMillis();
-    jobSpec.setConfig(jobSpec.getConfig().withValue(ConfigurationKeys.FLOW_EXECUTION_ID_KEY,
-        ConfigValueFactory.fromAnyRef(flowExecutionId)));
+    if (!jobSpec.getConfig().hasPath(ConfigurationKeys.FLOW_EXECUTION_ID_KEY)) {
+      long flowExecutionId = System.currentTimeMillis();
+      jobSpec.setConfig(jobSpec.getConfig().withValue(ConfigurationKeys.FLOW_EXECUTION_ID_KEY, ConfigValueFactory.fromAnyRef(flowExecutionId)));
+    }
 
     // Reset properties in Spec from Config
     jobSpec.setConfigAsProperties(ConfigUtils.configToProperties(jobSpec.getConfig()));

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/FlowUtils.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/FlowUtils.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.service.modules.flow;
+
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.runtime.api.FlowSpec;
+
+
+public class FlowUtils {
+
+  /**
+   * A FlowSpec contains a FlowExecutionId if it is a runOnce flow.
+   * Refer {@link FlowConfigResourceLocalHandler#createFlowSpecForConfig} for details.
+   * @param spec flow spec
+   * @return flow execution id
+   */
+  public static long getOrCreateFlowExecutionId(FlowSpec spec) {
+    long flowExecutionId;
+
+    if (spec.getConfig().hasPath(ConfigurationKeys.FLOW_EXECUTION_ID_KEY)) {
+      flowExecutionId = spec.getConfig().getLong(ConfigurationKeys.FLOW_EXECUTION_ID_KEY);
+    } else {
+      flowExecutionId = System.currentTimeMillis();
+    }
+
+    return flowExecutionId;
+  }
+}

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/MultiHopsFlowToJobSpecCompiler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/MultiHopsFlowToJobSpecCompiler.java
@@ -309,9 +309,10 @@ public class MultiHopsFlowToJobSpecCompiler extends BaseFlowToJobSpecCompiler {
     }
 
     // Add flow execution id for this compilation
-    long flowExecutionId = System.currentTimeMillis();
-    jobSpec.setConfig(jobSpec.getConfig().withValue(ConfigurationKeys.FLOW_EXECUTION_ID_KEY,
-        ConfigValueFactory.fromAnyRef(flowExecutionId)));
+    if (!jobSpec.getConfig().hasPath(ConfigurationKeys.FLOW_EXECUTION_ID_KEY)) {
+      long flowExecutionId = System.currentTimeMillis();
+      jobSpec.setConfig(jobSpec.getConfig().withValue(ConfigurationKeys.FLOW_EXECUTION_ID_KEY, ConfigValueFactory.fromAnyRef(flowExecutionId)));
+    }
 
     // Reset properties in Spec from Config
     jobSpec.setConfigAsProperties(ConfigUtils.configToProperties(jobSpec.getConfig()));

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/MultiHopsFlowToJobSpecCompiler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/MultiHopsFlowToJobSpecCompiler.java
@@ -17,7 +17,6 @@
 
 package org.apache.gobblin.service.modules.flow;
 
-import com.google.common.base.Splitter;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
@@ -28,41 +27,43 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.StringUtils;
+import org.jgrapht.graph.DirectedWeightedMultigraph;
+import org.slf4j.Logger;
+
 import com.google.common.base.Optional;
+import com.google.common.base.Splitter;
 import com.google.common.collect.Maps;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigValueFactory;
 
-import org.apache.commons.lang3.StringUtils;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
 import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.instrumented.Instrumented;
+import org.apache.gobblin.runtime.api.FlowEdge;
+import org.apache.gobblin.runtime.api.FlowSpec;
+import org.apache.gobblin.runtime.api.JobSpec;
+import org.apache.gobblin.runtime.api.JobTemplate;
+import org.apache.gobblin.runtime.api.ServiceNode;
+import org.apache.gobblin.runtime.api.Spec;
+import org.apache.gobblin.runtime.api.SpecExecutor;
+import org.apache.gobblin.runtime.api.SpecNotFoundException;
+import org.apache.gobblin.runtime.api.TopologySpec;
+import org.apache.gobblin.runtime.job_spec.ResolvedJobSpec;
+import org.apache.gobblin.runtime.spec_executorInstance.BaseServiceNodeImpl;
 import org.apache.gobblin.runtime.spec_executorInstance.InMemorySpecExecutor;
+import org.apache.gobblin.service.ServiceConfigKeys;
 import org.apache.gobblin.service.modules.flowgraph.Dag;
 import org.apache.gobblin.service.modules.policy.ServicePolicy;
 import org.apache.gobblin.service.modules.spec.JobExecutionPlan;
 import org.apache.gobblin.service.modules.spec.JobExecutionPlanDagFactory;
 import org.apache.gobblin.util.ClassAliasResolver;
 import org.apache.gobblin.util.ConfigUtils;
-import org.jgrapht.graph.DirectedWeightedMultigraph;
-import org.slf4j.Logger;
-import org.apache.gobblin.runtime.api.FlowEdge;
-import org.apache.gobblin.runtime.api.ServiceNode;
-import org.apache.gobblin.runtime.api.FlowSpec;
-import org.apache.gobblin.instrumented.Instrumented;
-import org.apache.gobblin.runtime.api.Spec;
-import org.apache.gobblin.runtime.api.TopologySpec;
-import org.apache.gobblin.service.ServiceConfigKeys;
-import org.apache.gobblin.runtime.spec_executorInstance.BaseServiceNodeImpl;
-import org.apache.gobblin.runtime.api.JobSpec;
-import org.apache.gobblin.runtime.api.JobTemplate;
-import org.apache.gobblin.runtime.api.SpecExecutor;
-import org.apache.gobblin.runtime.api.SpecNotFoundException;
-import org.apache.gobblin.runtime.job_spec.ResolvedJobSpec;
 
-import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
-
-import static org.apache.gobblin.service.ServiceConfigKeys.*;
-import static org.apache.gobblin.service.modules.utils.FindPathUtils.*;
+import static org.apache.gobblin.service.ServiceConfigKeys.SERVICE_POLICY_NAME;
+import static org.apache.gobblin.service.modules.utils.FindPathUtils.dijkstraBasedPathFindingHelper;
 
 // Users are capable to inject hints/prioritization into route selection, in two forms:
 // 1. PolicyBasedBlockedConnection: Define some undesired routes
@@ -309,10 +310,9 @@ public class MultiHopsFlowToJobSpecCompiler extends BaseFlowToJobSpecCompiler {
     }
 
     // Add flow execution id for this compilation
-    if (!jobSpec.getConfig().hasPath(ConfigurationKeys.FLOW_EXECUTION_ID_KEY)) {
-      long flowExecutionId = System.currentTimeMillis();
-      jobSpec.setConfig(jobSpec.getConfig().withValue(ConfigurationKeys.FLOW_EXECUTION_ID_KEY, ConfigValueFactory.fromAnyRef(flowExecutionId)));
-    }
+    long flowExecutionId = FlowUtils.getOrCreateFlowExecutionId(flowSpec);
+    jobSpec.setConfig(jobSpec.getConfig().withValue(ConfigurationKeys.FLOW_EXECUTION_ID_KEY,
+        ConfigValueFactory.fromAnyRef(flowExecutionId)));
 
     // Reset properties in Spec from Config
     jobSpec.setConfigAsProperties(ConfigUtils.configToProperties(jobSpec.getConfig()));

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/pathfinder/AbstractPathFinder.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/pathfinder/AbstractPathFinder.java
@@ -41,6 +41,7 @@ import org.apache.gobblin.service.ServiceConfigKeys;
 import org.apache.gobblin.service.modules.dataset.DatasetDescriptor;
 import org.apache.gobblin.service.modules.flow.FlowEdgeContext;
 import org.apache.gobblin.service.modules.flow.FlowGraphPath;
+import org.apache.gobblin.service.modules.flow.FlowUtils;
 import org.apache.gobblin.service.modules.flowgraph.Dag;
 import org.apache.gobblin.service.modules.flowgraph.DataNode;
 import org.apache.gobblin.service.modules.flowgraph.DatasetDescriptorConfigKeys;
@@ -78,6 +79,7 @@ public abstract class AbstractPathFinder implements PathFinder {
     this.flowGraph = flowGraph;
     this.flowSpec = flowSpec;
     this.flowConfig = flowSpec.getConfig();
+    this.flowExecutionId = FlowUtils.getOrCreateFlowExecutionId(flowSpec);
 
     //Get src/dest DataNodes from the flow config
     String srcNodeId = ConfigUtils.getString(flowConfig, ServiceConfigKeys.FLOW_SOURCE_IDENTIFIER_KEY, "");
@@ -237,8 +239,6 @@ public abstract class AbstractPathFinder implements PathFinder {
 
   @Override
   public FlowGraphPath findPath() throws PathFinderException {
-    // Generate flow execution id for this compilation
-    this.flowExecutionId = System.currentTimeMillis();
 
     FlowGraphPath flowGraphPath = new FlowGraphPath(flowSpec, flowExecutionId);
     //Path computation must be thread-safe to guarantee read consistency. In other words, we prevent concurrent read/write access to the


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below! @htran1  please review


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-XXX


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
add flowConfigsV2 which add flowExecutionId and return it on create embedded in FlowStatusId

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
not needed, it is a duplicate of flowConfigs

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

