### PR TITLE
[GOBBLIN-599] Handle task creation errors in GobblinMultiTaskAttempt

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/GobblinMultiTaskAttempt.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/GobblinMultiTaskAttempt.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
@@ -349,7 +350,7 @@ public class GobblinMultiTaskAttempt {
       }
 
       // Create a new task from the work unit and submit the task to run.
-      // If an exception occurs here then the count down latch is not incremented
+      // If an exception occurs here then the count down latch is decremented
       // to avoid being stuck waiting for a task that was not created and submitted successfully.
       Task task = null;
       try {
@@ -360,10 +361,18 @@ public class GobblinMultiTaskAttempt {
         tasks.add(task);
       } catch (Exception e) {
         if (task == null) {
+          // task could not be created, so directly count down
           countDownLatch.countDown();
           log.error("Could not create task for workunit {}", workUnit, e);
-        } else {
+        } else if (!task.hasTaskFuture()) {
+          // Task was created and may have been registered, but not submitted, so call the
+          // task state tracker task run completion directly since the task cancel does nothing if not submitted
+          this.taskStateTracker.onTaskRunCompletion(task);
           log.error("Could not submit task for workunit {}", workUnit, e);
+        } else {
+          // task was created and submitted, but failed later, so cancel the task to decrement the CountDownLatch
+          task.cancel();
+          log.error("Failure after task submitted for workunit {}", workUnit, e);
         }
       }
     }

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/Task.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/Task.java
@@ -34,6 +34,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
@@ -993,6 +994,11 @@ public class Task implements TaskIFace {
 
   public synchronized void setTaskFuture(Future<?> taskFuture) {
     this.taskFuture = taskFuture;
+  }
+
+  @VisibleForTesting
+  boolean hasTaskFuture() {
+    return this.taskFuture != null;
   }
 
   /**

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/mapreduce/MRTaskFactoryTest.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/mapreduce/MRTaskFactoryTest.java
@@ -48,6 +48,7 @@ import org.apache.hadoop.mapreduce.Reducer;
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.log4j.AppenderSkeleton;
+import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.apache.log4j.spi.LoggingEvent;
@@ -77,6 +78,7 @@ public class MRTaskFactoryTest {
 
     TestAppender testAppender = new TestAppender();
     Logger logger = LogManager.getLogger(MRTask.class.getName());
+    logger.setLevel(Level.INFO);
     logger.addAppender(testAppender);
 
     EmbeddedGobblin embeddedGobblin = new EmbeddedGobblin("WordCounter")

--- a/gobblin-runtime/src/test/resources/log4j.xml
+++ b/gobblin-runtime/src/test/resources/log4j.xml
@@ -28,7 +28,7 @@
   </appender>
 
   <root>
-    <level value="info" />
+    <level value="warn" />
     <appender-ref ref="console" />
   </root>
 

--- a/gobblin-test-harness/build.gradle
+++ b/gobblin-test-harness/build.gradle
@@ -23,6 +23,7 @@ dependencies {
   testCompile project(":gobblin-runtime")
   testCompile project(":gobblin-data-management")
 
+  testCompile externalDependency.bytemanBmunit
   testCompile externalDependency.calciteCore
   testCompile externalDependency.calciteAvatica
   testCompile externalDependency.jhyde

--- a/gobblin-test-harness/src/test/java/org/apache/gobblin/TaskErrorIntegrationTest.java
+++ b/gobblin-test-harness/src/test/java/org/apache/gobblin/TaskErrorIntegrationTest.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gobblin;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.log4j.AppenderSkeleton;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.apache.log4j.spi.LoggingEvent;
+import org.testng.Assert;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.configuration.SourceState;
+import org.apache.gobblin.configuration.WorkUnitState;
+import org.apache.gobblin.instrumented.extractor.InstrumentedExtractor;
+import org.apache.gobblin.runtime.GobblinMultiTaskAttempt;
+import org.apache.gobblin.source.Source;
+import org.apache.gobblin.source.extractor.DataRecordException;
+import org.apache.gobblin.source.extractor.Extractor;
+import org.apache.gobblin.source.workunit.WorkUnit;
+
+
+@Test(enabled=false)
+public class TaskErrorIntegrationTest {
+  private static String EXCEPTION_MESSAGE = "test exception";
+
+  @BeforeTest
+  @AfterTest
+  public void cleanDir()
+      throws IOException {
+    GobblinLocalJobLauncherUtils.cleanDir();
+  }
+
+  /**
+   * Test that an extractor that raises an error on creation results in a log message from {@link GobblinMultiTaskAttempt}
+   * @throws Exception
+   */
+  @Test
+  public void extractorCreationError()
+      throws Exception {
+    TestAppender testAppender = new TestAppender();
+    Logger logger = LogManager.getLogger(GobblinMultiTaskAttempt.class.getName() + "-noattempt");
+    logger.addAppender(testAppender);
+
+    Properties jobProperties =
+        GobblinLocalJobLauncherUtils.getJobProperties("runtime_test/skip_workunits_test.properties");
+
+    jobProperties.setProperty(ConfigurationKeys.SOURCE_CLASS_KEY, TestSource.class.getName());
+
+    GobblinLocalJobLauncherUtils.invokeLocalJobLauncher(jobProperties);
+
+    Assert.assertTrue(testAppender.events.stream().anyMatch(e -> e.getRenderedMessage()
+        .startsWith("Could not create task for workunit")));
+  }
+
+  /**
+   * Test extractor that raises an exception on construction
+   */
+  public static class TestExtractor<S, D> extends InstrumentedExtractor<S, D> {
+
+    public TestExtractor(WorkUnitState workUnitState) {
+      super(workUnitState);
+
+      throw new RuntimeException(EXCEPTION_MESSAGE);
+    }
+
+    @Override
+    public S getSchema() throws IOException {
+      return null;
+    }
+
+    @Override
+    public long getExpectedRecordCount() {
+      return 0;
+    }
+
+    @Override
+    public long getHighWatermark() {
+      return 0;
+    }
+
+    @Override
+    public D readRecordImpl(D reuse) throws DataRecordException, IOException {
+      return null;
+    }
+  }
+
+  /**
+   * Test source that creates a {@link TestExtractor}
+   */
+  public static class TestSource implements Source<Schema, GenericRecord> {
+
+    @Override
+    public List<WorkUnit> getWorkunits(SourceState state) {
+      WorkUnit workUnit = WorkUnit.createEmpty();
+      workUnit.addAll(state);
+      return Collections.singletonList(workUnit);
+    }
+
+    @Override
+    public Extractor<Schema, GenericRecord> getExtractor(WorkUnitState state)
+        throws IOException {
+      return new TestExtractor(state);
+    }
+
+    @Override
+    public void shutdown(SourceState state) {
+    }
+  }
+
+  private class TestAppender extends AppenderSkeleton {
+    List<LoggingEvent> events = new ArrayList<LoggingEvent>();
+    public void close() {}
+    public boolean requiresLayout() {return false;}
+    @Override
+    protected void append(LoggingEvent event) {
+      events.add(event);
+    }
+  }
+}


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-599


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
Task creation errors in GobblinMultiTaskAttempt.runWorkUnits() may result in GobblinMultiTaskAttempt.run() exiting prematurely and with an incorrect CountDownLatch count. This has been observed to result in hangs and tasks running to completion, but not committing.
The fix is to catch exceptions in the task creation and submission block and logging the exception without re-throwing it. The count down latch is not incremented until after it is added to the task list. Tasks that did not run will not be committed and the run loop will not wait for their completion.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
TaskErrorIntegrationTest

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

