### PR TITLE
[GOBBLIN-578] Comparison to None should be 'expr is None'

### DIFF
--- a/dev/gobblin-jira-version
+++ b/dev/gobblin-jira-version
@@ -153,7 +153,7 @@ def update_jira_issues():
             "Enter fix version", fg='blue', bold=True),
         default=None)
         
-    if fix_version == None:
+    if fix_version is None:
         raise click.UsageError('No fix version specified')
     
     update_jira_issue(


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### JIRA
https://issues.apache.org/jira/browse/GOBBLIN-578

### Description
- 'expr is None'