### PR TITLE
GOBBLIN-573: Add option to use finer level granularity at the hour level for TimeAwareDatasetfinder

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/TimeAwareRecursiveCopyableDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/TimeAwareRecursiveCopyableDataset.java
@@ -53,7 +53,8 @@ public class TimeAwareRecursiveCopyableDataset extends RecursiveCopyableDataset 
     this.lookbackPeriod = periodFormatter.parsePeriod(lookbackTime);
     this.datePattern = properties.getProperty(DATE_PATTERN_KEY);
     this.isPatternHourly = isDatePatternHourly(datePattern);
-    Assert.assertEquals(this.isPatternHourly, isLookbackTimeStringHourly(this.lookbackTime));
+    Assert.assertEquals(isLookbackTimeStringHourly(this.lookbackTime), this.isPatternHourly,
+        LOOKBACK_TIME_KEY + " is incompatible with " + DATE_PATTERN_KEY);
   }
 
   public static class DateRangeIterator implements Iterator {

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/TimeAwareRecursiveCopyableDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/TimeAwareRecursiveCopyableDataset.java
@@ -53,6 +53,8 @@ public class TimeAwareRecursiveCopyableDataset extends RecursiveCopyableDataset 
     this.lookbackPeriod = periodFormatter.parsePeriod(lookbackTime);
     this.datePattern = properties.getProperty(DATE_PATTERN_KEY);
     this.isPatternHourly = isDatePatternHourly(datePattern);
+
+    //Daily directories cannot have a "hourly" lookback pattern. But hourly directories can accept lookback pattern with days.
     if (!this.isPatternHourly) {
       Assert.assertTrue(isLookbackTimeStringDaily(this.lookbackTime), "Expected day format for lookback time; found hourly format");
     }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/TimeAwareRecursiveCopyableDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/TimeAwareRecursiveCopyableDataset.java
@@ -53,8 +53,9 @@ public class TimeAwareRecursiveCopyableDataset extends RecursiveCopyableDataset 
     this.lookbackPeriod = periodFormatter.parsePeriod(lookbackTime);
     this.datePattern = properties.getProperty(DATE_PATTERN_KEY);
     this.isPatternHourly = isDatePatternHourly(datePattern);
-    Assert.assertEquals(isLookbackTimeStringHourly(this.lookbackTime), this.isPatternHourly,
-        LOOKBACK_TIME_KEY + " is incompatible with " + DATE_PATTERN_KEY);
+    if (!this.isPatternHourly) {
+      Assert.assertTrue(isLookbackTimeStringDaily(this.lookbackTime), "Expected day format for lookback time; found hourly format");
+    }
   }
 
   public static class DateRangeIterator implements Iterator {
@@ -95,13 +96,13 @@ public class TimeAwareRecursiveCopyableDataset extends RecursiveCopyableDataset 
     return !refDateTimeString.equals(refDateTimeStringAtStartOfDay);
   }
 
-  private boolean isLookbackTimeStringHourly(String lookbackTime) {
+  private boolean isLookbackTimeStringDaily(String lookbackTime) {
     PeriodFormatter periodFormatter = new PeriodFormatterBuilder().appendDays().appendSuffix("d").toFormatter();
     try {
       periodFormatter.parsePeriod(lookbackTime);
-      return false;
-    } catch (Exception e) {
       return true;
+    } catch (Exception e) {
+      return false;
     }
   }
 

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/DateRangeIteratorTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/DateRangeIteratorTest.java
@@ -17,8 +17,9 @@
 
 package org.apache.gobblin.data.management.copy;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
+import org.joda.time.LocalDateTime;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -29,28 +30,28 @@ public class DateRangeIteratorTest {
 
   @Test
   public void testIterator() {
-    LocalDateTime endDate = LocalDateTime.of(2017, 1, 1, 0, 0, 0);
+    LocalDateTime endDate = new LocalDateTime(2017, 1, 1, 0, 0, 0);
     LocalDateTime startDate = endDate.minusHours(2);
     String datePattern = "HH/yyyy/MM/dd";
-    DateTimeFormatter format = DateTimeFormatter.ofPattern(datePattern);
+    DateTimeFormatter format = DateTimeFormat.forPattern(datePattern);
     TimeAwareRecursiveCopyableDataset.DateRangeIterator dateRangeIterator =
-        new TimeAwareRecursiveCopyableDataset.DateRangeIterator(startDate, endDate, datePattern);
+        new TimeAwareRecursiveCopyableDataset.DateRangeIterator(startDate, endDate, true);
     LocalDateTime dateTime = dateRangeIterator.next();
-    Assert.assertEquals(dateTime.format(format), "22/2016/12/31");
+    Assert.assertEquals(dateTime.toString(format), "22/2016/12/31");
     dateTime = dateRangeIterator.next();
-    Assert.assertEquals(dateTime.format(format), "23/2016/12/31");
+    Assert.assertEquals(dateTime.toString(format), "23/2016/12/31");
     dateTime = dateRangeIterator.next();
-    Assert.assertEquals(dateTime.format(format), "00/2017/01/01");
+    Assert.assertEquals(dateTime.toString(format), "00/2017/01/01");
     Assert.assertEquals(dateRangeIterator.hasNext(), false);
 
     datePattern = "yyyy/MM/dd";
-    format = DateTimeFormatter.ofPattern(datePattern);
+    format = DateTimeFormat.forPattern(datePattern);
     startDate = endDate.minusDays(1);
-    dateRangeIterator = new TimeAwareRecursiveCopyableDataset.DateRangeIterator(startDate, endDate, datePattern);
+    dateRangeIterator = new TimeAwareRecursiveCopyableDataset.DateRangeIterator(startDate, endDate, false);
     dateTime = dateRangeIterator.next();
-    Assert.assertEquals(dateTime.format(format), "2016/12/31");
+    Assert.assertEquals(dateTime.toString(format), "2016/12/31");
     dateTime = dateRangeIterator.next();
-    Assert.assertEquals(dateTime.format(format), "2017/01/01");
+    Assert.assertEquals(dateTime.toString(format), "2017/01/01");
     Assert.assertEquals(dateRangeIterator.hasNext(), false);
   }
 }

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/TimeAwareRecursiveCopyableDatasetTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/TimeAwareRecursiveCopyableDatasetTest.java
@@ -18,8 +18,6 @@
 package org.apache.gobblin.data.management.copy;
 
 import java.io.IOException;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
@@ -30,6 +28,12 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathFilter;
+import org.joda.time.LocalDateTime;
+import org.joda.time.Period;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.PeriodFormatter;
+import org.joda.time.format.PeriodFormatterBuilder;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -48,7 +52,9 @@ public class TimeAwareRecursiveCopyableDatasetTest {
   private static final String NUM_LOOKBACK_HOURS_STR = "4h";
   private static final Integer NUM_LOOKBACK_HOURS = 4;
   private static final Integer MAX_NUM_DAILY_DIRS = 4;
-  private static final Integer MAX_NUM_HOURLY_DIRS = 24;
+  private static final Integer MAX_NUM_HOURLY_DIRS = 48;
+  private static final String NUM_LOOKBACK_DAYS_HOURS_STR = "1d1h";
+  private static final Integer NUM_DAYS_HOURS_DIRS = 25;
 
   @BeforeClass
   public void setUp() throws IOException {
@@ -68,18 +74,20 @@ public class TimeAwareRecursiveCopyableDatasetTest {
       fs.delete(baseDir2, true);
     }
     fs.mkdirs(baseDir2);
+    PeriodFormatter formatter = new PeriodFormatterBuilder().appendDays().appendSuffix("d").appendHours().appendSuffix("h").toFormatter();
+    Period period = formatter.parsePeriod(NUM_LOOKBACK_DAYS_HOURS_STR);
   }
 
   @Test
   public void testGetFilesAtPath() throws IOException {
     String datePattern = "yyyy/MM/dd/HH";
-    DateTimeFormatter formatter = DateTimeFormatter.ofPattern(datePattern);
+    DateTimeFormatter formatter = DateTimeFormat.forPattern(datePattern);
 
     LocalDateTime endDate = LocalDateTime.now();
 
     Set<String> candidateFiles = new HashSet<>();
     for (int i = 0; i < MAX_NUM_HOURLY_DIRS; i++) {
-      String startDate = endDate.minusHours(i).format(formatter);
+      String startDate = endDate.minusHours(i).toString(formatter);
       Path subDirPath = new Path(baseDir1, new Path(startDate));
       fs.mkdirs(subDirPath);
       Path filePath = new Path(subDirPath, i + ".avro");
@@ -89,6 +97,7 @@ public class TimeAwareRecursiveCopyableDatasetTest {
       }
     }
 
+    //Lookback time = "4h"
     Properties properties = new Properties();
     properties.setProperty(TimeAwareRecursiveCopyableDataset.LOOKBACK_TIME_KEY, NUM_LOOKBACK_HOURS_STR);
     properties.setProperty(TimeAwareRecursiveCopyableDataset.DATE_PATTERN_KEY, "yyyy/MM/dd/HH");
@@ -104,13 +113,39 @@ public class TimeAwareRecursiveCopyableDatasetTest {
       Assert.assertTrue(candidateFiles.contains(PathUtils.getPathWithoutSchemeAndAuthority(fileStatus.getPath()).toString()));
     }
 
+    //Lookback time = "1d1h"
+    properties = new Properties();
+    properties.setProperty(TimeAwareRecursiveCopyableDataset.LOOKBACK_TIME_KEY, NUM_LOOKBACK_DAYS_HOURS_STR);
+    properties.setProperty(TimeAwareRecursiveCopyableDataset.DATE_PATTERN_KEY, "yyyy/MM/dd/HH");
+    dataset = new TimeAwareRecursiveCopyableDataset(fs, baseDir1, properties,
+        new Path("/tmp/src/*/hourly"));
+    fileStatusList = dataset.getFilesAtPath(fs, baseDir1, pathFilter);
+    candidateFiles = new HashSet<>();
+    datePattern = "yyyy/MM/dd/HH";
+    formatter = DateTimeFormat.forPattern(datePattern);
+
+    for (int i = 0; i < MAX_NUM_HOURLY_DIRS; i++) {
+      String startDate = endDate.minusHours(i).toString(formatter);
+      Path subDirPath = new Path(baseDir1, new Path(startDate));
+      Path filePath = new Path(subDirPath, i + ".avro");
+      if (i < NUM_DAYS_HOURS_DIRS + 1) {
+        candidateFiles.add(filePath.toString());
+      }
+    }
+
+    Assert.assertEquals(fileStatusList.size(), NUM_DAYS_HOURS_DIRS + 1);
+    for (FileStatus fileStatus: fileStatusList) {
+      Assert.assertTrue(candidateFiles.contains(PathUtils.getPathWithoutSchemeAndAuthority(fileStatus.getPath()).toString()));
+    }
+
+    //Lookback time = "2d"
     datePattern = "yyyy/MM/dd";
-    formatter = DateTimeFormatter.ofPattern(datePattern);
+    formatter = DateTimeFormat.forPattern(datePattern);
     endDate = LocalDateTime.now();
 
     candidateFiles = new HashSet<>();
     for (int i = 0; i < MAX_NUM_DAILY_DIRS; i++) {
-      String startDate = endDate.minusDays(i).format(formatter);
+      String startDate = endDate.minusDays(i).toString(formatter);
       Path subDirPath = new Path(baseDir2, new Path(startDate));
       fs.mkdirs(subDirPath);
       Path filePath = new Path(subDirPath, i + ".avro");
@@ -132,7 +167,6 @@ public class TimeAwareRecursiveCopyableDatasetTest {
     for (FileStatus fileStatus: fileStatusList) {
       Assert.assertTrue(candidateFiles.contains(PathUtils.getPathWithoutSchemeAndAuthority(fileStatus.getPath()).toString()));
     }
-
   }
 
   @AfterClass

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/TimeAwareRecursiveCopyableDatasetTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/TimeAwareRecursiveCopyableDatasetTest.java
@@ -39,6 +39,8 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import scala.sys.Prop;
+
 import org.apache.gobblin.util.PathUtils;
 import org.apache.gobblin.util.filters.HiddenFilter;
 
@@ -167,6 +169,17 @@ public class TimeAwareRecursiveCopyableDatasetTest {
     for (FileStatus fileStatus: fileStatusList) {
       Assert.assertTrue(candidateFiles.contains(PathUtils.getPathWithoutSchemeAndAuthority(fileStatus.getPath()).toString()));
     }
+  }
+
+  @Test (expectedExceptions = AssertionError.class)
+  public void testInstantiationError() {
+    //Daily directories, but look back time has days and hours. We should expect an assertion error.
+    Properties properties = new Properties();
+    properties.setProperty(TimeAwareRecursiveCopyableDataset.LOOKBACK_TIME_KEY, NUM_LOOKBACK_DAYS_HOURS_STR);
+    properties.setProperty(TimeAwareRecursiveCopyableDataset.DATE_PATTERN_KEY, "yyyy/MM/dd");
+
+    TimeAwareRecursiveCopyableDataset dataset = new TimeAwareRecursiveCopyableDataset(fs, baseDir2, properties,
+        new Path("/tmp/src/*/daily"));
   }
 
   @AfterClass

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/TimeAwareRecursiveCopyableDatasetTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/TimeAwareRecursiveCopyableDatasetTest.java
@@ -39,8 +39,6 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import scala.sys.Prop;
-
 import org.apache.gobblin.util.PathUtils;
 import org.apache.gobblin.util.filters.HiddenFilter;
 

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/TimeAwareRecursiveCopyableDatasetTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/TimeAwareRecursiveCopyableDatasetTest.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.data.management.copy;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Properties;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathFilter;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.gobblin.util.filters.HiddenFilter;
+
+@Slf4j
+public class TimeAwareRecursiveCopyableDatasetTest {
+  private FileSystem fs;
+  private Path baseDir1;
+  private Path baseDir2;
+
+  @BeforeClass
+  public void setUp() throws IOException {
+    this.fs = FileSystem.getLocal(new Configuration());
+
+    baseDir1 = new Path("/tmp/src/ds1/hourly");
+    if (fs.exists(baseDir1)) {
+      fs.delete(baseDir1, true);
+    }
+    fs.mkdirs(baseDir1);
+
+    baseDir2 = new Path("/tmp/src/ds1/daily");
+    if (fs.exists(baseDir2)) {
+      fs.delete(baseDir2, true);
+    }
+    fs.mkdirs(baseDir2);
+  }
+
+  @Test
+  public void testGetFilesAtPath() throws IOException {
+    String datePattern = "yyyy/MM/dd/HH";
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern(datePattern);
+
+    LocalDateTime endDate = LocalDateTime.now();
+
+    for (int i = 0; i < 24; i++) {
+      String startDate = endDate.minusHours(i).format(formatter);
+      Path subDirPath = new Path(baseDir1, new Path(startDate));
+      fs.mkdirs(subDirPath);
+      fs.create(new Path(subDirPath, i + ".avro"));
+    }
+
+    Properties properties = new Properties();
+    properties.setProperty(TimeAwareRecursiveCopyableDataset.LOOKBACK_TIME_KEY, "4h");
+    properties.setProperty(TimeAwareRecursiveCopyableDataset.DATE_PATTERN_KEY, "yyyy/MM/dd/HH");
+
+    PathFilter pathFilter = new HiddenFilter();
+    TimeAwareRecursiveCopyableDataset dataset = new TimeAwareRecursiveCopyableDataset(fs, baseDir1, properties,
+        new Path("/tmp/src/*/hourly"));
+    List<FileStatus> fileStatusList = dataset.getFilesAtPath(fs, baseDir1, pathFilter);
+
+    Assert.assertEquals(fileStatusList.size(), 5);
+
+    datePattern = "yyyy/MM/dd";
+    formatter = DateTimeFormatter.ofPattern(datePattern);
+    endDate = LocalDateTime.now();
+
+    for (int i = 0; i < 3; i++) {
+      String startDate = endDate.minusDays(i).format(formatter);
+      Path subDirPath = new Path(baseDir2, new Path(startDate));
+      fs.mkdirs(subDirPath);
+      fs.create(new Path(subDirPath, i + ".avro"));
+    }
+
+    properties = new Properties();
+    properties.setProperty(TimeAwareRecursiveCopyableDataset.LOOKBACK_TIME_KEY, "2d");
+    properties.setProperty(TimeAwareRecursiveCopyableDataset.DATE_PATTERN_KEY, "yyyy/MM/dd");
+
+    dataset = new TimeAwareRecursiveCopyableDataset(fs, baseDir2, properties,
+        new Path("/tmp/src/*/daily"));
+    fileStatusList = dataset.getFilesAtPath(fs, baseDir2, pathFilter);
+
+    Assert.assertEquals(fileStatusList.size(), 3);
+  }
+
+  @AfterClass
+  public void clean() throws IOException {
+    //Delete tmp directories
+    this.fs.delete(baseDir1, true);
+    this.fs.delete(baseDir2, true);
+  }
+}


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-573


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Add option to use finer level granularity at the hour level for TimeAwareDatasetfinder.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Added unit test TimeAwareRecursiveCopyableDatasetTest.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

