### PR TITLE
[GOBBLIN-585] Return expectedRecordCount of 1 for FileAwareInputStrea…

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/extractor/FileAwareInputStreamExtractor.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/extractor/FileAwareInputStreamExtractor.java
@@ -90,9 +90,12 @@ public class FileAwareInputStreamExtractor implements Extractor<String, FileAwar
     return null;
   }
 
+  /**
+   * Each {@link FileAwareInputStreamExtractor} processes exactly one record.
+   */
   @Override
   public long getExpectedRecordCount() {
-    return 0;
+    return 1;
   }
 
   @Override


### PR DESCRIPTION
…mExtractor

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-585


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
The expectedRecordCount() method currently returns 0. It should be 1 since each FileAwareInputStreamExtractor processes exactly one record.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Trivial

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

