### PR TITLE
[GOBBLIN-568] FsDataWriter lacks support for multiple files per partition using record count or block size

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -373,6 +373,7 @@ public class ConfigurationKeys {
   public static final String DEFAULT_WRITER_FILE_PATH_TYPE = "default";
   public static final String SIMPLE_WRITER_DELIMITER = "simple.writer.delimiter";
   public static final String SIMPLE_WRITER_PREPEND_SIZE = "simple.writer.prepend.size";
+  public static final String WRITER_RECORDS_PER_FILE_THRESHOLD = WRITER_PREFIX + ".records.perFile.threshold";
 
 
   // Internal use only - used to send metadata to publisher

--- a/gobblin-core/src/main/java/org/apache/gobblin/writer/FileFormatWriter.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/writer/FileFormatWriter.java
@@ -16,11 +16,15 @@
  */
 package org.apache.gobblin.writer;
 
+import java.io.Closeable;
 import java.io.IOException;
 
-import org.apache.hadoop.fs.Path;
 
+/**
+ * Represents a generic file writer of file format type <T>.
+ * @author tilakpatidar@gmail.com
+ */
+interface FileFormatWriter<T> extends Closeable {
 
-public abstract class MultipleFilesFsDataWriterBuilder<S, D> extends FsDataWriterBuilder<S, D> {
-  protected abstract FileFormatWriter<D> getNewWriter(int blockSize, Path stagingFile) throws IOException;
+  void write(T object) throws IOException;
 }

--- a/gobblin-core/src/main/java/org/apache/gobblin/writer/MultipleFilesFsDataWriter.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/writer/MultipleFilesFsDataWriter.java
@@ -52,13 +52,13 @@ public abstract class MultipleFilesFsDataWriter<D> extends FsDataWriter<D> {
   private final AtomicLong recordsWritten = new AtomicLong(0);
   private final AtomicLong recordsWrittenInCurrentWriter = new AtomicLong(0);
   private final AtomicLong currentWriterNumber = new AtomicLong(0);
-  private final MultipleFilesFsDataWriterBuilder<?, ?> builder;
+  private final MultipleFilesFsDataWriterBuilder<?, D> builder;
   @Getter
   public Path currentFilePath;
   private Long recordsWrittenThreshold;
-  private Object currentWriter;
+  private FileFormatWriter<D> currentWriter;
 
-  public MultipleFilesFsDataWriter(MultipleFilesFsDataWriterBuilder<?, ?> builder, State properties)
+  public MultipleFilesFsDataWriter(MultipleFilesFsDataWriterBuilder<?, D> builder, State properties)
       throws IOException {
     super(builder, properties);
     this.recordsWrittenThreshold = properties.getPropAsLong(ForkOperatorUtils
@@ -153,17 +153,17 @@ public abstract class MultipleFilesFsDataWriter<D> extends FsDataWriter<D> {
     return this.recordsWritten.get();
   }
 
-  public abstract void writeWithCurrentWriter(Object writer, D record)
+  public abstract void writeWithCurrentWriter(FileFormatWriter<D> writer, D record)
       throws IOException;
 
-  public abstract void closeCurrentWriter(Object writer)
+  public abstract void closeCurrentWriter(FileFormatWriter<D> writer)
       throws IOException;
 
   private List<WrittenFile> writtenFiles() {
     return LongStream.range(1, this.currentWriterNumber.get()).mapToObj(WrittenFile::new).collect(toList());
   }
 
-  private Object getNewWriter()
+  private FileFormatWriter<D> getNewWriter()
       throws IOException {
     this.currentWriterNumber.incrementAndGet();
     this.recordsWrittenInCurrentWriter.set(0);

--- a/gobblin-core/src/main/java/org/apache/gobblin/writer/MultipleFilesFsDataWriter.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/writer/MultipleFilesFsDataWriter.java
@@ -1,0 +1,204 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.writer;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.LongStream;
+
+import org.apache.commons.io.FilenameUtils;
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.configuration.State;
+import org.apache.gobblin.util.ForkOperatorUtils;
+import org.apache.gobblin.util.HadoopUtils;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+
+import lombok.Getter;
+
+import static java.util.stream.Collectors.toList;
+
+
+/**
+ * An implementation of {@link DataWriter} that writes to multiple files if certain number
+ * of records per file is reached.
+ *
+ * @author tilakpatidar@gmail.com
+ */
+public abstract class MultipleFilesFsDataWriter<D> extends FsDataWriter<D> {
+  public static final Long WRITER_RECORDS_PER_FILE_THRESHOLD_DEFAULT = 10000L;
+  private static final Logger LOG = LoggerFactory.getLogger(MultipleFilesFsDataWriter.class);
+  private final AtomicLong recordsWritten = new AtomicLong(0);
+  private final AtomicLong recordsWrittenInCurrentWriter = new AtomicLong(0);
+  private final AtomicLong currentWriterNumber = new AtomicLong(0);
+  private final MultipleFilesFsDataWriterBuilder<?, ?> builder;
+  @Getter
+  public Path currentFilePath;
+  private Long recordsWrittenThreshold;
+  private Object currentWriter;
+
+  public MultipleFilesFsDataWriter(MultipleFilesFsDataWriterBuilder<?, ?> builder, State properties)
+      throws IOException {
+    super(builder, properties);
+    this.recordsWrittenThreshold = properties.getPropAsLong(ForkOperatorUtils
+            .getPropertyNameForBranch(ConfigurationKeys.WRITER_RECORDS_PER_FILE_THRESHOLD, this.numBranches, this.branchId),
+        WRITER_RECORDS_PER_FILE_THRESHOLD_DEFAULT);
+    this.builder = builder;
+    this.currentWriter = this.getNewWriter();
+  }
+
+  @Override
+  public void write(D record)
+      throws IOException {
+    if (this.recordsWrittenInCurrentWriter.incrementAndGet() == this.recordsWrittenThreshold) {
+      LOG.debug("Record threshold {} reached", this.recordsWrittenThreshold.toString());
+      this.closeCurrentWriter(this.currentWriter);
+      this.currentWriter = this.getNewWriter();
+      LOG.debug("Current writer number {}", this.currentWriterNumber.toString());
+    }
+    this.writeWithCurrentWriter(this.currentWriter, record);
+    this.recordsWritten.incrementAndGet();
+    LOG.debug("Total records written {} and records written {} in current writer", this.recordsWritten.toString(),
+        this.recordsWrittenInCurrentWriter.toString());
+  }
+
+  @Override
+  protected void setStagingFileGroup()
+      throws IOException {
+    for (WrittenFile writtenFile : writtenFiles()) {
+
+      Preconditions.checkArgument(this.fs.exists(writtenFile.getStagingFile()),
+          String.format("Staging output file %s does not exist", writtenFile.getStagingFile()));
+      if (this.group.isPresent()) {
+        HadoopUtils.setGroup(this.fs, writtenFile.getStagingFile(), this.group.get());
+      }
+    }
+  }
+
+  @Override
+  public void commit()
+      throws IOException {
+    this.closer.close();
+
+    this.setStagingFileGroup();
+
+    Long bytesWritten = 0L;
+    for (WrittenFile writtenFile : writtenFiles()) {
+      if (!this.fs.exists(writtenFile.getStagingFile())) {
+        throw new IOException(String.format("File %s does not exist", writtenFile.getStagingFile()));
+      }
+      FileStatus stagingFileStatus = this.fs.getFileStatus(writtenFile.getStagingFile());
+
+      // Double check permission of staging file
+      if (!stagingFileStatus.getPermission().equals(this.filePermission)) {
+        this.fs.setPermission(writtenFile.getStagingFile(), this.filePermission);
+      }
+      bytesWritten += stagingFileStatus.getLen();
+    }
+
+    this.bytesWritten = Optional.of(bytesWritten);
+    for (WrittenFile writtenFile : writtenFiles()) {
+      LOG.info(String.format("Moving data from %s to %s", writtenFile.getStagingFile(), writtenFile.getOutputFile()));
+      // For the same reason as deleting the staging file if it already exists, deleting
+      // the output file if it already exists prevents task retry from being blocked.
+      if (this.fs.exists(writtenFile.getOutputFile())) {
+        LOG.warn(String.format("Task output file %s already exists", writtenFile.getOutputFile()));
+        HadoopUtils.deletePath(this.fs, writtenFile.getOutputFile(), false);
+      }
+      HadoopUtils.renamePath(this.fs, writtenFile.getStagingFile(), writtenFile.getOutputFile());
+    }
+  }
+
+  @Override
+  public void cleanup()
+      throws IOException {
+    for (WrittenFile writtenFile : writtenFiles()) {
+      // Delete the staging file
+      if (this.fs.exists(writtenFile.getStagingFile())) {
+        HadoopUtils.deletePath(this.fs, writtenFile.getStagingFile(), false);
+      }
+    }
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+    this.closeCurrentWriter(this.currentWriter);
+    super.close();
+  }
+
+  @Override
+  public long recordsWritten() {
+    return this.recordsWritten.get();
+  }
+
+  public abstract void writeWithCurrentWriter(Object writer, D record)
+      throws IOException;
+
+  public abstract void closeCurrentWriter(Object writer)
+      throws IOException;
+
+  private List<WrittenFile> writtenFiles() {
+    return LongStream.range(1, this.currentWriterNumber.get()).mapToObj(WrittenFile::new).collect(toList());
+  }
+
+  private Object getNewWriter()
+      throws IOException {
+    this.currentWriterNumber.incrementAndGet();
+    this.recordsWrittenInCurrentWriter.set(0);
+    Path stagingFile = getWriterStagingFileName(this.currentWriterNumber.get());
+    this.currentFilePath = stagingFile;
+    LOG.info("Created new writer for staging file {}", stagingFile.toString());
+    return this.builder.getNewWriter((int) this.blockSize, stagingFile);
+  }
+
+  private Path generateNewFileName(Path file, long writerNumber) {
+    String filePath = file.toString();
+    String path = FilenameUtils.getFullPath(filePath);
+    String baseName = FilenameUtils.getBaseName(filePath);
+    String extension = FilenameUtils.getExtension(filePath);
+    String fullExtension = extension.isEmpty() ? "" : "." + extension;
+    String newFilePath = path + baseName + "_" + writerNumber + fullExtension;
+    return new Path(newFilePath);
+  }
+
+  private Path getWriterStagingFileName(long writerNumber) {
+    return generateNewFileName(this.stagingFile, writerNumber);
+  }
+
+  private Path getWriterOutputFileName(long writerNumber) {
+    return generateNewFileName(this.outputFile, writerNumber);
+  }
+
+  @Getter
+  private class WrittenFile {
+    private final Path stagingFile;
+    private final Path outputFile;
+
+    WrittenFile(long writerNumber) {
+      this.stagingFile = getWriterStagingFileName(writerNumber);
+      this.outputFile = getWriterOutputFileName(writerNumber);
+    }
+  }
+}

--- a/gobblin-core/src/main/java/org/apache/gobblin/writer/MultipleFilesFsDataWriterBuilder.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/writer/MultipleFilesFsDataWriterBuilder.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gobblin.writer;
+
+import java.io.IOException;
+
+import org.apache.hadoop.fs.Path;
+
+
+public abstract class MultipleFilesFsDataWriterBuilder<S, D> extends FsDataWriterBuilder<S, D> {
+  protected abstract Object getNewWriter(int blockSize, Path stagingFile) throws IOException;
+}

--- a/gobblin-core/src/test/java/org/apache/gobblin/writer/MultipleFilesFsDataWriterTest.java
+++ b/gobblin-core/src/test/java/org/apache/gobblin/writer/MultipleFilesFsDataWriterTest.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gobblin.writer;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.hadoop.fs.FileUtil;
+import org.apache.hadoop.fs.Path;
+import org.mockito.Mockito;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import gobblin.configuration.State;
+
+import static org.apache.gobblin.writer.MultipleFilesFsDataWriter.WRITER_RECORDS_PER_FILE_THRESHOLD_DEFAULT;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+@Test(groups = {"gobblin.writer"})
+public class MultipleFilesFsDataWriterTest {
+
+  private MultipleFilesFsDataWriterBuilder<Object, Integer> builder;
+  private MultipleFilesFsDataWriter<Integer> writer;
+  private State state;
+
+  @BeforeMethod
+  public void setUp()
+      throws IOException {
+    builder = mock(MultipleFilesFsDataWriterBuilder.class);
+    state = createStateWithConfig();
+    when(builder.getNewWriter(anyInt(), any(Path.class))).thenReturn(new Object());
+    when(builder.getFileName(any(State.class))).thenReturn(TestConstants.TEST_FILE_NAME);
+    writer = new MultipleFilesFsDataWriter<Integer>(builder, state) {
+
+      @Override
+      public void writeWithCurrentWriter(Object writer, Integer record) {
+        java.nio.file.Path path = Paths.get(this.getCurrentFilePath().toString());
+        try {
+          File file = new File(path.toString());
+          file.createNewFile();
+          Files.write(path, record.toString().getBytes(), StandardOpenOption.APPEND);
+        } catch (IOException ignored) {
+        }
+      }
+
+      @Override
+      public void closeCurrentWriter(Object writer) {
+
+      }
+    };
+
+    // Making the staging and/or output dirs if necessary
+    File stagingDir = new File(buildAbsolutePath(TestConstants.TEST_STAGING_DIR));
+    File outputDir = new File(buildAbsolutePath(TestConstants.TEST_OUTPUT_DIR));
+    File writerPath = new File(buildAbsolutePath(TestConstants.TEST_STAGING_DIR + Path.SEPARATOR + getFilePath()));
+    if (!stagingDir.exists()) {
+      boolean mkdirs = stagingDir.mkdirs();
+      assert mkdirs;
+    }
+    if (!outputDir.exists()) {
+      boolean mkdirs = outputDir.mkdirs();
+      assert mkdirs;
+    }
+    if (!writerPath.exists()) {
+      boolean mkdirs = writerPath.mkdirs();
+      assert mkdirs;
+    }
+  }
+
+  @Test
+  public void testIfWritersAreSwitchedWhenRecordThresholdReached()
+      throws IOException {
+    for (int i = 0; i < WRITER_RECORDS_PER_FILE_THRESHOLD_DEFAULT; i++) {
+      writer.write(i);
+    }
+    assertThat(writer.recordsWritten(), is(WRITER_RECORDS_PER_FILE_THRESHOLD_DEFAULT));
+    writer.write(Integer.valueOf(String.valueOf(WRITER_RECORDS_PER_FILE_THRESHOLD_DEFAULT + 1)));
+    assertThat(writer.recordsWritten(), is(WRITER_RECORDS_PER_FILE_THRESHOLD_DEFAULT + 1));
+    writer.close();
+    verify(builder, Mockito.times(2)).getNewWriter(anyInt(), any(Path.class));
+  }
+
+  @Test
+  public void testIfStageFilesAreMovedToOutputOnCommit()
+      throws IOException {
+
+    for (int i = 0; i < WRITER_RECORDS_PER_FILE_THRESHOLD_DEFAULT; i++) {
+      writer.write(i);
+    }
+    assertThat(writer.recordsWritten(), is(WRITER_RECORDS_PER_FILE_THRESHOLD_DEFAULT));
+    writer.write(Integer.valueOf(String.valueOf(WRITER_RECORDS_PER_FILE_THRESHOLD_DEFAULT + 1)));
+    assertThat(writer.recordsWritten(), is(WRITER_RECORDS_PER_FILE_THRESHOLD_DEFAULT + 1));
+    writer.close();
+    writer.commit();
+    verify(builder, Mockito.times(2)).getNewWriter(anyInt(), any(Path.class));
+  }
+
+  @AfterMethod
+  public void tearDown() {
+    // Clean up the staging and/or output directories if necessary
+    File testRootDir = new File(System.getProperty("java.io.tmpdir"));
+    if (testRootDir.exists()) {
+      FileUtil.fullyDelete(testRootDir);
+    }
+  }
+
+  private State createStateWithConfig() {
+    State properties = new State();
+    properties.setProp(ConfigurationKeys.WRITER_BUFFER_SIZE, ConfigurationKeys.DEFAULT_BUFFER_SIZE);
+    properties.setProp(ConfigurationKeys.WRITER_FILE_SYSTEM_URI, "file:///");
+    properties.setProp(ConfigurationKeys.WRITER_STAGING_DIR, buildAbsolutePath(TestConstants.TEST_STAGING_DIR));
+    properties.setProp(ConfigurationKeys.WRITER_OUTPUT_DIR, buildAbsolutePath(TestConstants.TEST_OUTPUT_DIR));
+    properties.setProp(ConfigurationKeys.WRITER_FILE_PATH, getFilePath());
+    properties.setProp(ConfigurationKeys.WRITER_FILE_NAME, TestConstants.TEST_FILE_NAME);
+    return properties;
+  }
+
+  private String buildAbsolutePath(String path) {
+    return System.getProperty("java.io.tmpdir") + path;
+  }
+
+  private String getFilePath() {
+    return TestConstants.TEST_EXTRACT_NAMESPACE.replaceAll("\\.", "/") + "/" + TestConstants.TEST_EXTRACT_TABLE + "/"
+        + TestConstants.TEST_EXTRACT_ID + "_" + TestConstants.TEST_EXTRACT_PULL_TYPE;
+  }
+}

--- a/gobblin-modules/gobblin-parquet/src/main/java/org/apache/gobblin/writer/ParquetMultipleFilesDataWriterBuilder.java
+++ b/gobblin-modules/gobblin-parquet/src/main/java/org/apache/gobblin/writer/ParquetMultipleFilesDataWriterBuilder.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gobblin.writer;
+
+import java.io.IOException;
+
+import org.apache.hadoop.fs.Path;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+
+import parquet.example.data.Group;
+import parquet.hadoop.ParquetWriter;
+import parquet.schema.MessageType;
+
+import static org.apache.gobblin.writer.ParquetDataWriterBuilder.buildParquetWriter;
+
+
+public class ParquetMultipleFilesDataWriterBuilder extends MultipleFilesFsDataWriterBuilder<MessageType, Group> {
+
+  @Override
+  public DataWriter<Group> build()
+      throws IOException {
+    Preconditions.checkNotNull(this.destination);
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(this.writerId));
+    Preconditions.checkNotNull(this.schema);
+    Preconditions.checkArgument(this.format == WriterOutputFormat.PARQUET);
+
+    switch (this.destination.getType()) {
+      case HDFS:
+        return new ParquetMultipleFilesHdfsDataWriter(this, this.destination.getProperties());
+      default:
+        throw new RuntimeException("Unknown destination type: " + this.destination.getType());
+    }
+  }
+
+  /**
+   * Build a {@link ParquetWriter<Group>} for given file path with a block size.
+   * @param blockSize
+   * @param stagingFile
+   * @return
+   * @throws IOException
+   */
+  @Override
+  public Object getNewWriter(int blockSize, Path stagingFile)
+      throws IOException {
+    return buildParquetWriter(this.destination.getProperties(), this.schema, this.branches, this.branch, stagingFile,
+        blockSize);
+  }
+}

--- a/gobblin-modules/gobblin-parquet/src/main/java/org/apache/gobblin/writer/ParquetMultipleFilesDataWriterBuilder.java
+++ b/gobblin-modules/gobblin-parquet/src/main/java/org/apache/gobblin/writer/ParquetMultipleFilesDataWriterBuilder.java
@@ -56,9 +56,25 @@ public class ParquetMultipleFilesDataWriterBuilder extends MultipleFilesFsDataWr
    * @throws IOException
    */
   @Override
-  public Object getNewWriter(int blockSize, Path stagingFile)
+  public FileFormatWriter<Group> getNewWriter(int blockSize, Path stagingFile)
       throws IOException {
-    return buildParquetWriter(this.destination.getProperties(), this.schema, this.branches, this.branch, stagingFile,
-        blockSize);
+    ParquetWriter<Group> groupParquetWriter =
+        buildParquetWriter(this.destination.getProperties(), this.schema, this.branches, this.branch, stagingFile,
+            blockSize);
+
+    return new FileFormatWriter<Group>() {
+
+      @Override
+      public void write(Group record)
+          throws IOException {
+        groupParquetWriter.write(record);
+      }
+
+      @Override
+      public void close()
+          throws IOException {
+        groupParquetWriter.close();
+      }
+    };
   }
 }

--- a/gobblin-modules/gobblin-parquet/src/main/java/org/apache/gobblin/writer/ParquetMultipleFilesHdfsDataWriter.java
+++ b/gobblin-modules/gobblin-parquet/src/main/java/org/apache/gobblin/writer/ParquetMultipleFilesHdfsDataWriter.java
@@ -24,7 +24,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import parquet.example.data.Group;
-import parquet.hadoop.ParquetWriter;
 
 
 /**
@@ -42,24 +41,22 @@ public class ParquetMultipleFilesHdfsDataWriter extends MultipleFilesFsDataWrite
 
   private static final Logger LOG = LoggerFactory.getLogger(ParquetMultipleFilesHdfsDataWriter.class);
 
-  public ParquetMultipleFilesHdfsDataWriter(MultipleFilesFsDataWriterBuilder<?, ?> builder, State state)
+  public ParquetMultipleFilesHdfsDataWriter(MultipleFilesFsDataWriterBuilder<?, Group> builder, State state)
       throws IOException {
     super(builder, state);
   }
 
   @Override
-  public void writeWithCurrentWriter(Object writer, Group record)
+  public void writeWithCurrentWriter(FileFormatWriter<Group> writer, Group record)
       throws IOException {
-    ParquetWriter<Group> parquetWriter = (ParquetWriter<Group>) writer;
-    parquetWriter.write(record);
+    writer.write(record);
   }
 
   @Override
-  public void closeCurrentWriter(Object writer)
+  public void closeCurrentWriter(FileFormatWriter<Group> writer)
       throws IOException {
-    ParquetWriter<Group> parquetWriter = (ParquetWriter<Group>) writer;
     try {
-      parquetWriter.close();
+      writer.close();
     } finally {
       super.close();
     }

--- a/gobblin-modules/gobblin-parquet/src/main/java/org/apache/gobblin/writer/ParquetMultipleFilesHdfsDataWriter.java
+++ b/gobblin-modules/gobblin-parquet/src/main/java/org/apache/gobblin/writer/ParquetMultipleFilesHdfsDataWriter.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gobblin.writer;
+
+import java.io.IOException;
+
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.configuration.State;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import parquet.example.data.Group;
+import parquet.hadoop.ParquetWriter;
+
+
+/**
+ * An extension to {@link MultipleFilesFsDataWriter} that writes in Parquet format in the form of {@link Group}s.
+ * Using {@link MultipleFilesFsDataWriter} allows the user to control the number of {@link Group} records per file.
+ * Use property {@link ConfigurationKeys#WRITER_RECORDS_PER_FILE_THRESHOLD} to set number of records per file.
+ * <p>
+ *   This implementation allows users to specify the {@link parquet.hadoop.CodecFactory} to use through the configuration
+ *   property {@link ConfigurationKeys#WRITER_CODEC_TYPE}. By default, the deflate codec is used.
+ * </p>
+ *
+ * @author tilakpatidar
+ */
+public class ParquetMultipleFilesHdfsDataWriter extends MultipleFilesFsDataWriter<Group> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ParquetMultipleFilesHdfsDataWriter.class);
+
+  public ParquetMultipleFilesHdfsDataWriter(MultipleFilesFsDataWriterBuilder<?, ?> builder, State state)
+      throws IOException {
+    super(builder, state);
+  }
+
+  @Override
+  public void writeWithCurrentWriter(Object writer, Group record)
+      throws IOException {
+    ParquetWriter<Group> parquetWriter = (ParquetWriter<Group>) writer;
+    parquetWriter.write(record);
+  }
+
+  @Override
+  public void closeCurrentWriter(Object writer)
+      throws IOException {
+    ParquetWriter<Group> parquetWriter = (ParquetWriter<Group>) writer;
+    try {
+      parquetWriter.close();
+    } finally {
+      super.close();
+    }
+    LOG.info("Current writer closed");
+  }
+}


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] [GOBBLIN-568](https://issues.apache.org/jira/browse/GOBBLIN-568) FsDataWriter lacks support for multiple files per partition using record count or block size 


### Description
- [x] Currently, FsDataWriter does not support writing multiple files per partition. As a result, a huge file is getting generated per partition. If someone is using file formats such as parquet it is not advisable.
- [x] `org.apache.gobblin.writer.MultipleFilesFsDataWriter` extends `org.apache.gobblin.writer.FsDataWriter` to provide a wrapper around `org.apache.gobblin.writer.FsDataWriter` so that new writers can be instantiated once a threshold of records per file is reached. This can be configured using `ConfigurationKeys.WRITER_RECORDS_PER_FILE_THRESHOLD`
- [x] `org.apache.gobblin.writer.MultipleFilesFsDataWriterBuilder` provides a way to build such a writer. However, the user has to implement in the builder how to instantiate the new writer `MultipleFilesFsDataWriterBuilder::getNewWriter`.
- [x] As an example to build such writers in future refer `org.apache.gobblin.writer.ParquetMultipleFilesHdfsDataWriter` and `org.apache.gobblin.writer.ParquetMultipleFilesDataWriterBuilder`. They demonstrate how to build a writer where new files will be opened whenever the record count threshold is reached.


### Tests
- [x] `org.apache.gobblin.writer.MultipleFilesFsDataWriterTest`

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

