### PR TITLE
[GOBBLIN-589] Add more statistics to KafkaExtractor tracking event

### DIFF
--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaExtractor.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaExtractor.java
@@ -28,7 +28,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Stopwatch;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -71,6 +70,7 @@ public abstract class KafkaExtractor<S, D> extends EventBasedExtractor<S, D> {
   public static final String EXPECTED_HIGH_WATERMARK = "expectedHighWatermark";
   public static final String ELAPSED_TIME = "elapsedTime";
   public static final String PROCESSED_RECORD_COUNT = "processedRecordCount";
+  public static final String PARTITION_TOTAL_SIZE = "partitionTotalSize";
   public static final String AVG_RECORD_PULL_TIME = "avgRecordPullTime";
   public static final String READ_RECORD_TIME = "readRecordTime";
   public static final String DECODE_RECORD_TIME = "decodeRecordTime";
@@ -87,16 +87,17 @@ public abstract class KafkaExtractor<S, D> extends EventBasedExtractor<S, D> {
   protected final GobblinKafkaConsumerClient kafkaConsumerClient;
   private final ClassAliasResolver<GobblinKafkaConsumerClientFactory> kafkaConsumerClientResolver;
 
-  protected final Stopwatch stopwatch;
-
   protected final Map<KafkaPartition, Integer> decodingErrorCount;
   private final Map<KafkaPartition, Double> avgMillisPerRecord;
   private final Map<KafkaPartition, Long> avgRecordSizes;
   private final Map<KafkaPartition, Long> elapsedTime;
   private final Map<KafkaPartition, Long> processedRecordCount;
+  private final Map<KafkaPartition, Long> partitionTotalSize;
   private final Map<KafkaPartition, Long> decodeRecordTime;
   private final Map<KafkaPartition, Long> fetchMessageBufferTime;
   private final Map<KafkaPartition, Long> readRecordTime;
+  private final Map<KafkaPartition, Long> startFetchEpochTime;
+  private final Map<KafkaPartition, Long> stopFetchEpochTime;
 
   private final Set<Integer> errorPartitions;
   private int undecodableMessageCount = 0;
@@ -105,10 +106,10 @@ public abstract class KafkaExtractor<S, D> extends EventBasedExtractor<S, D> {
   private int currentPartitionIdx = INITIAL_PARTITION_IDX;
   private long currentPartitionRecordCount = 0;
   private long currentPartitionTotalSize = 0;
-  private long currentPartitionFetchDuration = 0;
   private long currentPartitionDecodeRecordTime = 0;
   private long currentPartitionFetchMessageBufferTime = 0;
   private long currentPartitionReadRecordTime = 0;
+  protected D currentPartitionLastSuccessfulRecord = null;
 
   public KafkaExtractor(WorkUnitState state) {
     super(state);
@@ -130,16 +131,17 @@ public abstract class KafkaExtractor<S, D> extends EventBasedExtractor<S, D> {
       throw new RuntimeException(e);
     }
 
-    this.stopwatch = Stopwatch.createUnstarted();
-
     this.decodingErrorCount = Maps.newHashMap();
     this.avgMillisPerRecord = Maps.newHashMapWithExpectedSize(this.partitions.size());
     this.avgRecordSizes = Maps.newHashMapWithExpectedSize(this.partitions.size());
     this.elapsedTime = Maps.newHashMapWithExpectedSize(this.partitions.size());
     this.processedRecordCount = Maps.newHashMapWithExpectedSize(this.partitions.size());
+    this.partitionTotalSize = Maps.newHashMapWithExpectedSize(this.partitions.size());
     this.decodeRecordTime = Maps.newHashMapWithExpectedSize(this.partitions.size());
     this.fetchMessageBufferTime = Maps.newHashMapWithExpectedSize(this.partitions.size());
     this.readRecordTime = Maps.newHashMapWithExpectedSize(this.partitions.size());
+    this.startFetchEpochTime = Maps.newHashMapWithExpectedSize(this.partitions.size());
+    this.stopFetchEpochTime= Maps.newHashMapWithExpectedSize(this.partitions.size());
 
     this.errorPartitions = Sets.newHashSet();
 
@@ -224,6 +226,7 @@ public abstract class KafkaExtractor<S, D> extends EventBasedExtractor<S, D> {
           this.currentPartitionRecordCount++;
           this.currentPartitionTotalSize += nextValidMessage.getValueSizeInBytes();
           this.currentPartitionReadRecordTime += System.nanoTime() - readStartTime;
+          this.currentPartitionLastSuccessfulRecord = record;
           return record;
         } catch (Throwable t) {
           this.errorPartitions.add(this.currentPartitionIdx);
@@ -268,10 +271,11 @@ public abstract class KafkaExtractor<S, D> extends EventBasedExtractor<S, D> {
       updateStatisticsForCurrentPartition();
       this.currentPartitionIdx++;
       this.currentPartitionRecordCount = 0;
-      this.currentPartitionFetchDuration = 0;
+      this.currentPartitionTotalSize = 0;
       this.currentPartitionDecodeRecordTime = 0;
       this.currentPartitionFetchMessageBufferTime = 0;
       this.currentPartitionReadRecordTime = 0;
+      this.currentPartitionLastSuccessfulRecord = null;
     }
 
     this.messageIterator = null;
@@ -281,29 +285,36 @@ public abstract class KafkaExtractor<S, D> extends EventBasedExtractor<S, D> {
           this.highWatermark.get(this.currentPartitionIdx) - this.nextWatermark.get(this.currentPartitionIdx)));
       switchMetricContextToCurrentPartition();
     }
-    this.stopwatch.start();
+
+    if (!allPartitionsFinished()) {
+      this.startFetchEpochTime.put(this.getCurrentPartition(), System.currentTimeMillis());
+    }
   }
 
-  private void updateStatisticsForCurrentPartition() {
-    this.stopwatch.stop();
+  protected void updateStatisticsForCurrentPartition() {
+    long stopFetchEpochTime = System.currentTimeMillis();
+
+    if (!allPartitionsFinished()) {
+      this.stopFetchEpochTime.put(this.getCurrentPartition(), stopFetchEpochTime);
+    }
 
     if (this.currentPartitionRecordCount != 0) {
-      this.currentPartitionFetchDuration = this.stopwatch.elapsed(TimeUnit.MILLISECONDS);
+      long currentPartitionFetchDuration =
+          stopFetchEpochTime - this.startFetchEpochTime.get(this.getCurrentPartition());
       double avgMillisForCurrentPartition =
-          (double) this.currentPartitionFetchDuration / (double) this.currentPartitionRecordCount;
+          (double) currentPartitionFetchDuration / (double) this.currentPartitionRecordCount;
       this.avgMillisPerRecord.put(this.getCurrentPartition(), avgMillisForCurrentPartition);
 
       long avgRecordSize = this.currentPartitionTotalSize / this.currentPartitionRecordCount;
       this.avgRecordSizes.put(this.getCurrentPartition(), avgRecordSize);
 
-      this.elapsedTime.put(this.getCurrentPartition(), this.currentPartitionFetchDuration);
+      this.elapsedTime.put(this.getCurrentPartition(), currentPartitionFetchDuration);
       this.processedRecordCount.put(this.getCurrentPartition(), this.currentPartitionRecordCount);
+      this.partitionTotalSize.put(this.getCurrentPartition(), this.currentPartitionTotalSize);
       this.decodeRecordTime.put(this.getCurrentPartition(), this.currentPartitionDecodeRecordTime);
       this.fetchMessageBufferTime.put(this.getCurrentPartition(), this.currentPartitionFetchMessageBufferTime);
       this.readRecordTime.put(this.getCurrentPartition(), this.currentPartitionReadRecordTime);
     }
-
-    this.stopwatch.reset();
   }
 
   private void switchMetricContextToCurrentPartition() {
@@ -367,64 +378,12 @@ public abstract class KafkaExtractor<S, D> extends EventBasedExtractor<S, D> {
     this.workUnitState.setProp(ConfigurationKeys.ERROR_PARTITION_COUNT, this.errorPartitions.size());
     this.workUnitState.setProp(ConfigurationKeys.ERROR_MESSAGE_UNDECODABLE_COUNT, this.undecodableMessageCount);
 
-    // Commit actual high watermark for each partition
     for (int i = 0; i < this.partitions.size(); i++) {
       LOG.info(String.format("Actual high watermark for partition %s=%d, expected=%d", this.partitions.get(i),
           this.nextWatermark.get(i), this.highWatermark.get(i)));
-
-      Map<String, String> tagsForPartition = Maps.newHashMap();
-      KafkaPartition partition = this.partitions.get(i);
-      tagsForPartition.put(TOPIC, partition.getTopicName());
-      tagsForPartition.put(PARTITION, Integer.toString(partition.getId()));
-      tagsForPartition.put(LOW_WATERMARK, Long.toString(this.lowWatermark.get(i)));
-      tagsForPartition.put(ACTUAL_HIGH_WATERMARK, Long.toString(this.nextWatermark.get(i)));
-      // These are used to compute the load factor,
-      // gobblin consumption rate relative to the kafka production rate.
-      // The gobblin rate is computed as (processed record count/elapsed time)
-      // The kafka rate is computed as (expected high watermark - previous latest offset) /
-      // (current offset fetch epoch time - previous offset fetch epoch time).
-      tagsForPartition.put(EXPECTED_HIGH_WATERMARK, Long.toString(this.highWatermark.get(i)));
-      tagsForPartition.put(KafkaSource.PREVIOUS_OFFSET_FETCH_EPOCH_TIME,
-          this.workUnitState.getProp(KafkaUtils.getPartitionPropName(KafkaSource.PREVIOUS_OFFSET_FETCH_EPOCH_TIME,
-              i)));
-      tagsForPartition.put(KafkaSource.OFFSET_FETCH_EPOCH_TIME,
-          this.workUnitState.getProp(KafkaUtils.getPartitionPropName(KafkaSource.OFFSET_FETCH_EPOCH_TIME, i)));
-      tagsForPartition.put(KafkaSource.PREVIOUS_LATEST_OFFSET,
-          this.workUnitState.getProp(KafkaUtils.getPartitionPropName(KafkaSource.PREVIOUS_LATEST_OFFSET, i)));
-
-      if (this.processedRecordCount.containsKey(partition)) {
-        tagsForPartition.put(PROCESSED_RECORD_COUNT, Long.toString(this.processedRecordCount.get(partition)));
-        tagsForPartition.put(ELAPSED_TIME, Long.toString(this.elapsedTime.get(partition)));
-        tagsForPartition.put(DECODE_RECORD_TIME, Long.toString(TimeUnit.NANOSECONDS.toMillis(
-            this.decodeRecordTime.get(partition))));
-        tagsForPartition.put(FETCH_MESSAGE_BUFFER_TIME, Long.toString(TimeUnit.NANOSECONDS.toMillis(
-            this.fetchMessageBufferTime.get(partition))));
-        tagsForPartition.put(READ_RECORD_TIME, Long.toString(TimeUnit.NANOSECONDS.toMillis(
-            this.readRecordTime.get(partition))));
-      } else {
-        tagsForPartition.put(PROCESSED_RECORD_COUNT, "0");
-        tagsForPartition.put(ELAPSED_TIME, "0");
-        tagsForPartition.put(DECODE_RECORD_TIME, "0");
-        tagsForPartition.put(FETCH_MESSAGE_BUFFER_TIME, "0");
-        tagsForPartition.put(READ_RECORD_TIME, "0");
-      }
-
-      tagsForPartitionsMap.put(partition, tagsForPartition);
+      tagsForPartitionsMap.put(this.partitions.get(i), createTagsForPartition(i));
     }
     this.workUnitState.setActualHighWatermark(this.nextWatermark);
-
-    // Commit avg time to pull a record for each partition
-    for (KafkaPartition partition : this.partitions) {
-      if (this.avgMillisPerRecord.containsKey(partition)) {
-        double avgMillis = this.avgMillisPerRecord.get(partition);
-        LOG.info(String.format("Avg time to pull a record for partition %s = %f milliseconds", partition, avgMillis));
-        KafkaUtils.setPartitionAvgRecordMillis(this.workUnitState, partition, avgMillis);
-        tagsForPartitionsMap.get(partition).put(AVG_RECORD_PULL_TIME, Double.toString(avgMillis));
-      } else {
-        LOG.info(String.format("Avg time to pull a record for partition %s not recorded", partition));
-        tagsForPartitionsMap.get(partition).put(AVG_RECORD_PULL_TIME, Double.toString(-1));
-      }
-    }
 
     if (isInstrumentationEnabled()) {
       for (Map.Entry<KafkaPartition, Map<String, String>> eventTags : tagsForPartitionsMap.entrySet()) {
@@ -434,6 +393,84 @@ public abstract class KafkaExtractor<S, D> extends EventBasedExtractor<S, D> {
     }
 
     this.closer.close();
+  }
+
+  protected Map<String, String> createTagsForPartition(int partitionId) {
+    Map<String, String> tagsForPartition = Maps.newHashMap();
+    KafkaPartition partition = this.partitions.get(partitionId);
+
+    tagsForPartition.put(TOPIC, partition.getTopicName());
+    tagsForPartition.put(PARTITION, Integer.toString(partition.getId()));
+    tagsForPartition.put(LOW_WATERMARK, Long.toString(this.lowWatermark.get(partitionId)));
+    tagsForPartition.put(ACTUAL_HIGH_WATERMARK, Long.toString(this.nextWatermark.get(partitionId)));
+
+    // These are used to compute the load factor,
+    // gobblin consumption rate relative to the kafka production rate.
+    // The gobblin rate is computed as (processed record count/elapsed time)
+    // The kafka rate is computed as (expected high watermark - previous latest offset) /
+    // (current offset fetch epoch time - previous offset fetch epoch time).
+    tagsForPartition.put(EXPECTED_HIGH_WATERMARK, Long.toString(this.highWatermark.get(partitionId)));
+    tagsForPartition.put(KafkaSource.PREVIOUS_OFFSET_FETCH_EPOCH_TIME,
+        Long.toString(KafkaUtils.getPropAsLongFromSingleOrMultiWorkUnitState(this.workUnitState,
+            KafkaSource.PREVIOUS_OFFSET_FETCH_EPOCH_TIME, partitionId)));
+    tagsForPartition.put(KafkaSource.OFFSET_FETCH_EPOCH_TIME,
+        Long.toString(KafkaUtils.getPropAsLongFromSingleOrMultiWorkUnitState(this.workUnitState,
+            KafkaSource.OFFSET_FETCH_EPOCH_TIME, partitionId)));
+    tagsForPartition.put(KafkaSource.PREVIOUS_LATEST_OFFSET,
+        Long.toString(KafkaUtils.getPropAsLongFromSingleOrMultiWorkUnitState(this.workUnitState,
+            KafkaSource.PREVIOUS_LATEST_OFFSET, partitionId)));
+
+    tagsForPartition.put(KafkaSource.PREVIOUS_LOW_WATERMARK,
+        Long.toString(KafkaUtils.getPropAsLongFromSingleOrMultiWorkUnitState(this.workUnitState,
+            KafkaSource.PREVIOUS_LOW_WATERMARK, partitionId)));
+    tagsForPartition.put(KafkaSource.PREVIOUS_HIGH_WATERMARK,
+        Long.toString(KafkaUtils.getPropAsLongFromSingleOrMultiWorkUnitState(this.workUnitState,
+            KafkaSource.PREVIOUS_HIGH_WATERMARK, partitionId)));
+    tagsForPartition.put(KafkaSource.PREVIOUS_START_FETCH_EPOCH_TIME,
+        Long.toString(KafkaUtils.getPropAsLongFromSingleOrMultiWorkUnitState(this.workUnitState,
+            KafkaSource.PREVIOUS_START_FETCH_EPOCH_TIME, partitionId)));
+    tagsForPartition.put(KafkaSource.PREVIOUS_STOP_FETCH_EPOCH_TIME,
+        Long.toString(KafkaUtils.getPropAsLongFromSingleOrMultiWorkUnitState(this.workUnitState,
+            KafkaSource.PREVIOUS_STOP_FETCH_EPOCH_TIME, partitionId)));
+
+    tagsForPartition.put(KafkaSource.START_FETCH_EPOCH_TIME, Long.toString(this.startFetchEpochTime.get(partition)));
+    tagsForPartition.put(KafkaSource.STOP_FETCH_EPOCH_TIME, Long.toString(this.stopFetchEpochTime.get(partition)));
+    this.workUnitState.setProp(KafkaUtils.getPartitionPropName(KafkaSource.START_FETCH_EPOCH_TIME, partitionId),
+        Long.toString(this.startFetchEpochTime.get(partition)));
+    this.workUnitState.setProp(KafkaUtils.getPartitionPropName(KafkaSource.STOP_FETCH_EPOCH_TIME, partitionId),
+        Long.toString(this.stopFetchEpochTime.get(partition)));
+
+    if (this.processedRecordCount.containsKey(partition)) {
+      tagsForPartition.put(PROCESSED_RECORD_COUNT, Long.toString(this.processedRecordCount.get(partition)));
+      tagsForPartition.put(PARTITION_TOTAL_SIZE, Long.toString(this.partitionTotalSize.get(partition)));
+      tagsForPartition.put(ELAPSED_TIME, Long.toString(this.elapsedTime.get(partition)));
+      tagsForPartition.put(DECODE_RECORD_TIME, Long.toString(TimeUnit.NANOSECONDS.toMillis(
+          this.decodeRecordTime.get(partition))));
+      tagsForPartition.put(FETCH_MESSAGE_BUFFER_TIME, Long.toString(TimeUnit.NANOSECONDS.toMillis(
+          this.fetchMessageBufferTime.get(partition))));
+      tagsForPartition.put(READ_RECORD_TIME, Long.toString(TimeUnit.NANOSECONDS.toMillis(
+          this.readRecordTime.get(partition))));
+    } else {
+      tagsForPartition.put(PROCESSED_RECORD_COUNT, "0");
+      tagsForPartition.put(PARTITION_TOTAL_SIZE, "0");
+      tagsForPartition.put(ELAPSED_TIME, "0");
+      tagsForPartition.put(DECODE_RECORD_TIME, "0");
+      tagsForPartition.put(FETCH_MESSAGE_BUFFER_TIME, "0");
+      tagsForPartition.put(READ_RECORD_TIME, "0");
+    }
+
+    // Commit avg time to pull a record for each partition
+    if (this.avgMillisPerRecord.containsKey(partition)) {
+      double avgMillis = this.avgMillisPerRecord.get(partition);
+      LOG.info(String.format("Avg time to pull a record for partition %s = %f milliseconds", partition, avgMillis));
+      KafkaUtils.setPartitionAvgRecordMillis(this.workUnitState, partition, avgMillis);
+      tagsForPartition.put(AVG_RECORD_PULL_TIME, Double.toString(avgMillis));
+    } else {
+      LOG.info(String.format("Avg time to pull a record for partition %s not recorded", partition));
+      tagsForPartition.put(AVG_RECORD_PULL_TIME, Double.toString(-1));
+    }
+
+    return tagsForPartition;
   }
 
   @Deprecated

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaUtils.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaUtils.java
@@ -19,6 +19,7 @@ package org.apache.gobblin.source.extractor.extract.kafka;
 
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.State;
+import org.apache.gobblin.configuration.WorkUnitState;
 
 import java.util.List;
 
@@ -167,5 +168,18 @@ public class KafkaUtils {
     state.setProp(
         getPartitionPropName(partition.getTopicName(), partition.getId()) + "." + KafkaSource.AVG_RECORD_MILLIS,
         millis);
+  }
+
+  /**
+   * Get a property as long from a work unit that may or may not be a multiworkunit.
+   * This method is needed because the SingleLevelWorkUnitPacker does not squeeze work units
+   * into a multiworkunit, and thus does not append the partitionId to property keys, while
+   * the BiLevelWorkUnitPacker does.
+   * Return 0 as default if key not found in either form.
+   */
+  public static long getPropAsLongFromSingleOrMultiWorkUnitState(WorkUnitState workUnitState,
+                                                                 String key, int partitionId) {
+    return Long.parseLong(workUnitState.contains(key) ? workUnitState.getProp(key)
+        : workUnitState.getProp(KafkaUtils.getPartitionPropName(key, partitionId), "0"));
   }
 }

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaWorkUnitPacker.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaWorkUnitPacker.java
@@ -225,6 +225,14 @@ public abstract class KafkaWorkUnitPacker {
     // (current latest offset - previous latest offset)/(current epoch time - previous epoch time).
     int index = 0;
     for (WorkUnit wu : multiWorkUnit.getWorkUnits()) {
+      workUnit.setProp(KafkaUtils.getPartitionPropName(KafkaSource.PREVIOUS_START_FETCH_EPOCH_TIME, index),
+          wu.getProp(KafkaSource.PREVIOUS_START_FETCH_EPOCH_TIME));
+      workUnit.setProp(KafkaUtils.getPartitionPropName(KafkaSource.PREVIOUS_STOP_FETCH_EPOCH_TIME, index),
+          wu.getProp(KafkaSource.PREVIOUS_STOP_FETCH_EPOCH_TIME));
+      workUnit.setProp(KafkaUtils.getPartitionPropName(KafkaSource.PREVIOUS_LOW_WATERMARK, index),
+          wu.getProp(KafkaSource.PREVIOUS_LOW_WATERMARK));
+      workUnit.setProp(KafkaUtils.getPartitionPropName(KafkaSource.PREVIOUS_HIGH_WATERMARK, index),
+          wu.getProp(KafkaSource.PREVIOUS_HIGH_WATERMARK));
       workUnit.setProp(KafkaUtils.getPartitionPropName(KafkaSource.PREVIOUS_OFFSET_FETCH_EPOCH_TIME, index),
           wu.getProp(KafkaSource.PREVIOUS_OFFSET_FETCH_EPOCH_TIME));
       workUnit.setProp(KafkaUtils.getPartitionPropName(KafkaSource.OFFSET_FETCH_EPOCH_TIME, index),
@@ -233,6 +241,10 @@ public abstract class KafkaWorkUnitPacker {
           wu.getProp(KafkaSource.PREVIOUS_LATEST_OFFSET));
       index++;
     }
+    workUnit.removeProp(KafkaSource.PREVIOUS_START_FETCH_EPOCH_TIME);
+    workUnit.removeProp(KafkaSource.PREVIOUS_STOP_FETCH_EPOCH_TIME);
+    workUnit.removeProp(KafkaSource.PREVIOUS_LOW_WATERMARK);
+    workUnit.removeProp(KafkaSource.PREVIOUS_HIGH_WATERMARK);
     workUnit.removeProp(KafkaSource.PREVIOUS_OFFSET_FETCH_EPOCH_TIME);
     workUnit.removeProp(KafkaSource.OFFSET_FETCH_EPOCH_TIME);
     workUnit.removeProp(KafkaSource.PREVIOUS_LATEST_OFFSET);


### PR DESCRIPTION
@htran1 

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-589

### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
- Added emitting start/stop fetch epoch time statistics as well as partition total size.
- Added lagging and emitting of fetch epoch times and watermark statistics from previous run.
- Made changes to allow subclasses of KafkaExtractor to emit statistics based on the lastSuccessfulRecord.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
- Tested manually using a simple Gobblin Kafka flow, checking that metrics were emitted correctly in tracking event message.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"
