### PR TITLE
[GOBBLIN-574] Workaround Could not get unknown property 'mavenDeployer' issue.

### DIFF
--- a/gobblin-modules/gobblin-elasticsearch-deps/build.gradle
+++ b/gobblin-modules/gobblin-elasticsearch-deps/build.gradle
@@ -27,6 +27,7 @@ buildscript {
 
 apply plugin: 'com.github.johnrengelman.shadow'
 apply plugin: 'java'
+tasks.remove(tasks.uploadShadow)
 
 dependencies {
   compile "org.elasticsearch.client:transport:5.6.8"


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-574


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
   Workaround the issue by adding "tasks.remove(tasks.uploadShadow)"

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

