### PR TITLE
[GOBBLIN-592] Allow disabling file-based failure reporting through config

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -658,6 +658,8 @@ public class ConfigurationKeys {
   public static final String METRICS_LOG_DIR_KEY = METRICS_CONFIGURATIONS_PREFIX + "log.dir";
   public static final String METRICS_FILE_SUFFIX = METRICS_CONFIGURATIONS_PREFIX + "reporting.file.suffix";
   public static final String DEFAULT_METRICS_FILE_SUFFIX = "";
+  public static final String FAILURE_REPORTING_FILE_ENABLED_KEY = "failure.reporting.file.enabled";
+  public static final String DEFAULT_FAILURE_REPORTING_FILE_ENABLED = Boolean.toString(true);
   public static final String FAILURE_LOG_DIR_KEY =  "failure.log.dir";
 
   // JMX-based reporting

--- a/gobblin-metrics-libs/gobblin-metrics/src/main/java/org/apache/gobblin/metrics/GobblinMetrics.java
+++ b/gobblin-metrics-libs/gobblin-metrics/src/main/java/org/apache/gobblin/metrics/GobblinMetrics.java
@@ -524,6 +524,12 @@ public class GobblinMetrics {
   }
 
   private void buildFileFailureEventReporter(Properties properties) {
+    if (!Boolean.valueOf(properties.getProperty(ConfigurationKeys.FAILURE_REPORTING_FILE_ENABLED_KEY,
+        ConfigurationKeys.DEFAULT_FAILURE_REPORTING_FILE_ENABLED))) {
+      return;
+    }
+    LOGGER.info("Reporting failure to log files");
+
     if (!properties.containsKey(ConfigurationKeys.FAILURE_LOG_DIR_KEY)) {
       LOGGER.error(
           "Not reporting failure to log files because " + ConfigurationKeys.FAILURE_LOG_DIR_KEY + " is undefined");


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-592


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Gobblin logs an ERROR when `failure.log.dir` is not defined. We want a way to suppress this since it is unnecessary noise for our users. I added a configuration key which can be used to disable the file-based failure reporter. Similar configuration keys exist for other reporters.  

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Do not have an easy way to write unit tests as the only side effect of the configuration key is visible in `GobblinMetrics.codahaleScheduledReporters` which is private

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

