### PR TITLE
GOBBLIN-604: Map dependencies in job templates to the job names in compiled JobSpecs.

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -175,6 +175,7 @@ public class ConfigurationKeys {
   public static final String WORK_UNIT_CREATION_AND_RUN_INTERVAL = "workunit.creation.and.run.interval";
   public static final String WORK_UNIT_ENABLE_TRACKING_LOGS = "workunit.enableTrackingLogs";
 
+  public static final String JOB_DEPENDENCIES = "job.dependencies";
   public static final String JOB_RUN_ONCE_KEY = "job.runonce";
   public static final String JOB_DISABLED_KEY = "job.disabled";
   public static final String JOB_JAR_FILES_KEY = "job.jars";
@@ -207,10 +208,9 @@ public class ConfigurationKeys {
   public static final String JOB_TEMPLATE_PATH = "job.template";
 
   /**
-   * Configuration property used only for job configuration file's tempalte, inside .template file
+   * Configuration property used only for job configuration file's template
    */
   public static final String REQUIRED_ATRRIBUTES_LIST = "gobblin.template.required_attributes";
-  public static final String JOB_DEPENDENCIES = "dependencies";
 
   /**
    * Configuration for emitting job events

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/spec/JobExecutionPlan.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/spec/JobExecutionPlan.java
@@ -73,7 +73,7 @@ public class JobExecutionPlan {
       String jobName = ConfigUtils.getString(jobConfig, ConfigurationKeys.JOB_NAME_KEY, "");
 
       //Modify the job name to include the flow group, flow name and a randomly generated integer to make the job name unique.
-      jobName = Joiner.on(JOB_NAME_COMPONENT_SEPARATION_CHAR).join(flowGroup, flowName, jobName, random.nextInt());
+      jobName = Joiner.on(JOB_NAME_COMPONENT_SEPARATION_CHAR).join(flowGroup, flowName, jobName, random.nextInt(Integer.MAX_VALUE));
 
       JobSpec.Builder jobSpecBuilder = JobSpec.builder(jobSpecURIGenerator(flowGroup, jobName, flowSpec)).withConfig(jobConfig)
           .withDescription(flowSpec.getDescription()).withVersion(flowSpec.getVersion());

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/spec/JobExecutionPlan.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/spec/JobExecutionPlan.java
@@ -72,7 +72,7 @@ public class JobExecutionPlan {
       String flowGroup = ConfigUtils.getString(flowConfig, ConfigurationKeys.FLOW_GROUP_KEY, "");
       String jobName = ConfigUtils.getString(jobConfig, ConfigurationKeys.JOB_NAME_KEY, "");
 
-      //Modify the job name to include the flow group, flow name and a randomly generated uuid to make the job name unique.
+      //Modify the job name to include the flow group, flow name and a randomly generated integer to make the job name unique.
       jobName = Joiner.on(JOB_NAME_COMPONENT_SEPARATION_CHAR).join(flowGroup, flowName, jobName, random.nextInt());
 
       JobSpec.Builder jobSpecBuilder = JobSpec.builder(jobSpecURIGenerator(flowGroup, jobName, flowSpec)).withConfig(jobConfig)

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/spec/JobExecutionPlan.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/spec/JobExecutionPlan.java
@@ -19,6 +19,7 @@ package org.apache.gobblin.service.modules.spec;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Random;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -49,6 +50,8 @@ public class JobExecutionPlan {
   private ExecutionStatus executionStatus = ExecutionStatus.$UNKNOWN;
 
   public static class Factory {
+    public static final String JOB_NAME_COMPONENT_SEPARATION_CHAR = "_";
+    private static final Random random = new Random();
 
     public JobExecutionPlan createPlan(FlowSpec flowSpec, Config jobConfig, SpecExecutor specExecutor, Long flowExecutionId)
         throws URISyntaxException {
@@ -69,8 +72,8 @@ public class JobExecutionPlan {
       String flowGroup = ConfigUtils.getString(flowConfig, ConfigurationKeys.FLOW_GROUP_KEY, "");
       String jobName = ConfigUtils.getString(jobConfig, ConfigurationKeys.JOB_NAME_KEY, "");
 
-      //Modify the job name to include the flow group:flow name.
-      jobName = Joiner.on(":").join(flowGroup, flowName, jobName);
+      //Modify the job name to include the flow group, flow name and a randomly generated uuid to make the job name unique.
+      jobName = Joiner.on(JOB_NAME_COMPONENT_SEPARATION_CHAR).join(flowGroup, flowName, jobName, random.nextInt());
 
       JobSpec.Builder jobSpecBuilder = JobSpec.builder(jobSpecURIGenerator(flowGroup, jobName, flowSpec)).withConfig(jobConfig)
           .withDescription(flowSpec.getDescription()).withVersion(flowSpec.getVersion());
@@ -78,6 +81,9 @@ public class JobExecutionPlan {
       //Get job template uri
       URI jobTemplateUri = new URI(jobConfig.getString(ConfigurationKeys.JOB_TEMPLATE_PATH));
       JobSpec jobSpec = jobSpecBuilder.withTemplate(jobTemplateUri).build();
+
+      //Add flowGroup to job spec
+      jobSpec.setConfig(jobSpec.getConfig().withValue(ConfigurationKeys.FLOW_GROUP_KEY, ConfigValueFactory.fromAnyRef(flowGroup)));
 
       //Add flowName to job spec
       jobSpec.setConfig(jobSpec.getConfig().withValue(ConfigurationKeys.FLOW_NAME_KEY, ConfigValueFactory.fromAnyRef(flowName)));
@@ -109,7 +115,7 @@ public class JobExecutionPlan {
      * A naive implementation of generating a jobSpec's URI within a multi-hop flow that follows the convention:
      * <JOB_CATALOG_SCHEME>/{@link ConfigurationKeys#JOB_GROUP_KEY}/{@link ConfigurationKeys#JOB_NAME_KEY}.
      */
-    public static URI jobSpecURIGenerator(String jobGroup, String jobName, FlowSpec flowSpec)
+    private static URI jobSpecURIGenerator(String jobGroup, String jobName, FlowSpec flowSpec)
         throws URISyntaxException {
       return new URI(JobSpec.Builder.DEFAULT_JOB_CATALOG_SCHEME, flowSpec.getUri().getAuthority(),
           StringUtils.appendIfMissing(StringUtils.prependIfMissing(flowSpec.getUri().getPath(), "/"), "/") + jobGroup

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/flow/MultiHopFlowCompilerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/flow/MultiHopFlowCompilerTest.java
@@ -47,6 +47,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import com.google.common.base.Charsets;
+import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
 import com.google.common.io.Files;
 import com.typesafe.config.Config;
@@ -183,7 +184,11 @@ public class MultiHopFlowCompilerTest {
 
     //Ensure the resolved job config for the first hop has the correct substitutions.
     Config jobConfig = jobSpec.getConfig();
-    Assert.assertEquals(jobConfig.getString("job.name"), "testFlowGroup:testFlowName:Distcp-HDFS-HDFS");
+    String flowGroup = "testFlowGroup";
+    String flowName = "testFlowName";
+    String expectedJobName1 = Joiner.on(JobExecutionPlan.Factory.JOB_NAME_COMPONENT_SEPARATION_CHAR).
+        join(flowGroup, flowName, "Distcp-HDFS-HDFS");
+    Assert.assertTrue(jobConfig.getString(ConfigurationKeys.JOB_NAME_KEY).startsWith(expectedJobName1));
     String from = jobConfig.getString("from");
     String to = jobConfig.getString("to");
     Assert.assertEquals(from, "/data/out/testTeam/testDataset");
@@ -210,7 +215,9 @@ public class MultiHopFlowCompilerTest {
     Dag.DagNode<JobExecutionPlan> secondHopNode = jobDag.getChildren(startNode).get(0);
     jobSpecWithExecutor = secondHopNode.getValue();
     jobConfig = jobSpecWithExecutor.getJobSpec().getConfig();
-    Assert.assertEquals(jobConfig.getString("job.name"), "testFlowGroup:testFlowName:convert-to-json-and-encrypt");
+    String expectedJobName2 = Joiner.on(JobExecutionPlan.Factory.JOB_NAME_COMPONENT_SEPARATION_CHAR).
+        join(flowGroup, flowName, "convert-to-json-and-encrypt");
+    Assert.assertTrue(jobConfig.getString(ConfigurationKeys.JOB_NAME_KEY).startsWith(expectedJobName2));
     from = jobConfig.getString("from");
     to = jobConfig.getString("to");
     Assert.assertEquals(from, "/data/out/testTeam/testDataset");
@@ -226,7 +233,9 @@ public class MultiHopFlowCompilerTest {
     Dag.DagNode<JobExecutionPlan> thirdHopNode = jobDag.getChildren(secondHopNode).get(0);
     jobSpecWithExecutor = thirdHopNode.getValue();
     jobConfig = jobSpecWithExecutor.getJobSpec().getConfig();
-    Assert.assertEquals(jobConfig.getString("job.name"), "testFlowGroup:testFlowName:Distcp-HDFS-HDFS");
+    String expectedJobName3 = Joiner.on(JobExecutionPlan.Factory.JOB_NAME_COMPONENT_SEPARATION_CHAR).
+        join(flowGroup, flowName, "Distcp-HDFS-HDFS");
+    Assert.assertTrue(jobConfig.getString(ConfigurationKeys.JOB_NAME_KEY).startsWith(expectedJobName3));
     from = jobConfig.getString("from");
     to = jobConfig.getString("to");
     Assert.assertEquals(from, "/data/encrypted/testTeam/testDataset");
@@ -246,7 +255,9 @@ public class MultiHopFlowCompilerTest {
     Dag.DagNode<JobExecutionPlan> fourthHopNode = jobDag.getChildren(thirdHopNode).get(0);
     jobSpecWithExecutor = fourthHopNode.getValue();
     jobConfig = jobSpecWithExecutor.getJobSpec().getConfig();
-    Assert.assertEquals(jobConfig.getString("job.name"), "testFlowGroup:testFlowName:Distcp-HDFS-ADL");
+    String expectedJobName4 = Joiner.on(JobExecutionPlan.Factory.JOB_NAME_COMPONENT_SEPARATION_CHAR).
+        join(flowGroup, flowName, "Distcp-HDFS-ADL");
+    Assert.assertTrue(jobConfig.getString(ConfigurationKeys.JOB_NAME_KEY).startsWith(expectedJobName4));
     from = jobConfig.getString("from");
     to = jobConfig.getString("to");
     Assert.assertEquals(from, "/data/encrypted/testTeam/testDataset");
@@ -287,7 +298,11 @@ public class MultiHopFlowCompilerTest {
 
     //Ensure the resolved job config for the first hop has the correct substitutions.
     Config jobConfig = jobSpec.getConfig();
-    Assert.assertEquals(jobConfig.getString("job.name"), "testFlowGroup:testFlowName:Distcp-HDFS-HDFS");
+    String flowGroup = "testFlowGroup";
+    String flowName = "testFlowName";
+    String expectedJobName1 = Joiner.on(JobExecutionPlan.Factory.JOB_NAME_COMPONENT_SEPARATION_CHAR).
+        join(flowGroup, flowName, "Distcp-HDFS-HDFS");
+    Assert.assertTrue(jobConfig.getString(ConfigurationKeys.JOB_NAME_KEY).startsWith(expectedJobName1));
     String from = jobConfig.getString("from");
     String to = jobConfig.getString("to");
     Assert.assertEquals(from, "/data/out/testTeam/testDataset");
@@ -314,7 +329,9 @@ public class MultiHopFlowCompilerTest {
     Dag.DagNode<JobExecutionPlan> secondHopNode = jobDag.getChildren(startNode).get(0);
     jobExecutionPlan = secondHopNode.getValue();
     jobConfig = jobExecutionPlan.getJobSpec().getConfig();
-    Assert.assertEquals(jobConfig.getString("job.name"), "testFlowGroup:testFlowName:convert-to-json-and-encrypt");
+    String expectedJobName2 = Joiner.on(JobExecutionPlan.Factory.JOB_NAME_COMPONENT_SEPARATION_CHAR).
+        join(flowGroup, flowName, "convert-to-json-and-encrypt");
+    Assert.assertTrue(jobConfig.getString(ConfigurationKeys.JOB_NAME_KEY).startsWith(expectedJobName2));
     from = jobConfig.getString("from");
     to = jobConfig.getString("to");
     Assert.assertEquals(from, "/data/out/testTeam/testDataset");
@@ -330,7 +347,9 @@ public class MultiHopFlowCompilerTest {
     Dag.DagNode<JobExecutionPlan> thirdHopNode = jobDag.getChildren(secondHopNode).get(0);
     jobExecutionPlan = thirdHopNode.getValue();
     jobConfig = jobExecutionPlan.getJobSpec().getConfig();
-    Assert.assertEquals(jobConfig.getString("job.name"), "testFlowGroup:testFlowName:Distcp-HDFS-HDFS");
+    String expectedJobName3 = Joiner.on(JobExecutionPlan.Factory.JOB_NAME_COMPONENT_SEPARATION_CHAR).
+        join(flowGroup, flowName, "Distcp-HDFS-HDFS");
+    Assert.assertTrue(jobConfig.getString(ConfigurationKeys.JOB_NAME_KEY).startsWith(expectedJobName3));
     from = jobConfig.getString("from");
     to = jobConfig.getString("to");
     Assert.assertEquals(from, "/data/encrypted/testTeam/testDataset");
@@ -350,7 +369,10 @@ public class MultiHopFlowCompilerTest {
     Dag.DagNode<JobExecutionPlan> fourthHopNode = jobDag.getChildren(thirdHopNode).get(0);
     jobExecutionPlan = fourthHopNode.getValue();
     jobConfig = jobExecutionPlan.getJobSpec().getConfig();
-    Assert.assertEquals(jobConfig.getString("job.name"), "testFlowGroup:testFlowName:Distcp-HDFS-ADL");
+
+    String expectedJobName4 = Joiner.on(JobExecutionPlan.Factory.JOB_NAME_COMPONENT_SEPARATION_CHAR).
+        join(flowGroup, flowName, "Distcp-HDFS-ADL");
+    Assert.assertTrue(jobConfig.getString(ConfigurationKeys.JOB_NAME_KEY).startsWith(expectedJobName4));
     from = jobConfig.getString("from");
     to = jobConfig.getString("to");
     Assert.assertEquals(from, "/data/encrypted/testTeam/testDataset");

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/flow/MultiHopFlowCompilerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/flow/MultiHopFlowCompilerTest.java
@@ -169,6 +169,7 @@ public class MultiHopFlowCompilerTest {
     FlowSpec spec = flowSpecBuilder.build();
     return spec;
   }
+
   @Test
   public void testCompileFlow() throws URISyntaxException, IOException {
     FlowSpec spec = createFlowSpec("flow/flow.conf", "LocalFS-1", "ADLS-1");
@@ -188,7 +189,8 @@ public class MultiHopFlowCompilerTest {
     String flowName = "testFlowName";
     String expectedJobName1 = Joiner.on(JobExecutionPlan.Factory.JOB_NAME_COMPONENT_SEPARATION_CHAR).
         join(flowGroup, flowName, "Distcp-HDFS-HDFS");
-    Assert.assertTrue(jobConfig.getString(ConfigurationKeys.JOB_NAME_KEY).startsWith(expectedJobName1));
+    String jobName1 = jobConfig.getString(ConfigurationKeys.JOB_NAME_KEY);
+    Assert.assertTrue(jobName1.startsWith(expectedJobName1));
     String from = jobConfig.getString("from");
     String to = jobConfig.getString("to");
     Assert.assertEquals(from, "/data/out/testTeam/testDataset");
@@ -217,7 +219,9 @@ public class MultiHopFlowCompilerTest {
     jobConfig = jobSpecWithExecutor.getJobSpec().getConfig();
     String expectedJobName2 = Joiner.on(JobExecutionPlan.Factory.JOB_NAME_COMPONENT_SEPARATION_CHAR).
         join(flowGroup, flowName, "convert-to-json-and-encrypt");
-    Assert.assertTrue(jobConfig.getString(ConfigurationKeys.JOB_NAME_KEY).startsWith(expectedJobName2));
+    String jobName2 = jobConfig.getString(ConfigurationKeys.JOB_NAME_KEY);
+    Assert.assertTrue(jobName2.startsWith(expectedJobName2));
+    Assert.assertEquals(jobConfig.getString(ConfigurationKeys.JOB_DEPENDENCIES), jobName1);
     from = jobConfig.getString("from");
     to = jobConfig.getString("to");
     Assert.assertEquals(from, "/data/out/testTeam/testDataset");
@@ -235,7 +239,9 @@ public class MultiHopFlowCompilerTest {
     jobConfig = jobSpecWithExecutor.getJobSpec().getConfig();
     String expectedJobName3 = Joiner.on(JobExecutionPlan.Factory.JOB_NAME_COMPONENT_SEPARATION_CHAR).
         join(flowGroup, flowName, "Distcp-HDFS-HDFS");
-    Assert.assertTrue(jobConfig.getString(ConfigurationKeys.JOB_NAME_KEY).startsWith(expectedJobName3));
+    String jobName3 = jobConfig.getString(ConfigurationKeys.JOB_NAME_KEY);
+    Assert.assertTrue(jobName3.startsWith(expectedJobName3));
+    Assert.assertEquals(jobConfig.getString(ConfigurationKeys.JOB_DEPENDENCIES), jobName2);
     from = jobConfig.getString("from");
     to = jobConfig.getString("to");
     Assert.assertEquals(from, "/data/encrypted/testTeam/testDataset");
@@ -257,7 +263,9 @@ public class MultiHopFlowCompilerTest {
     jobConfig = jobSpecWithExecutor.getJobSpec().getConfig();
     String expectedJobName4 = Joiner.on(JobExecutionPlan.Factory.JOB_NAME_COMPONENT_SEPARATION_CHAR).
         join(flowGroup, flowName, "Distcp-HDFS-ADL");
-    Assert.assertTrue(jobConfig.getString(ConfigurationKeys.JOB_NAME_KEY).startsWith(expectedJobName4));
+    String jobName4 = jobConfig.getString(ConfigurationKeys.JOB_NAME_KEY);
+    Assert.assertTrue(jobName4.startsWith(expectedJobName4));
+    Assert.assertEquals(jobConfig.getString(ConfigurationKeys.JOB_DEPENDENCIES), jobName3);
     from = jobConfig.getString("from");
     to = jobConfig.getString("to");
     Assert.assertEquals(from, "/data/encrypted/testTeam/testDataset");
@@ -302,7 +310,8 @@ public class MultiHopFlowCompilerTest {
     String flowName = "testFlowName";
     String expectedJobName1 = Joiner.on(JobExecutionPlan.Factory.JOB_NAME_COMPONENT_SEPARATION_CHAR).
         join(flowGroup, flowName, "Distcp-HDFS-HDFS");
-    Assert.assertTrue(jobConfig.getString(ConfigurationKeys.JOB_NAME_KEY).startsWith(expectedJobName1));
+    String jobName1 = jobConfig.getString(ConfigurationKeys.JOB_NAME_KEY);
+    Assert.assertTrue(jobName1.startsWith(expectedJobName1));
     String from = jobConfig.getString("from");
     String to = jobConfig.getString("to");
     Assert.assertEquals(from, "/data/out/testTeam/testDataset");
@@ -331,7 +340,9 @@ public class MultiHopFlowCompilerTest {
     jobConfig = jobExecutionPlan.getJobSpec().getConfig();
     String expectedJobName2 = Joiner.on(JobExecutionPlan.Factory.JOB_NAME_COMPONENT_SEPARATION_CHAR).
         join(flowGroup, flowName, "convert-to-json-and-encrypt");
-    Assert.assertTrue(jobConfig.getString(ConfigurationKeys.JOB_NAME_KEY).startsWith(expectedJobName2));
+    String jobName2 = jobConfig.getString(ConfigurationKeys.JOB_NAME_KEY);
+    Assert.assertTrue(jobName2.startsWith(expectedJobName2));
+    Assert.assertEquals(jobConfig.getString(ConfigurationKeys.JOB_DEPENDENCIES), jobName1);
     from = jobConfig.getString("from");
     to = jobConfig.getString("to");
     Assert.assertEquals(from, "/data/out/testTeam/testDataset");
@@ -349,7 +360,9 @@ public class MultiHopFlowCompilerTest {
     jobConfig = jobExecutionPlan.getJobSpec().getConfig();
     String expectedJobName3 = Joiner.on(JobExecutionPlan.Factory.JOB_NAME_COMPONENT_SEPARATION_CHAR).
         join(flowGroup, flowName, "Distcp-HDFS-HDFS");
-    Assert.assertTrue(jobConfig.getString(ConfigurationKeys.JOB_NAME_KEY).startsWith(expectedJobName3));
+    String jobName3 = jobConfig.getString(ConfigurationKeys.JOB_NAME_KEY);
+    Assert.assertTrue(jobName3.startsWith(expectedJobName3));
+    Assert.assertEquals(jobConfig.getString(ConfigurationKeys.JOB_DEPENDENCIES), jobName2);
     from = jobConfig.getString("from");
     to = jobConfig.getString("to");
     Assert.assertEquals(from, "/data/encrypted/testTeam/testDataset");
@@ -372,7 +385,9 @@ public class MultiHopFlowCompilerTest {
 
     String expectedJobName4 = Joiner.on(JobExecutionPlan.Factory.JOB_NAME_COMPONENT_SEPARATION_CHAR).
         join(flowGroup, flowName, "Distcp-HDFS-ADL");
-    Assert.assertTrue(jobConfig.getString(ConfigurationKeys.JOB_NAME_KEY).startsWith(expectedJobName4));
+    String jobName4 = jobConfig.getString(ConfigurationKeys.JOB_NAME_KEY);
+    Assert.assertTrue(jobName4.startsWith(expectedJobName4));
+    Assert.assertEquals(jobConfig.getString(ConfigurationKeys.JOB_DEPENDENCIES), jobName3);
     from = jobConfig.getString("from");
     to = jobConfig.getString("to");
     Assert.assertEquals(from, "/data/encrypted/testTeam/testDataset");

--- a/gobblin-service/src/test/resources/template_catalog/flowEdgeTemplate/jobs/job2.job
+++ b/gobblin-service/src/test/resources/template_catalog/flowEdgeTemplate/jobs/job2.job
@@ -1,3 +1,2 @@
 gobblin.template.uri="resource:///template_catalog/templates/job2.template"
-
-dependencies=job1
+job.dependencies=job1

--- a/gobblin-service/src/test/resources/template_catalog/flowEdgeTemplate/jobs/job3.job
+++ b/gobblin-service/src/test/resources/template_catalog/flowEdgeTemplate/jobs/job3.job
@@ -1,2 +1,2 @@
 gobblin.template.uri="resource:///template_catalog/templates/job3.template"
-dependencies=job1
+job.dependencies=job1

--- a/gobblin-service/src/test/resources/template_catalog/flowEdgeTemplate/jobs/job4.job
+++ b/gobblin-service/src/test/resources/template_catalog/flowEdgeTemplate/jobs/job4.job
@@ -1,2 +1,2 @@
 gobblin.template.uri="resource:///template_catalog/templates/job4.template"
-dependencies="job2,job3"
+job.dependencies="job2,job3"

--- a/gobblin-service/src/test/resources/template_catalog/templates/job1.template
+++ b/gobblin-service/src/test/resources/template_catalog/templates/job1.template
@@ -1,2 +1,3 @@
+job.name=job1
 key11=val11
 key12=val12

--- a/gobblin-service/src/test/resources/template_catalog/templates/job2.template
+++ b/gobblin-service/src/test/resources/template_catalog/templates/job2.template
@@ -1,2 +1,3 @@
+job.name=job2
 key21=val21
 key22=val22

--- a/gobblin-service/src/test/resources/template_catalog/templates/job3.template
+++ b/gobblin-service/src/test/resources/template_catalog/templates/job3.template
@@ -1,2 +1,3 @@
+job.name=job3
 key31=val31
 key32=val32

--- a/gobblin-service/src/test/resources/template_catalog/templates/job4.template
+++ b/gobblin-service/src/test/resources/template_catalog/templates/job4.template
@@ -1,2 +1,3 @@
+job.name=job4
 key41=val41
 key42=val42

--- a/gobblin-service/src/test/resources/template_catalog/test-template/jobs/job2.job
+++ b/gobblin-service/src/test/resources/template_catalog/test-template/jobs/job2.job
@@ -1,3 +1,2 @@
 gobblin.template.uri=resource:///template_catalog/templates/job2.template
-
-dependencies=job1
+job.dependencies=job1

--- a/gobblin-service/src/test/resources/template_catalog/test-template/jobs/job3.job
+++ b/gobblin-service/src/test/resources/template_catalog/test-template/jobs/job3.job
@@ -1,2 +1,2 @@
 gobblin.template.uri=resource:///template_catalog/templates/job3.template
-dependencies=job1
+job.dependencies=job1

--- a/gobblin-service/src/test/resources/template_catalog/test-template/jobs/job4.job
+++ b/gobblin-service/src/test/resources/template_catalog/test-template/jobs/job4.job
@@ -1,2 +1,2 @@
 gobblin.template.uri=resource:///template_catalog/templates/job4.template
-dependencies=job2,job3
+job.dependencies=job2,job3


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-604

### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
The dependencies list in job templates (specified in job.dependencies config) are based on file names of job templates. But since the same job template could be re-used across multiple jobs in a multi-hop flow, the dependencies need to be made unique to avoid collisions. 


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Enhanced test cases in MultiHopFlowCompilerTest class.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

