### PR TITLE
[GOBBLIN-586] Added enhancement to apply retention on remote HDFS

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/retention/DatasetCleaner.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/retention/DatasetCleaner.java
@@ -42,6 +42,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 
 import org.apache.gobblin.util.AzkabanTags;
+import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.data.management.retention.dataset.CleanableDataset;
 import org.apache.gobblin.data.management.retention.profile.MultiCleanableDatasetFinder;
@@ -56,6 +57,7 @@ import org.apache.gobblin.metrics.event.EventSubmitter;
 import org.apache.gobblin.util.ExecutorsUtils;
 import org.apache.gobblin.util.RateControlledFileSystem;
 import org.apache.gobblin.util.executors.ScalingThreadPoolExecutor;
+import org.apache.gobblin.util.WriterUtils;
 
 
 /**
@@ -86,11 +88,14 @@ public class DatasetCleaner implements Instrumentable, Closeable {
 
   public DatasetCleaner(FileSystem fs, Properties props) throws IOException {
 
+    State state = new State(props);
+    FileSystem targetFs =
+        props.containsKey(ConfigurationKeys.WRITER_FILE_SYSTEM_URI) ? WriterUtils.getWriterFs(state) : fs;
     this.closer = Closer.create();
     try {
-      FileSystem optionalRateControlledFs = fs;
+      FileSystem optionalRateControlledFs = targetFs;
       if (props.contains(DATASET_CLEAN_HDFS_CALLS_PER_SECOND_LIMIT)) {
-        optionalRateControlledFs = this.closer.register(new RateControlledFileSystem(fs,
+        optionalRateControlledFs = this.closer.register(new RateControlledFileSystem(targetFs,
             Long.parseLong(props.getProperty(DATASET_CLEAN_HDFS_CALLS_PER_SECOND_LIMIT))));
         ((RateControlledFileSystem) optionalRateControlledFs).startRateControl();
       }
@@ -152,7 +157,6 @@ public class DatasetCleaner implements Instrumentable, Closeable {
           LOG.info("Successfully cleaned: " + dataset.datasetURN());
           Instrumented.markMeter(DatasetCleaner.this.datasetsCleanSuccessMeter);
         }
-
       });
     }
   }
@@ -196,8 +200,8 @@ public class DatasetCleaner implements Instrumentable, Closeable {
 
   @Override
   public void switchMetricContext(List<Tag<?>> tags) {
-    this.metricContext = this.closer
-        .register(Instrumented.newContextFromReferenceContext(this.metricContext, tags, Optional.<String> absent()));
+    this.metricContext = this.closer.register(
+        Instrumented.newContextFromReferenceContext(this.metricContext, tags, Optional.<String>absent()));
     this.regenerateMetrics();
   }
 

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/retention/profile/MultiDatasetFinder.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/retention/profile/MultiDatasetFinder.java
@@ -103,23 +103,13 @@ public abstract class MultiDatasetFinder implements DatasetsFinder<Dataset> {
           importedBys.addAll(client.getImportedBy(new URI(tag), false));
         }
 
-        FileSystem targetFs;
-        if(this.jobProps.containsKey(ConfigurationKeys.WRITER_FILE_SYSTEM_URI)) {
-          State state = new State(jobProps);
-          targetFs = WriterUtils.getWriterFs(state);
-        } else {
-          targetFs = fs;
-        }
-
-        log.info("Derived Target FS - {}", targetFs.getUri());
-
         for (URI importedBy : importedBys) {
           Config datasetClassConfig = client.getConfig(importedBy);
 
           try {
             this.datasetFinders.add((DatasetsFinder) GobblinConstructorUtils.invokeFirstConstructor(
-                Class.forName(datasetClassConfig.getString(datasetFinderClassKey())), ImmutableList.of(targetFs, jobProps,
-                    datasetClassConfig), ImmutableList.of(targetFs, jobProps)));
+                Class.forName(datasetClassConfig.getString(datasetFinderClassKey())), ImmutableList.of(fs, jobProps,
+                    datasetClassConfig), ImmutableList.of(fs, jobProps)));
             log.info(String.format("Instantiated datasetfinder %s for %s.",
                 datasetClassConfig.getString(datasetFinderClassKey()), importedBy));
           } catch (InstantiationException | IllegalAccessException | IllegalArgumentException
@@ -136,7 +126,7 @@ public abstract class MultiDatasetFinder implements DatasetsFinder<Dataset> {
       }
 
     } catch (IllegalArgumentException | VersionDoesNotExistException | ConfigStoreFactoryDoesNotExistsException
-        | ConfigStoreCreationException | URISyntaxException | IOException e) {
+        | ConfigStoreCreationException | URISyntaxException e) {
       Throwables.propagate(e);
     }
   }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/retention/profile/MultiDatasetFinder.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/retention/profile/MultiDatasetFinder.java
@@ -27,8 +27,6 @@ import java.util.Properties;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.commons.lang3.reflect.ConstructorUtils;
-import org.apache.gobblin.configuration.ConfigurationKeys;
-import org.apache.gobblin.util.WriterUtils;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
@@ -44,7 +42,6 @@ import org.apache.gobblin.config.client.api.ConfigStoreFactoryDoesNotExistsExcep
 import org.apache.gobblin.config.client.api.VersionStabilityPolicy;
 import org.apache.gobblin.config.store.api.ConfigStoreCreationException;
 import org.apache.gobblin.config.store.api.VersionDoesNotExistException;
-import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.dataset.Dataset;
 import org.apache.gobblin.dataset.DatasetsFinder;
 import org.apache.gobblin.util.reflection.GobblinConstructorUtils;

--- a/gobblin-modules/gobblin-azkaban/src/main/java/org/apache/gobblin/data/management/retention/DatasetCleanerJob.java
+++ b/gobblin-modules/gobblin-azkaban/src/main/java/org/apache/gobblin/data/management/retention/DatasetCleanerJob.java
@@ -19,9 +19,6 @@ package org.apache.gobblin.data.management.retention;
 
 import java.io.IOException;
 
-import org.apache.gobblin.configuration.ConfigurationKeys;
-import org.apache.gobblin.configuration.State;
-import org.apache.gobblin.util.WriterUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.util.Tool;

--- a/gobblin-modules/gobblin-azkaban/src/main/java/org/apache/gobblin/data/management/retention/DatasetCleanerJob.java
+++ b/gobblin-modules/gobblin-azkaban/src/main/java/org/apache/gobblin/data/management/retention/DatasetCleanerJob.java
@@ -52,17 +52,16 @@ public class DatasetCleanerJob extends AbstractJob implements Tool {
     super(id, Logger.getLogger(DatasetCleanerJob.class));
     this.conf = new Configuration();
     State state = new State(props.toProperties());
-    if(props.toProperties().containsKey(ConfigurationKeys.WRITER_FILE_SYSTEM_URI)) {
-      this.datasetCleaner = new DatasetCleaner(WriterUtils.getWriterFs(state), props.toProperties());
-    } else {
-      this.datasetCleaner = new DatasetCleaner(FileSystem.get(getConf()), props.toProperties());
-    }
+    this.datasetCleaner =
+        props.toProperties().containsKey(ConfigurationKeys.WRITER_FILE_SYSTEM_URI) ? new DatasetCleaner(
+            WriterUtils.getWriterFs(state), props.toProperties())
+            : new DatasetCleaner(FileSystem.get(getConf()), props.toProperties());
   }
 
   @Override
   public void run() throws Exception {
     if (this.datasetCleaner != null) {
-        this.datasetCleaner.clean();
+      this.datasetCleaner.clean();
     }
   }
 

--- a/gobblin-modules/gobblin-azkaban/src/main/java/org/apache/gobblin/data/management/retention/DatasetCleanerJob.java
+++ b/gobblin-modules/gobblin-azkaban/src/main/java/org/apache/gobblin/data/management/retention/DatasetCleanerJob.java
@@ -19,6 +19,9 @@ package org.apache.gobblin.data.management.retention;
 
 import java.io.IOException;
 
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.configuration.State;
+import org.apache.gobblin.util.WriterUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.util.Tool;
@@ -48,7 +51,12 @@ public class DatasetCleanerJob extends AbstractJob implements Tool {
   public DatasetCleanerJob(String id, Props props) throws IOException {
     super(id, Logger.getLogger(DatasetCleanerJob.class));
     this.conf = new Configuration();
-    this.datasetCleaner = new DatasetCleaner(FileSystem.get(getConf()), props.toProperties());
+    State state = new State(props.toProperties());
+    if(props.toProperties().containsKey(ConfigurationKeys.WRITER_FILE_SYSTEM_URI)) {
+      this.datasetCleaner = new DatasetCleaner(WriterUtils.getWriterFs(state), props.toProperties());
+    } else {
+      this.datasetCleaner = new DatasetCleaner(FileSystem.get(getConf()), props.toProperties());
+    }
   }
 
   @Override

--- a/gobblin-modules/gobblin-azkaban/src/main/java/org/apache/gobblin/data/management/retention/DatasetCleanerJob.java
+++ b/gobblin-modules/gobblin-azkaban/src/main/java/org/apache/gobblin/data/management/retention/DatasetCleanerJob.java
@@ -51,11 +51,7 @@ public class DatasetCleanerJob extends AbstractJob implements Tool {
   public DatasetCleanerJob(String id, Props props) throws IOException {
     super(id, Logger.getLogger(DatasetCleanerJob.class));
     this.conf = new Configuration();
-    State state = new State(props.toProperties());
-    this.datasetCleaner =
-        props.toProperties().containsKey(ConfigurationKeys.WRITER_FILE_SYSTEM_URI) ? new DatasetCleaner(
-            WriterUtils.getWriterFs(state), props.toProperties())
-            : new DatasetCleaner(FileSystem.get(getConf()), props.toProperties());
+    this.datasetCleaner = new DatasetCleaner(FileSystem.get(getConf()), props.toProperties());
   }
 
   @Override


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-586] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-586


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
       Initialized target file system using property **writer.fs.uri**, if **writer.fs.uri** does not exists, then default to local HDFS.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Performed integration testing in simulate mode.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

