### PR TITLE
[GOBBLIN-571] Fix parquet schema for complex types

### DIFF
--- a/gobblin-modules/gobblin-parquet/src/main/java/org/apache/gobblin/converter/parquet/JsonElementConversionFactory.java
+++ b/gobblin-modules/gobblin-parquet/src/main/java/org/apache/gobblin/converter/parquet/JsonElementConversionFactory.java
@@ -326,7 +326,7 @@ public class JsonElementConversionFactory {
 
     @Override
     JsonSchema getElementSchema() {
-      JsonSchema jsonSchema = JsonSchema.buildBaseSchema(this.elementType);
+      JsonSchema jsonSchema = JsonSchema.buildBaseSchema(this.elementType, true);
       jsonSchema.setColumnName(ARRAY_KEY);
       return jsonSchema;
     }
@@ -343,7 +343,7 @@ public class JsonElementConversionFactory {
 
     @Override
     Object convertField(JsonElement value) {
-      if (symbols.contains(value.getAsString()) || this.jsonSchema.isNullable()) {
+      if (symbols.contains(value.getAsString()) || (this.jsonSchema.isNullable() && value.isJsonNull())) {
         return this.elementConverter.convert(value);
       }
       throw new RuntimeException("Symbol " + value.getAsString() + " does not belong to set " + symbols.toString());
@@ -356,7 +356,7 @@ public class JsonElementConversionFactory {
 
     @Override
     JsonSchema getElementSchema() {
-      JsonSchema jsonSchema = JsonSchema.buildBaseSchema(STRING);
+      JsonSchema jsonSchema = JsonSchema.buildBaseSchema(STRING, this.jsonSchema.isNullable());
       jsonSchema.setColumnName(this.jsonSchema.getColumnName());
       return jsonSchema;
     }
@@ -471,13 +471,13 @@ public class JsonElementConversionFactory {
 
     @Override
     JsonSchema getElementSchema() {
-      JsonSchema jsonSchema = JsonSchema.buildBaseSchema(this.elementType);
+      JsonSchema jsonSchema = JsonSchema.buildBaseSchema(this.elementType, false);
       jsonSchema.setColumnName(MAP_VALUE_COLUMN_NAME);
       return jsonSchema;
     }
 
     public JsonElementConverter getKeyConverter() {
-      JsonSchema jsonSchema = JsonSchema.buildBaseSchema(STRING);
+      JsonSchema jsonSchema = JsonSchema.buildBaseSchema(STRING, false);
       jsonSchema.setColumnName(MAP_KEY_COLUMN_NAME);
       return getConverter(jsonSchema, false);
     }

--- a/gobblin-modules/gobblin-parquet/src/main/java/org/apache/gobblin/converter/parquet/JsonSchema.java
+++ b/gobblin-modules/gobblin-parquet/src/main/java/org/apache/gobblin/converter/parquet/JsonSchema.java
@@ -21,6 +21,7 @@ import org.apache.gobblin.source.extractor.schema.Schema;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
 
 import parquet.schema.Type.Repetition;
 
@@ -108,14 +109,16 @@ public class JsonSchema extends Schema {
   /**
    * Builds a {@link JsonSchema} object for a given {@link InputType} object.
    * @param type
+   * @param isNullable
    * @return
    */
-  public static JsonSchema buildBaseSchema(InputType type) {
+  public static JsonSchema buildBaseSchema(InputType type, boolean isNullable) {
     JsonObject jsonObject = new JsonObject();
     JsonObject dataType = new JsonObject();
     jsonObject.addProperty(COLUMN_NAME_KEY, DEFAULT_RECORD_COLUMN_NAME);
     dataType.addProperty(TYPE_KEY, type.toString());
     jsonObject.add(DATA_TYPE_KEY, dataType);
+    jsonObject.add(IS_NULLABLE_KEY, new JsonPrimitive(isNullable));
     return new JsonSchema(jsonObject);
   }
 

--- a/gobblin-modules/gobblin-parquet/src/test/java/org/apache/gobblin/converter/parquet/JsonIntermediateToParquetGroupConverterTest.java
+++ b/gobblin-modules/gobblin-parquet/src/test/java/org/apache/gobblin/converter/parquet/JsonIntermediateToParquetGroupConverterTest.java
@@ -66,7 +66,6 @@ public class JsonIntermediateToParquetGroupConverterTest {
     MessageType schema = parquetConverter.convertSchema(test.get("schema").getAsJsonArray(), workUnit);
     Group record =
         parquetConverter.convertRecord(schema, test.get("record").getAsJsonObject(), workUnit).iterator().next();
-
     assertEqualsIgnoreSpaces(schema.toString(), test.get("expectedSchema").getAsString());
     assertEqualsIgnoreSpaces(record.toString(), test.get("expectedRecord").getAsString());
   }
@@ -74,7 +73,7 @@ public class JsonIntermediateToParquetGroupConverterTest {
   @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "Symbol .* does not belong to set \\[.*?\\]")
   public void testEnumTypeBelongsToEnumSet()
       throws Exception {
-    JsonObject test = testCases.get("enum").getAsJsonObject();
+    JsonObject test = deepCopy(testCases.get("enum").getAsJsonObject(), JsonObject.class);
     parquetConverter = new JsonIntermediateToParquetGroupConverter();
 
     MessageType schema = parquetConverter.convertSchema(test.get("schema").getAsJsonArray(), workUnit);
@@ -97,9 +96,15 @@ public class JsonIntermediateToParquetGroupConverterTest {
   }
 
   @Test
-  public void testEnumType()
+  public void testEnumTypeWithNullableTrue()
       throws Exception {
     testCase("enum");
+  }
+
+  @Test
+  public void testEnumTypeWithNullableFalse()
+      throws Exception {
+    testCase("enum1");
   }
 
   @Test
@@ -124,5 +129,15 @@ public class JsonIntermediateToParquetGroupConverterTest {
   private void assertEqualsIgnoreSpaces(String actual, String expected) {
     assertEquals(actual.replaceAll("\\n", ";").replaceAll("\\s|\\t", ""),
         expected.replaceAll("\\n", ";").replaceAll("\\s|\\t", ""));
+  }
+
+  public <T> T deepCopy(T object, Class<T> type) {
+    try {
+      Gson gson = new Gson();
+      return gson.fromJson(gson.toJson(object, type), type);
+    } catch (Exception e) {
+      e.printStackTrace();
+      return null;
+    }
   }
 }

--- a/gobblin-modules/gobblin-parquet/src/test/resources/converter/JsonIntermediateToParquetConverter.json
+++ b/gobblin-modules/gobblin-parquet/src/test/resources/converter/JsonIntermediateToParquetConverter.json
@@ -80,7 +80,8 @@
         "dataType": {
           "type": "array",
           "items": "int"
-        }
+        },
+        "isNullable": true
       },
       {
         "columnName": "somearray1",
@@ -119,7 +120,7 @@
       }
     ],
     "expectedRecord": "somearray ;  item:1 ;  item:2 ;  item:3 ; somearray1 ;  item:1 ;  item:2 ;  item:3 ; somearray2 ;  item:1.0 ;  item:2.0 ;  item:3.0 ; somearray3 ;  item:1.0 ;  item:2.0 ;  item:3.0 ; somearray4 ;  item:true ;  item:false ;  item:true ; somearray5 ;  item:hello ;  item:world ; ",
-    "expectedSchema": "message test_table {  ;  required group somearray {  ; repeated int32 item ;  ; } ;  required groupsomearray1 {  ; repeated int64 item ;  ; } ;  required groupsomearray2 {  ; repeated float item ;  ; } ;  required groupsomearray3 {  ; repeated double item ;  ; } ;  required groupsomearray4 {  ; repeated boolean item ;  ; } ;  required groupsomearray5 {  ; repeated binary item(UTF8) ;  ; } ; } ; "
+    "expectedSchema": "message test_table {  ;  optional group somearray {  ; repeated int32 item ;  ; } ;  required groupsomearray1 {  ; repeated int64 item ;  ; } ;  required groupsomearray2 {  ; repeated float item ;  ; } ;  required groupsomearray3 {  ; repeated double item ;  ; } ;  required groupsomearray4 {  ; repeated boolean item ;  ; } ;  required groupsomearray5 {  ; repeated binary item(UTF8) ;  ; } ; } ; "
   },
   "enum": {
     "record": {
@@ -134,7 +135,28 @@
             "HELLO",
             "WORLD"
           ]
-        }
+        },
+        "isNullable": true
+      }
+    ],
+    "expectedRecord": "some_enum : HELLO ;",
+    "expectedSchema": "message test_table { ; optional binary some_enum (UTF8) ;; } ;"
+  },
+  "enum1": {
+    "record": {
+      "some_enum": "HELLO"
+    },
+    "schema": [
+      {
+        "columnName": "some_enum",
+        "dataType": {
+          "type": "enum",
+          "symbols": [
+            "HELLO",
+            "WORLD"
+          ]
+        },
+        "isNullable": false
       }
     ],
     "expectedRecord": "some_enum : HELLO ;",


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin-571 JsonIntermediateToParquetGroupConverter generates wrong parquet schema for complex types such as enums, arrays and maps](https://issues.apache.org/jira/browse/GOBBLIN-571)


### Description
- [x] For complex types such as arrays, maps and enums `JsonIntermediateToParquetGroupConverter` is generating wrong schema. For enums, arrays and maps the OPTIONAL and REQUIRED attribute of the SchemaField is messed up.

Due to this spark throws the following errors when reading parquet files generated using JsonIntermediateToParquetGroupConverter
```sh
Caused by: parquet.io.ParquetDecodingException: Can not read value at 0 
```
Ex of a wrong schema generated is below. Notice the field `payload.action is marked as required`

```sh
message EventData {
optional int64 id;
optional binary type (UTF8);
required group actor {
optional int64 id;
optional binary login (UTF8);
optional binary gravatar_id (UTF8);
optional binary url (UTF8);
optional binary avatar_url (UTF8);
}
required group repo {
optional int64 id;
optional binary name (UTF8);
optional binary url (UTF8);
optional binary urlid (UTF8);
}
required group payload {
optional int64 id;
optional binary ref (UTF8);
optional binary ref_type (UTF8);
optional binary master_branch (UTF8);
optional binary description (UTF8);
optional binary pusher_type (UTF8);
optional binary before (UTF8);
required binary action (UTF8);
}
optional boolean public;
optional binary created_at (UTF8);
optional binary created_at_id (UTF8);
}
```
But the field `payload.action` which is defined in the `source.schema` property is set to `isNullable: true`

```json
[ ....
    {
    "columnName": "payload",
    "dataType": {
      "type": "record",
      "name": "payloadDetails",
      "values": [
        ....
        {
          "columnName": "action",
          "isNullable": true,
          "dataType": {
            "type": "enum",
            "name": "actionType",
            "symbols": [
              "started",
              "published",
              "opened",
              "closed",
              "created",
              "reopened",
              "added"
            ]
          }
        }
      ]
    }
  }....
]
```

### Tests
- [x] org.apache.gobblin.parquet.converter.JsonIntermediateToParquetGroupConverterTest


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

