### PR TITLE
[GOBBLIN-598] Add DistcpFileSplitter to allow for block level distcp

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/CopySource.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/CopySource.java
@@ -55,6 +55,7 @@ import org.apache.gobblin.data.management.copy.extractor.EmptyExtractor;
 import org.apache.gobblin.data.management.copy.extractor.FileAwareInputStreamExtractor;
 import org.apache.gobblin.data.management.copy.prioritization.FileSetComparator;
 import org.apache.gobblin.data.management.copy.publisher.CopyEventSubmitterHelper;
+import org.apache.gobblin.data.management.copy.splitter.DistcpFileSplitter;
 import org.apache.gobblin.data.management.copy.watermark.CopyableFileWatermarkGenerator;
 import org.apache.gobblin.data.management.copy.watermark.CopyableFileWatermarkHelper;
 import org.apache.gobblin.data.management.dataset.DatasetUtils;
@@ -217,7 +218,7 @@ public class CopySource extends AbstractSource<String, FileAwareInputStream> {
               try {
                 return GobblinConstructorUtils.<FileSetWorkUnitGenerator>invokeLongestConstructor(
                     new ClassAliasResolver(FileSetWorkUnitGenerator.class).resolveClass(filesetWuGeneratorAlias),
-                    input.getDataset(), input, state, workUnitsMap, watermarkGenerator, minWorkUnitWeight, lineageInfo);
+                    input.getDataset(), input, state, targetFs, workUnitsMap, watermarkGenerator, minWorkUnitWeight, lineageInfo);
               } catch (Exception e) {
                 throw new RuntimeException("Cannot create workunits generator", e);
               }
@@ -335,6 +336,7 @@ public class CopySource extends AbstractSource<String, FileAwareInputStream> {
     protected final CopyableDatasetBase copyableDataset;
     protected final FileSet<CopyEntity> fileSet;
     protected final State state;
+    protected final FileSystem targetFs;
     protected final SetMultimap<FileSet<CopyEntity>, WorkUnit> workUnitList;
     protected final Optional<CopyableFileWatermarkGenerator> watermarkGenerator;
     protected final long minWorkUnitWeight;
@@ -365,7 +367,11 @@ public class CopySource extends AbstractSource<String, FileAwareInputStream> {
           setWorkUnitWeight(workUnit, copyEntity, minWorkUnitWeight);
           setWorkUnitWatermark(workUnit, watermarkGenerator, copyEntity);
           computeAndSetWorkUnitGuid(workUnit);
-          workUnitsForPartition.add(workUnit);
+          if (copyEntity instanceof CopyableFile && DistcpFileSplitter.allowSplit(this.state)) {
+            workUnitsForPartition.addAll(DistcpFileSplitter.splitFile((CopyableFile) copyEntity, workUnit, this.targetFs));
+          } else {
+            workUnitsForPartition.add(workUnit);
+          }
           addLineageInfo(copyEntity, workUnit);
         }
 

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/CopySource.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/CopySource.java
@@ -368,7 +368,7 @@ public class CopySource extends AbstractSource<String, FileAwareInputStream> {
           setWorkUnitWatermark(workUnit, watermarkGenerator, copyEntity);
           computeAndSetWorkUnitGuid(workUnit);
           addLineageInfo(copyEntity, workUnit);
-          if (copyEntity instanceof CopyableFile && DistcpFileSplitter.allowSplit(this.state)) {
+          if (copyEntity instanceof CopyableFile && DistcpFileSplitter.allowSplit(this.state, this.targetFs)) {
             workUnitsForPartition.addAll(DistcpFileSplitter.splitFile((CopyableFile) copyEntity, workUnit, this.targetFs));
           } else {
             workUnitsForPartition.add(workUnit);

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/CopySource.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/CopySource.java
@@ -367,12 +367,12 @@ public class CopySource extends AbstractSource<String, FileAwareInputStream> {
           setWorkUnitWeight(workUnit, copyEntity, minWorkUnitWeight);
           setWorkUnitWatermark(workUnit, watermarkGenerator, copyEntity);
           computeAndSetWorkUnitGuid(workUnit);
+          addLineageInfo(copyEntity, workUnit);
           if (copyEntity instanceof CopyableFile && DistcpFileSplitter.allowSplit(this.state)) {
             workUnitsForPartition.addAll(DistcpFileSplitter.splitFile((CopyableFile) copyEntity, workUnit, this.targetFs));
           } else {
             workUnitsForPartition.add(workUnit);
           }
-          addLineageInfo(copyEntity, workUnit);
         }
 
         this.workUnitList.putAll(this.fileSet, workUnitsForPartition);

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/CopyableFile.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/CopyableFile.java
@@ -352,6 +352,22 @@ public class CopyableFile extends CopyEntity implements File {
   }
 
   /**
+   * @return desired block size for destination file.
+   */
+  public long getBlockSize(FileSystem targetFs) {
+    return getPreserve().preserve(PreserveAttributes.Option.BLOCK_SIZE) ?
+        getOrigin().getBlockSize() : targetFs.getDefaultBlockSize(this.destination);
+  }
+
+  /**
+   * @return desired replication for destination file.
+   */
+  public short getReplication(FileSystem targetFs) {
+    return getPreserve().preserve(PreserveAttributes.Option.REPLICATION) ?
+        getOrigin().getReplication() : targetFs.getDefaultReplication(this.destination);
+  }
+
+  /**
    * Generates a replicable guid to uniquely identify the origin of this {@link CopyableFile}.
    * @return a guid uniquely identifying the origin file.
    */

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/FileAwareInputStream.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/FileAwareInputStream.java
@@ -31,6 +31,9 @@ import org.apache.gobblin.data.management.copy.splitter.DistcpFileSplitter;
 /**
  * A wrapper to {@link InputStream} that represents an entity to be copied. The enclosed {@link CopyableFile} instance
  * contains file Metadata like permission, destination path etc. required by the writers and converters.
+ * The enclosed {@link DistcpFileSplitter.Split} object indicates whether the {@link InputStream} to be copied is a
+ * block of the {@link CopyableFile} or not. If it is present, the {@link InputStream} should already be at the start
+ * position of the specified split/block.
  */
 @Getter
 public class FileAwareInputStream {

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/FileAwareInputStream.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/FileAwareInputStream.java
@@ -19,19 +19,33 @@ package org.apache.gobblin.data.management.copy;
 
 import java.io.InputStream;
 
-import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NonNull;
 import lombok.Getter;
+
+import com.google.common.base.Optional;
+
+import org.apache.gobblin.data.management.copy.splitter.DistcpFileSplitter;
+
 
 /**
  * A wrapper to {@link InputStream} that represents an entity to be copied. The enclosed {@link CopyableFile} instance
  * contains file Metadata like permission, destination path etc. required by the writers and converters.
  */
-@AllArgsConstructor
 @Getter
 public class FileAwareInputStream {
 
   private CopyableFile file;
   private InputStream inputStream;
+  private Optional<DistcpFileSplitter.Split> split = Optional.absent();
+
+  @Builder(toBuilder = true)
+  public FileAwareInputStream(@NonNull CopyableFile file, @NonNull InputStream inputStream,
+      Optional<DistcpFileSplitter.Split> split) {
+    this.file = file;
+    this.inputStream = inputStream;
+    this.split = split == null ? Optional.<DistcpFileSplitter.Split>absent() : split;
+  }
 
   @Override
   public String toString() {

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/converter/DistcpConverter.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/converter/DistcpConverter.java
@@ -85,7 +85,7 @@ public abstract class DistcpConverter extends Converter<String, String, FileAwar
     modifyExtensionAtDestination(fileAwareInputStream.getFile());
     try {
       InputStream newInputStream = inputStreamTransformation().apply(fileAwareInputStream.getInputStream());
-      return new SingleRecordIterable<>(new FileAwareInputStream(fileAwareInputStream.getFile(), newInputStream));
+      return new SingleRecordIterable<>(fileAwareInputStream.toBuilder().inputStream(newInputStream).build());
     } catch (RuntimeException re) {
       throw new DataConversionException(re);
     }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/extractor/FileAwareInputStreamExtractor.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/extractor/FileAwareInputStreamExtractor.java
@@ -17,20 +17,23 @@
 
 package org.apache.gobblin.data.management.copy.extractor;
 
+import com.google.common.base.Optional;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileSystem;
+
 import org.apache.gobblin.configuration.WorkUnitState;
 import org.apache.gobblin.data.management.copy.CopyableFile;
 import org.apache.gobblin.data.management.copy.FileAwareInputStream;
+import org.apache.gobblin.data.management.copy.splitter.DistcpFileSplitter;
 import org.apache.gobblin.source.extractor.DataRecordException;
 import org.apache.gobblin.source.extractor.Extractor;
 import org.apache.gobblin.util.HadoopUtils;
 import org.apache.gobblin.util.io.EmptyInputStream;
 import org.apache.gobblin.util.io.MeteredInputStream;
-
-import java.io.IOException;
-import java.io.InputStream;
-
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileSystem;
 
 
 /**
@@ -81,11 +84,21 @@ public class FileAwareInputStreamExtractor implements Extractor<String, FileAwar
           this.state == null ? HadoopUtils.newConfiguration() : HadoopUtils.getConfFromState(this.state);
       FileSystem fsFromFile = this.file.getOrigin().getPath().getFileSystem(conf);
       this.recordRead = true;
+      FileAwareInputStream.FileAwareInputStreamBuilder builder = FileAwareInputStream.builder().file(this.file);
       if (this.file.getFileStatus().isDirectory()) {
-        return new FileAwareInputStream(this.file, EmptyInputStream.instance);
+        return builder.inputStream(EmptyInputStream.instance).build();
       }
-      return new FileAwareInputStream(this.file,
-          MeteredInputStream.builder().in(fsFromFile.open(this.file.getFileStatus().getPath())).build());
+
+      FSDataInputStream dataInputStream = fsFromFile.open(this.file.getFileStatus().getPath());
+      if (this.state != null && DistcpFileSplitter.isSplitWorkUnit(this.state)) {
+        Optional<DistcpFileSplitter.Split> split = DistcpFileSplitter.getSplit(this.state);
+        builder.split(split);
+        if (split.isPresent()) {
+          dataInputStream.seek(split.get().getLowPosition());
+        }
+      }
+      builder.inputStream(MeteredInputStream.builder().in(dataInputStream).build());
+      return builder.build();
     }
     return null;
   }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/splitter/DistcpFileSplitter.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/splitter/DistcpFileSplitter.java
@@ -161,6 +161,8 @@ public class DistcpFileSplitter {
       WorkUnitState newWorkUnit = mergeSplits(fs, file, splitWorkUnitsMap.get(file), parentPath);
 
       for (WorkUnitState wu : splitWorkUnitsMap.get(file)) {
+        // Set to committed so that task states will not fail
+        wu.setWorkingState(WorkUnitState.WorkingState.COMMITTED);
         workUnits.remove(wu);
       }
       workUnits.add(newWorkUnit);

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/splitter/DistcpFileSplitter.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/splitter/DistcpFileSplitter.java
@@ -1,0 +1,225 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.data.management.copy.splitter;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Set;
+
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ListMultimap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.google.gson.Gson;
+
+import org.apache.gobblin.configuration.State;
+import org.apache.gobblin.configuration.WorkUnitState;
+import org.apache.gobblin.data.management.copy.CopyableFile;
+import org.apache.gobblin.data.management.copy.CopyConfiguration;
+import org.apache.gobblin.data.management.copy.CopyEntity;
+import org.apache.gobblin.data.management.copy.CopySource;
+import org.apache.gobblin.data.management.copy.writer.FileAwareInputStreamDataWriter;
+import org.apache.gobblin.source.workunit.WorkUnit;
+import org.apache.gobblin.util.guid.Guid;
+
+
+/**
+ * Helper class for splitting files for distcp.
+ */
+@Slf4j
+public class DistcpFileSplitter {
+
+  public static final String SPLIT_ENABLED = CopyConfiguration.COPY_PREFIX + ".split.enabled";
+  public static final String MAX_SPLIT_SIZE_KEY = CopyConfiguration.COPY_PREFIX + ".file.max.split.size";
+
+  public static final long DEFAULT_MAX_SPLIT_SIZE = Long.MAX_VALUE;
+  public static final Set<String> KNOWN_SCHEMES_SUPPORTING_CONCAT = Sets.newHashSet("hdfs");
+
+  /**
+   * A split for a distcp file. Represents a section of a file, aligned to block boundaries.
+   */
+  @Data
+  public static class Split {
+    private final long lowPosition;
+    private final long highPosition;
+    private final int splitNumber;
+    private final int totalSplits;
+    private final String partName;
+
+    public final boolean isLastSplit() {
+      return this.splitNumber == this.totalSplits - 1;
+    }
+  }
+
+  private static final String SPLIT_KEY = CopyConfiguration.COPY_PREFIX + ".file.splitter.split";
+  private static final Gson GSON = new Gson();
+
+  /**
+   * Split an input {@link CopyableFile} into multiple splits aligned with block boundaries.
+   *
+   * @param file {@link CopyableFile} to split.
+   * @param workUnit {@link WorkUnit} generated for this file.
+   * @param targetFs destination {@link FileSystem} where file is to be copied.
+   * @return a list of {@link WorkUnit}, each for a split of this file.
+   * @throws IOException
+   */
+  public static Collection<WorkUnit> splitFile(CopyableFile file, WorkUnit workUnit, FileSystem targetFs)
+      throws IOException {
+    long len = file.getFileStatus().getLen();
+    long blockSize = file.getBlockSize(targetFs);
+    long maxSplitSize = workUnit.getPropAsLong(MAX_SPLIT_SIZE_KEY, DEFAULT_MAX_SPLIT_SIZE);
+
+    if (maxSplitSize < blockSize) {
+      log.warn(String.format("Max split size must be at least block size. Adjusting to %d.", blockSize));
+      maxSplitSize = blockSize;
+    }
+    if (len < maxSplitSize) {
+      return Lists.newArrayList(workUnit);
+    }
+    if (!KNOWN_SCHEMES_SUPPORTING_CONCAT.contains(targetFs.getUri().getScheme())) {
+      log.warn(String.format("File %s with size %d should be split, however file system with scheme %s does "
+          + "not appear to support concat. Will not split.", file.getDestination(), len, targetFs.getUri().getScheme()));
+      return Lists.newArrayList(workUnit);
+    }
+
+    Collection<WorkUnit> newWorkUnits = Lists.newArrayList();
+
+    long lengthPerSplit = (maxSplitSize / blockSize) * blockSize;
+    int splits = (int) (len / lengthPerSplit + 1);
+
+    for (int i = 0; i < splits; i++) {
+      WorkUnit newWorkUnit = WorkUnit.copyOf(workUnit);
+
+      long lowPos = lengthPerSplit * i;
+      long highPos = lengthPerSplit * (i + 1);
+
+      Split split = new Split(lowPos, highPos, i, splits,
+          String.format("%s.__PART%d__", file.getDestination().getName(), i));
+      String serializedSplit = GSON.toJson(split);
+
+      newWorkUnit.setProp(SPLIT_KEY, serializedSplit);
+
+      Guid oldGuid = CopySource.getWorkUnitGuid(newWorkUnit).get();
+      Guid newGuid = oldGuid.append(Guid.fromStrings(serializedSplit));
+
+      CopySource.setWorkUnitGuid(workUnit, newGuid);
+      newWorkUnits.add(newWorkUnit);
+    }
+    return newWorkUnits;
+  }
+
+  /**
+   * Finds all split work units in the input collection and merges the file parts into the expected output files.
+   * @param fs {@link FileSystem} where file parts exist.
+   * @param workUnits Collection of {@link WorkUnitState}s possibly containing split work units.
+   * @return The collection of {@link WorkUnitState}s where split work units for each file have been merged.
+   * @throws IOException
+   */
+  public static Collection<WorkUnitState> mergeAllSplitWorkUnits(FileSystem fs, Collection<WorkUnitState> workUnits)
+      throws IOException {
+    ListMultimap<CopyableFile, WorkUnitState> splitWorkUnitsMap = ArrayListMultimap.create();
+    for (WorkUnitState workUnit : workUnits) {
+      if (isSplitWorkUnit(workUnit)) {
+        CopyableFile copyableFile = (CopyableFile) CopySource.deserializeCopyEntity(workUnit);
+        splitWorkUnitsMap.put(copyableFile, workUnit);
+      }
+    }
+
+    for (CopyableFile file : splitWorkUnitsMap.keySet()) {
+      log.info(String.format("Merging split file %s.", file.getDestination()));
+
+      WorkUnitState oldWorkUnit = splitWorkUnitsMap.get(file).get(0);
+      Path outputDir = FileAwareInputStreamDataWriter.getOutputDir(oldWorkUnit);
+      CopyEntity.DatasetAndPartition datasetAndPartition =
+          file.getDatasetAndPartition(CopySource.deserializeCopyableDataset(oldWorkUnit));
+      Path parentPath = FileAwareInputStreamDataWriter.getOutputFilePath(file, outputDir, datasetAndPartition)
+          .getParent();
+
+      WorkUnitState newWorkUnit = mergeSplits(fs, file, splitWorkUnitsMap.get(file), parentPath);
+
+      for (WorkUnitState wu : splitWorkUnitsMap.get(file)) {
+        workUnits.remove(wu);
+      }
+      workUnits.add(newWorkUnit);
+    }
+    return workUnits;
+  }
+
+  /**
+   * Merges all the splits for a given file.
+   * @param fs {@link FileSystem} where file parts exist.
+   * @param file {@link CopyableFile} to merge.
+   * @param workUnits {@link WorkUnitState}s for all parts of this file.
+   * @param parentPath {@link Path} where the parts of the file are located.
+   * @return a {@link WorkUnit} equivalent to the distcp work unit if the file had not been split.
+   * @throws IOException
+   */
+  private static WorkUnitState mergeSplits(FileSystem fs, CopyableFile file, Collection<WorkUnitState> workUnits,
+      Path parentPath) throws IOException {
+
+    log.info(String.format("File %s was written in %d parts. Merging.", file.getDestination(), workUnits.size()));
+    Path[] parts = new Path[workUnits.size()];
+    for (WorkUnitState workUnit : workUnits) {
+      if (!isSplitWorkUnit(workUnit)) {
+        throw new IOException("Not a split work unit.");
+      }
+      Split split = getSplit(workUnit).get();
+      parts[split.getSplitNumber()] = new Path(parentPath, split.getPartName());
+    }
+
+    Path target = new Path(parentPath, file.getDestination().getName());
+
+    fs.rename(parts[0], target);
+    fs.concat(target, Arrays.copyOfRange(parts, 1, parts.length));
+
+    WorkUnitState finalWorkUnit = workUnits.iterator().next();
+    finalWorkUnit.removeProp(SPLIT_KEY);
+    return finalWorkUnit;
+  }
+
+  /**
+   * @return whether the {@link WorkUnit} is a split work unit.
+   */
+  public static boolean isSplitWorkUnit(State workUnit) {
+    return workUnit.contains(SPLIT_KEY);
+  }
+
+  /**
+   * @return the {@link Split} object contained in the {@link WorkUnit}.
+   */
+  public static Optional<Split> getSplit(State workUnit) {
+    return workUnit.contains(SPLIT_KEY) ? Optional.of(GSON.fromJson(workUnit.getProp(SPLIT_KEY), Split.class))
+        : Optional.<Split>absent();
+  }
+
+  /**
+   * @return whether the state allows for splitting of work units
+   */
+  public static boolean allowSplit(State state) {
+    return state.contains(SPLIT_ENABLED) && state.getPropAsBoolean(SPLIT_ENABLED);
+  }
+
+}

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/writer/TarArchiveInputStreamDataWriter.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/writer/TarArchiveInputStreamDataWriter.java
@@ -22,7 +22,6 @@ import org.apache.gobblin.data.management.copy.CopyableFile;
 import org.apache.gobblin.data.management.copy.FileAwareInputStream;
 import org.apache.gobblin.util.FileUtils;
 import org.apache.gobblin.util.io.StreamCopier;
-import org.apache.gobblin.util.io.StreamUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -36,7 +35,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.lang.StringUtils;
-import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -62,7 +60,8 @@ public class TarArchiveInputStreamDataWriter extends FileAwareInputStreamDataWri
    * @see org.apache.gobblin.data.management.copy.writer.FileAwareInputStreamDataWriter#write(org.apache.gobblin.data.management.copy.FileAwareInputStream)
    */
   @Override
-  public void writeImpl(InputStream inputStream, Path writeAt, CopyableFile copyableFile) throws IOException {
+  public void writeImpl(InputStream inputStream, Path writeAt, CopyableFile copyableFile, FileAwareInputStream record)
+      throws IOException {
     this.closer.register(inputStream);
 
     TarArchiveInputStream tarIn = new TarArchiveInputStream(inputStream);

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/converter/DecryptConverterTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/converter/DecryptConverterTest.java
@@ -71,8 +71,8 @@ public class DecryptConverterTest {
 
       String gpgFilePath = url.getFile();
       try (FSDataInputStream gpgFileInput = fs.open(new Path(gpgFilePath))) {
-	      FileAwareInputStream fileAwareInputStream =
-	          new FileAwareInputStream(CopyableFileUtils.getTestCopyableFile(), gpgFileInput);
+	      FileAwareInputStream fileAwareInputStream = FileAwareInputStream.builder()
+            .file(CopyableFileUtils.getTestCopyableFile()).inputStream(gpgFileInput).build();
 
 	      Iterable<FileAwareInputStream> iterable =
 	          converter.convertRecord("outputSchema", fileAwareInputStream, workUnitState);
@@ -106,8 +106,8 @@ public class DecryptConverterTest {
 
       String testFilePath = url.getFile();
       try (FSDataInputStream testFileInput = fs.open(new Path(testFilePath))) {
-        FileAwareInputStream fileAwareInputStream =
-            new FileAwareInputStream(CopyableFileUtils.getTestCopyableFile(), testFileInput);
+        FileAwareInputStream fileAwareInputStream = FileAwareInputStream.builder()
+            .file(CopyableFileUtils.getTestCopyableFile()).inputStream(testFileInput).build();
         fileAwareInputStream.getFile().setDestination(new Path("file:///tmp/decrypt-test.txt.insecure_shift"));
         Iterable<FileAwareInputStream> iterable =
             converter.convertRecord("outputSchema", fileAwareInputStream, workUnitState);

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/converter/UnGzipConverterTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/converter/UnGzipConverterTest.java
@@ -58,8 +58,8 @@ public class UnGzipConverterTest {
     FileSystem fs = FileSystem.getLocal(new Configuration());
 
     String fullPath = getClass().getClassLoader().getResource(filePath).getFile();
-    FileAwareInputStream fileAwareInputStream =
-        new FileAwareInputStream(CopyableFileUtils.getTestCopyableFile(filePath), fs.open(new Path(fullPath)));
+    FileAwareInputStream fileAwareInputStream = FileAwareInputStream.builder()
+        .file(CopyableFileUtils.getTestCopyableFile(filePath)).inputStream(fs.open(new Path(fullPath))).build();
 
     Iterable<FileAwareInputStream> iterable =
         converter.convertRecord("outputSchema", fileAwareInputStream, new WorkUnitState());
@@ -80,9 +80,9 @@ public class UnGzipConverterTest {
       String filePath = "unGzipConverterTest/" + fileName;
       String fullPath = getClass().getClassLoader().getResource(filePath).getFile();
 
-      FileAwareInputStream fileAwareInputStream =
-          new FileAwareInputStream(CopyableFileUtils.getTestCopyableFile(filePath, "/tmp/" + fileName, null, null),
-              fs.open(new Path(fullPath)));
+      FileAwareInputStream fileAwareInputStream = FileAwareInputStream.builder()
+          .file(CopyableFileUtils.getTestCopyableFile(filePath, "/tmp/" + fileName, null, null))
+          .inputStream(fs.open(new Path(fullPath))).build();
 
       Iterable<FileAwareInputStream> iterable = converter.convertRecord("outputSchema", fileAwareInputStream, new WorkUnitState());
       FileAwareInputStream out = iterable.iterator().next();

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/splitter/DistcpFileSplitterTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/splitter/DistcpFileSplitterTest.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gobblin.data.management.copy.splitter;
+
+import java.net.URI;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Optional;
+
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.configuration.WorkUnitState;
+import org.apache.gobblin.data.management.copy.CopySource;
+import org.apache.gobblin.data.management.copy.CopyableDatasetMetadata;
+import org.apache.gobblin.data.management.copy.CopyableFile;
+import org.apache.gobblin.data.management.copy.CopyableFileUtils;
+import org.apache.gobblin.data.management.copy.TestCopyableDataset;
+import org.apache.gobblin.source.workunit.WorkUnit;
+import org.apache.gobblin.util.ForkOperatorUtils;
+import org.apache.gobblin.util.guid.Guid;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+
+public class DistcpFileSplitterTest {
+
+  // This test ONLY checks whether manipulates the properties of the work units correctly
+  // (i.e. "merging" them within the collection that was passed in).
+  // It does NOT check that the merge in the filesystem has been completed successfully.
+  // This requires testing on an HDFS setup.
+  @Test
+  public void testMergeSplitWorkUnits() throws Exception {
+    long mockFileLen = 12L;
+    long mockBlockSize = 4L;
+    long mockMaxSplitSize = 4L;
+    long expectedSplitSize = (mockMaxSplitSize / mockBlockSize) * mockBlockSize;
+    int expectedSplits = (int) (mockFileLen / expectedSplitSize + 1);
+
+    FileSystem fs = mock(FileSystem.class);
+
+    List<WorkUnitState> splitWorkUnits =
+        createMockSplitWorkUnits(fs, mockFileLen, mockBlockSize, mockMaxSplitSize).stream()
+            .map(wu -> new WorkUnitState(wu)).collect(Collectors.toList());
+    Assert.assertEquals(splitWorkUnits.size(), expectedSplits);
+
+    Collection<WorkUnitState> mergedWorkUnits = DistcpFileSplitter.mergeAllSplitWorkUnits(fs, splitWorkUnits);
+    Assert.assertEquals(mergedWorkUnits.size(), 1);
+  }
+
+  // This test checks whether a work unit has been successfully set up for a split,
+  // but does not check that the split is actually done correctly when input streams are used.
+  @Test
+  public void testSplitFile() throws Exception {
+    long mockFileLen = 12L;
+    long mockBlockSize = 4L;
+    long mockMaxSplitSize = 4L;
+    long expectedSplitSize = (mockMaxSplitSize / mockBlockSize) * mockBlockSize;
+    int expectedSplits = (int) (mockFileLen / expectedSplitSize + 1);
+
+    FileSystem fs = mock(FileSystem.class);
+
+    Collection<WorkUnit> splitWorkUnits = createMockSplitWorkUnits(fs, mockFileLen, mockBlockSize, mockMaxSplitSize);
+    Assert.assertEquals(splitWorkUnits.size(), expectedSplits);
+
+    Set<Integer> splitNums = new HashSet<>();
+    for (WorkUnit wu : splitWorkUnits) {
+      Optional<DistcpFileSplitter.Split> split = DistcpFileSplitter.getSplit(wu);
+      Assert.assertTrue(split.isPresent());
+      Assert.assertEquals(split.get().getTotalSplits(), expectedSplits);
+
+      int splitNum = split.get().getSplitNumber();
+      Assert.assertFalse(splitNums.contains(splitNum));
+      splitNums.add(splitNum);
+      Assert.assertEquals(split.get().getLowPosition(), expectedSplitSize * splitNum);
+      Assert.assertEquals(split.get().getHighPosition(), expectedSplitSize * (splitNum + 1));
+    }
+  }
+
+  private Collection<WorkUnit> createMockSplitWorkUnits(FileSystem fs, long fileLen, long blockSize, long maxSplitSize)
+      throws Exception {
+    FileStatus file = mock(FileStatus.class);
+    when(file.getLen()).thenReturn(fileLen);
+
+    URI uri = new URI("hdfs", "dummyhost", "/test", "test");
+    Path path = new Path(uri);
+    when(fs.getUri()).thenReturn(uri);
+
+    CopyableDatasetMetadata cdm = new CopyableDatasetMetadata(new TestCopyableDataset(path));
+
+    CopyableFile cf = CopyableFileUtils.getTestCopyableFile();
+    CopyableFile spy = spy(cf);
+    doReturn(file).when(spy).getFileStatus();
+    doReturn(blockSize).when(spy).getBlockSize(any(FileSystem.class));
+    doReturn(path).when(spy).getDestination();
+
+    WorkUnit wu = WorkUnit.createEmpty();
+    wu.setProp(DistcpFileSplitter.MAX_SPLIT_SIZE_KEY, maxSplitSize);
+    wu.setProp(ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_OUTPUT_DIR, 1, 0),
+        path.toString());
+    CopySource.setWorkUnitGuid(wu, Guid.fromStrings(wu.toString()));
+    CopySource.serializeCopyEntity(wu, cf);
+    CopySource.serializeCopyableDataset(wu, cdm);
+
+    return DistcpFileSplitter.splitFile(spy, wu, fs);
+  }
+
+}

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/splitter/DistcpFileSplitterTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/splitter/DistcpFileSplitterTest.java
@@ -91,17 +91,23 @@ public class DistcpFileSplitterTest {
     Assert.assertEquals(splitWorkUnits.size(), expectedSplits);
 
     Set<Integer> splitNums = new HashSet<>();
+    boolean hasLastSplit = false;
     for (WorkUnit wu : splitWorkUnits) {
       Optional<DistcpFileSplitter.Split> split = DistcpFileSplitter.getSplit(wu);
       Assert.assertTrue(split.isPresent());
       Assert.assertEquals(split.get().getTotalSplits(), expectedSplits);
-
       int splitNum = split.get().getSplitNumber();
       Assert.assertFalse(splitNums.contains(splitNum));
       splitNums.add(splitNum);
       Assert.assertEquals(split.get().getLowPosition(), expectedSplitSize * splitNum);
-      Assert.assertEquals(split.get().getHighPosition(), expectedSplitSize * (splitNum + 1));
+      if (split.get().isLastSplit()) {
+        hasLastSplit = true;
+        Assert.assertEquals(split.get().getHighPosition(), mockFileLen);
+      } else {
+        Assert.assertEquals(split.get().getHighPosition(), expectedSplitSize * (splitNum + 1));
+      }
     }
+    Assert.assertTrue(hasLastSplit);
   }
 
   private Collection<WorkUnit> createMockSplitWorkUnits(FileSystem fs, long fileLen, long blockSize, long maxSplitSize)

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/splitter/DistcpFileSplitterTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/splitter/DistcpFileSplitterTest.java
@@ -114,6 +114,7 @@ public class DistcpFileSplitterTest {
       throws Exception {
     FileStatus file = mock(FileStatus.class);
     when(file.getLen()).thenReturn(fileLen);
+    when(file.getBlockSize()).thenReturn(blockSize);
 
     URI uri = new URI("hdfs", "dummyhost", "/test", "test");
     Path path = new Path(uri);

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriterTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriterTest.java
@@ -26,7 +26,9 @@ import java.util.Properties;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.RandomStringUtils;
+import org.apache.gobblin.data.management.copy.splitter.DistcpFileSplitter;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -92,12 +94,52 @@ public class FileAwareInputStreamDataWriterTest {
 
     FileAwareInputStreamDataWriter dataWriter = new FileAwareInputStreamDataWriter(state, 1, 0);
 
-    FileAwareInputStream fileAwareInputStream = new FileAwareInputStream(cf, StreamUtils.convertStream(IOUtils.toInputStream(streamString)));
+    FileAwareInputStream fileAwareInputStream = FileAwareInputStream.builder().file(cf)
+        .inputStream(StreamUtils.convertStream(IOUtils.toInputStream(streamString))).build();
     dataWriter.write(fileAwareInputStream);
     dataWriter.commit();
     Path writtenFilePath = new Path(new Path(state.getProp(ConfigurationKeys.WRITER_OUTPUT_DIR),
         cf.getDatasetAndPartition(metadata).identifier()), cf.getDestination());
     Assert.assertEquals(IOUtils.toString(new FileInputStream(writtenFilePath.toString())), streamString);
+  }
+
+  @Test
+  public void testBlockWrite() throws Exception {
+    String streamString = "testContents";
+
+    FileStatus status = fs.getFileStatus(testTempPath);
+    OwnerAndPermission ownerAndPermission =
+        new OwnerAndPermission(status.getOwner(), status.getGroup(), new FsPermission(FsAction.ALL, FsAction.ALL, FsAction.ALL));
+    CopyableFile cf = CopyableFileUtils.getTestCopyableFile(ownerAndPermission);
+
+    CopyableDatasetMetadata metadata = new CopyableDatasetMetadata(new TestCopyableDataset(new Path("/source")));
+
+    WorkUnitState state = TestUtils.createTestWorkUnitState();
+    state.setProp(ConfigurationKeys.WRITER_STAGING_DIR, new Path(testTempPath, "staging").toString());
+    state.setProp(ConfigurationKeys.WRITER_OUTPUT_DIR, new Path(testTempPath, "output").toString());
+    state.setProp(ConfigurationKeys.WRITER_FILE_PATH, RandomStringUtils.randomAlphabetic(5));
+    state.setProp(DistcpFileSplitter.SPLIT_ENABLED, true);
+    CopySource.serializeCopyEntity(state, cf);
+    CopySource.serializeCopyableDataset(state, metadata);
+
+    FileAwareInputStreamDataWriter dataWriter = new FileAwareInputStreamDataWriter(state, 1, 0);
+
+    long splitLen = 4;
+    int splits = (int) (streamString.length() / splitLen + 1);
+    DistcpFileSplitter.Split split = new DistcpFileSplitter.Split(0, splitLen, 0, splits,
+        String.format("%s.__PART%d__", cf.getDestination().getName(), 0));
+    FSDataInputStream dataInputStream = StreamUtils.convertStream(IOUtils.toInputStream(streamString));
+    dataInputStream.seek(split.getLowPosition());
+    FileAwareInputStream fileAwareInputStream = FileAwareInputStream.builder().file(cf)
+        .inputStream(dataInputStream)
+        .split(Optional.of(split))
+        .build();
+    dataWriter.write(fileAwareInputStream);
+    dataWriter.commit();
+    Path writtenFilePath = new Path(new Path(state.getProp(ConfigurationKeys.WRITER_OUTPUT_DIR),
+        cf.getDatasetAndPartition(metadata).identifier()), cf.getDestination());
+    Assert.assertEquals(IOUtils.toString(new FileInputStream(writtenFilePath.toString())),
+        streamString.substring(0, (int) splitLen));
   }
 
   @Test
@@ -126,8 +168,8 @@ public class FileAwareInputStreamDataWriterTest {
 
     FileAwareInputStreamDataWriter dataWriter = new FileAwareInputStreamDataWriter(state, 1, 0);
 
-    FileAwareInputStream fileAwareInputStream = new FileAwareInputStream(cf, StreamUtils.convertStream(
-        new ByteArrayInputStream(streamString)));
+    FileAwareInputStream fileAwareInputStream = FileAwareInputStream.builder().file(cf)
+        .inputStream(StreamUtils.convertStream(new ByteArrayInputStream(streamString))).build();
     dataWriter.write(fileAwareInputStream);
     dataWriter.commit();
 
@@ -161,8 +203,8 @@ public class FileAwareInputStreamDataWriterTest {
 
     FileAwareInputStreamDataWriter dataWriter = new FileAwareInputStreamDataWriter(state, 1, 0);
 
-    FileAwareInputStream fileAwareInputStream = new FileAwareInputStream(cf, StreamUtils.convertStream(
-        new ByteArrayInputStream(streamString)));
+    FileAwareInputStream fileAwareInputStream = FileAwareInputStream.builder().file(cf)
+        .inputStream(StreamUtils.convertStream(new ByteArrayInputStream(streamString))).build();
     dataWriter.write(fileAwareInputStream);
     dataWriter.commit();
 
@@ -217,8 +259,8 @@ public class FileAwareInputStreamDataWriterTest {
 
     FileAwareInputStreamDataWriter dataWriter = new FileAwareInputStreamDataWriter(state, 1, 0);
 
-    FileAwareInputStream fileAwareInputStream = new FileAwareInputStream(cf, StreamUtils.convertStream(
-        new ByteArrayInputStream(streamString)));
+    FileAwareInputStream fileAwareInputStream = FileAwareInputStream.builder().file(cf)
+        .inputStream(StreamUtils.convertStream(new ByteArrayInputStream(streamString))).build();
     dataWriter.write(fileAwareInputStream);
     dataWriter.commit();
 

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/writer/TarArchiveInputStreamDataWriterTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/writer/TarArchiveInputStreamDataWriterTest.java
@@ -121,7 +121,8 @@ public class TarArchiveInputStreamDataWriterTest {
         CopyableFileUtils.getTestCopyableFile(filePath, new Path(testTempPath, newFileName).toString(), newFileName,
             ownerAndPermission);
 
-    FileAwareInputStream fileAwareInputStream = new FileAwareInputStream(cf, fs.open(new Path(fullPath)));
+    FileAwareInputStream fileAwareInputStream = FileAwareInputStream.builder().file(cf)
+        .inputStream(fs.open(new Path(fullPath))).build();
 
     Iterable<FileAwareInputStream> iterable =
         converter.convertRecord("outputSchema", fileAwareInputStream, new WorkUnitState());

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/io/StreamCopier.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/io/StreamCopier.java
@@ -95,7 +95,8 @@ public class StreamCopier {
   }
 
   /**
-   * Execute the copy of bytes from the input to the output stream.
+   * Execute the copy of bytes from the input to the output stream. If maxBytes is specified, limits the number of
+   * bytes copied to maxBytes.
    * Note: this method should only be called once. Further calls will throw a {@link IllegalStateException}.
    * @return Number of bytes copied.
    */
@@ -111,6 +112,7 @@ public class StreamCopier {
       long totalBytes = 0;
 
       final ByteBuffer buffer = ByteBuffer.allocateDirect(this.bufferSize);
+      // Only keep copying if we've read less than maxBytes (if maxBytes exists)
       while ((this.maxBytes == null || this.maxBytes > totalBytes) &&
           (numBytes = fillBufferFromInputChannel(buffer)) != -1) {
         totalBytes += numBytes;

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/io/StreamCopier.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/io/StreamCopier.java
@@ -26,11 +26,11 @@ import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
 
+import javax.annotation.concurrent.NotThreadSafe;
+
 import com.codahale.metrics.Meter;
 
 import org.apache.gobblin.util.limiter.Limiter;
-
-import javax.annotation.concurrent.NotThreadSafe;
 
 
 /**
@@ -44,6 +44,8 @@ public class StreamCopier {
 
   private final ReadableByteChannel inputChannel;
   private final WritableByteChannel outputChannel;
+
+  private final Long maxBytes;
   private int bufferSize = DEFAULT_BUFFER_SIZE;
   private Meter copySpeedMeter;
 
@@ -51,12 +53,21 @@ public class StreamCopier {
   private volatile boolean copied = false;
 
   public StreamCopier(InputStream inputStream, OutputStream outputStream) {
-    this(Channels.newChannel(inputStream), Channels.newChannel(outputStream));
+    this(inputStream, outputStream, null);
+  }
+
+  public StreamCopier(InputStream inputStream, OutputStream outputStream, Long maxBytes) {
+    this(Channels.newChannel(inputStream), Channels.newChannel(outputStream), maxBytes);
   }
 
   public StreamCopier(ReadableByteChannel inputChannel, WritableByteChannel outputChannel) {
+    this(inputChannel, outputChannel, null);
+  }
+
+  public StreamCopier(ReadableByteChannel inputChannel, WritableByteChannel outputChannel, Long maxBytes) {
     this.inputChannel = inputChannel;
     this.outputChannel = outputChannel;
+    this.maxBytes = maxBytes;
   }
 
   /**
@@ -96,19 +107,27 @@ public class StreamCopier {
     this.copied = true;
 
     try {
-      long bytesRead = 0;
-      long totalBytesRead = 0;
+      long numBytes = 0;
+      long totalBytes = 0;
 
       final ByteBuffer buffer = ByteBuffer.allocateDirect(this.bufferSize);
-      while ((bytesRead = fillBufferFromInputChannel(buffer)) != -1) {
-        totalBytesRead += bytesRead;
+      while ((this.maxBytes == null || this.maxBytes > totalBytes) &&
+          (numBytes = fillBufferFromInputChannel(buffer)) != -1) {
+        totalBytes += numBytes;
         // flip the buffer to be written
         buffer.flip();
+
+        // If we've read more than maxBytes, discard enough bytes to only write maxBytes.
+        if (this.maxBytes != null && totalBytes > this.maxBytes) {
+          buffer.limit(buffer.limit() - (int) (totalBytes - this.maxBytes));
+          totalBytes = this.maxBytes;
+        }
+
         this.outputChannel.write(buffer);
         // Clear if empty
         buffer.compact();
         if (this.copySpeedMeter != null) {
-          this.copySpeedMeter.mark(bytesRead);
+          this.copySpeedMeter.mark(numBytes);
         }
       }
       // Done writing, now flip to read again
@@ -118,7 +137,7 @@ public class StreamCopier {
         this.outputChannel.write(buffer);
       }
 
-      return totalBytesRead;
+      return totalBytes;
     } finally {
       if (this.closeChannelsOnComplete) {
         this.inputChannel.close();

--- a/gobblin-utility/src/test/java/org/apache/gobblin/util/io/StreamCopierTest.java
+++ b/gobblin-utility/src/test/java/org/apache/gobblin/util/io/StreamCopierTest.java
@@ -27,8 +27,6 @@ import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Charsets;
 
-import org.apache.gobblin.util.limiter.CountBasedLimiter;
-
 
 public class StreamCopierTest {
 
@@ -56,6 +54,19 @@ public class StreamCopierTest {
     new StreamCopier(inputStream, outputStream).withBufferSize(100).copy();
 
     Assert.assertEquals(testString, new String(outputStream.toByteArray(), Charsets.UTF_8));
+  }
+
+  @Test
+  public void testBlockCopy() throws Exception {
+    String testString = "This is a string";
+    ByteArrayInputStream inputStream = new ByteArrayInputStream(testString.getBytes(Charsets.UTF_8));
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+    long maxBytes = 4L;
+    new StreamCopier(inputStream, outputStream, maxBytes).copy();
+
+    Assert.assertEquals(new String(outputStream.toByteArray(), Charsets.UTF_8),
+        testString.substring(0, (int) maxBytes));
   }
 
   @Test


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-598


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
    - Modified the distcp pipeline workflow to allow for work units to be split by the CopySource into block level work units which are then merged after copying by the CopyDataPublisher.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
    - Added some unit tests including testing of non-filesystem related functionality of the added DistcpFileSplitter methods.
    - I ran a split-enabled distcp job on a local pseudo distributed hdfs setup with a small file, kind of as a smoke test: it didn't actually use a split because the file was much smaller than the block size, but it completed successfully
    - Tested with a job that successfully copied two 3gb files with block sizes of 512 mbs (verified copied files using hdfs dfs checksum)

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

