### PR TITLE
[GOBBLIN-569] Address the pylint warnings in github-pr-change-log.py

### DIFF
--- a/maven-sonatype/github-pr-change-log.py
+++ b/maven-sonatype/github-pr-change-log.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+# pylint: disable=line-too-long
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -33,10 +34,10 @@
 # The script should be run as follows "./pull-requests-change-log.py [github-username] [github-password] [starting-pr-number] [ending-pr-number]
 # For example, to produce the above output the command run was "./pull-requests-change-log.py sahilTakiar [my-password] 900 905"
 
-import requests
 import sys
+import requests
 
 for prNumber in range(int(sys.argv[3]), int(sys.argv[4])):
-	pr = requests.get("https://api.github.com/repos/linkedin/gobblin/pulls/" + str(prNumber), auth=(sys.argv[1], sys.argv[2])).json();
-	if "state" in pr.keys() and  pr["state"] == "closed" and pr["merged"]:
-		print "* [] [PR " + str(pr["number"]) + "] " + pr["title"]
+    pr = requests.get("https://api.github.com/repos/linkedin/gobblin/pulls/" + str(prNumber), auth=(sys.argv[1], sys.argv[2])).json()
+    if "state" in pr.keys() and  pr["state"] == "closed" and pr["merged"]:
+        print "* [] [PR " + str(pr["number"]) + "] " + pr["title"]


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
https://issues.apache.org/jira/browse/GOBBLIN-569

### Description
Address the pylint warnings in github-pr-change-log.py(https://github.com/apache/incubator-gobblin/blob/f5b893cf3972a89c6557e7899138e34493882dcb/maven-sonatype/github-pr-change-log.py)

### Tests
Pylint score Before **-11.67/10**
Pylint score Now **6.67/10**
