### PR TITLE
GOBBLIN-582: Allow file overwrite when copying from task staging to task output for FileAwareInputStreamDataWriter.

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
@@ -131,12 +131,14 @@ public class FileAwareInputStreamDataWriter extends InstrumentedDataWriter<FileA
 
     this.writerAttemptIdOptional = Optional.fromNullable(writerAttemptId);
 
-    String uri = this.state.getProp(
+    String uriStr = this.state.getProp(
         ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_FILE_SYSTEM_URI, numBranches, branchId),
         ConfigurationKeys.LOCAL_FS_URI);
 
-    this.fs = FileSystem.get(URI.create(uri), WriterUtils.getFsConfiguration(state));
-    this.fileContext = FileContext.getFileContext(URI.create(uri), WriterUtils.getFsConfiguration(state));
+    Configuration conf = WriterUtils.getFsConfiguration(state);
+    URI uri = URI.create(uriStr);
+    this.fs = FileSystem.get(uri, conf);
+    this.fileContext = FileContext.getFileContext(uri, conf);
 
     this.stagingDir = this.writerAttemptIdOptional.isPresent() ? WriterUtils
         .getWriterStagingDir(state, numBranches, branchId, this.writerAttemptIdOptional.get())


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-582


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Currently, we disallow overwriting contents of task output when copying contents from task staging dir to output dir.  This can be a problem when a task fails after the commit step is successful. Subsequent task attempts fail during the commit step as they attempt to copy data from staging to output dir, which results in a job failure. We provide an option to force overwriting contents of the task output directory for such scenarios and let the job succeed.



### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Ran a distcp job in test environment. 

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

