### PR TITLE
[GOBBLIN-588] Remove final decoration to allow Azkaban password to be overwritten

### DIFF
--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/suite/IntegrationBasicSuite.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/suite/IntegrationBasicSuite.java
@@ -194,7 +194,7 @@ public class IntegrationBasicSuite {
   }
 
   public void waitForAndVerifyOutputFiles() throws Exception {
-    AssertWithBackoff asserter = AssertWithBackoff.create().logger(log).timeoutMs(60_000)
+    AssertWithBackoff asserter = AssertWithBackoff.create().logger(log).timeoutMs(120_000)
         .maxSleepMs(100).backoffFactor(1.5);
 
     asserter.assertTrue(this::hasExpectedFilesBeenCreated, "Waiting for job-completion");

--- a/gobblin-modules/gobblin-azkaban/src/main/java/org/apache/gobblin/service/modules/orchestration/AzkabanClient.java
+++ b/gobblin-modules/gobblin-azkaban/src/main/java/org/apache/gobblin/service/modules/orchestration/AzkabanClient.java
@@ -74,10 +74,10 @@ import lombok.Builder;
  */
 public class AzkabanClient implements Closeable {
   protected final String username;
-  protected final String password;
   protected final String url;
   protected final long sessionExpireInMin; // default value is 12h.
 
+  protected String password;
   protected String sessionId;
   protected long sessionCreationTime = 0;
   protected CloseableHttpClient client;

--- a/gradle/scripts/dependencyDefinitions.gradle
+++ b/gradle/scripts/dependencyDefinitions.gradle
@@ -62,7 +62,7 @@ ext.externalDependency = [
     "hadoopYarnMiniCluster": "org.apache.hadoop:hadoop-minicluster:" + hadoopVersion,
     "hadoopAnnotations": "org.apache.hadoop:hadoop-annotations:" + hadoopVersion,
     "hadoopAws": "org.apache.hadoop:hadoop-aws:2.6.0",
-    "helix": "org.apache.helix:helix-core:0.8.1",
+    "helix": "org.apache.helix:helix-core:0.8.2",
     "hiveCommon": "org.apache.hive:hive-common:" + hiveVersion,
     "hiveService": "org.apache.hive:hive-service:" + hiveVersion,
     "hiveJdbc": "org.apache.hive:hive-jdbc:" + hiveVersion,


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-588


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
    1)Bump the version of Helix.
    2)Remove the final decoration for AzkabanClient::password field to allow subclass to overwrite the value.
    3) Increase the cluster integration test timeout from 1min to 2min in case of the Travis is slow.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

