### PR TITLE
GOBBLIN-603: Add ServiceManager to manage GitFlowGraphMonitor in multihop flow compiler.

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GitFlowGraphMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GitFlowGraphMonitor.java
@@ -91,7 +91,7 @@ public class GitFlowGraphMonitor extends GitMonitoringService {
    */
   @Override
   public boolean shouldPollGit() {
-    return this.isActive;
+    return true;
   }
 
   /**

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GitMonitoringService.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GitMonitoringService.java
@@ -120,8 +120,8 @@ public abstract class GitMonitoringService extends AbstractIdleService {
   /** Start the service. */
   @Override
   protected void startUp() throws Exception {
-    log.info("Starting the " + GitConfigMonitor.class.getSimpleName());
-    log.info("Polling git with inteval {} ", this.pollingInterval);
+    log.info("Starting the " + getClass().getSimpleName());
+    log.info("Polling git with interval {} ", this.pollingInterval);
 
     // Schedule the job config fetch task
     this.scheduledExecutor.scheduleAtFixedRate(new Runnable() {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/MultiHopFlowCompiler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/MultiHopFlowCompiler.java
@@ -21,12 +21,15 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.slf4j.Logger;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.ServiceManager;
 import com.typesafe.config.Config;
 
 import lombok.Getter;
@@ -59,12 +62,14 @@ import org.apache.gobblin.util.ConfigUtils;
 @Alpha
 @Slf4j
 public class MultiHopFlowCompiler extends BaseFlowToJobSpecCompiler {
-
   @Getter
   private final FlowGraph flowGraph;
-  private GitFlowGraphMonitor gitFlowGraphMonitor;
+  @Getter
+  private ServiceManager serviceManager;
   @Getter
   private boolean active;
+
+  private GitFlowGraphMonitor gitFlowGraphMonitor;
 
   public MultiHopFlowCompiler(Config config) {
     this(config, true);
@@ -90,6 +95,15 @@ public class MultiHopFlowCompiler extends BaseFlowToJobSpecCompiler {
     }
     this.flowGraph = new BaseFlowGraph();
     this.gitFlowGraphMonitor = new GitFlowGraphMonitor(this.config, flowCatalog, this.flowGraph);
+    this.serviceManager = new ServiceManager(Lists.newArrayList(this.gitFlowGraphMonitor));
+    addShutdownHook();
+    //Start the git flow graph monitor
+    try {
+      this.serviceManager.startAsync().awaitHealthy(5, TimeUnit.SECONDS);
+    } catch (TimeoutException te) {
+      this.log.error("Timed out while waiting for the service manager to start up", te);
+      throw new RuntimeException(te);
+    }
   }
 
   @VisibleForTesting
@@ -150,5 +164,23 @@ public class MultiHopFlowCompiler extends BaseFlowToJobSpecCompiler {
   protected void populateEdgeTemplateMap() {
     log.warn("No population of templates based on edge happen in this implementation");
     return;
+  }
+
+  /**
+   * Register a shutdown hook for this thread.
+   */
+  private void addShutdownHook() {
+    ServiceManager manager = this.serviceManager;
+    Runtime.getRuntime().addShutdownHook(new Thread() {
+      public void run() {
+        // Give the services 5 seconds to stop to ensure that we are responsive to shutdown
+        // requests.
+        try {
+          manager.stopAsync().awaitStopped(5, TimeUnit.SECONDS);
+        } catch (TimeoutException timeout) {
+          // stopping timed out
+        }
+      }
+    });
   }
 }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-603


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Add ServiceManager to start/stop GitFlowGraphMonitor service in the multi-hop flow compiler. 

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Added unit test to MultiHopFlowCompilerTest class.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

