### PR TITLE
GOBBLIN-605: Avoid setting the flowExecutionId twice during path finding in Multi-hop flow compilation.

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/pathfinder/BFSPathFinder.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/pathfinder/BFSPathFinder.java
@@ -75,9 +75,6 @@ public class BFSPathFinder extends AbstractPathFinder {
       //Initialization of auxiliary data structures used for path computation
       this.pathMap = new HashMap<>();
 
-      // Generate flow execution id for this compilation
-      this.flowExecutionId = System.currentTimeMillis();
-
       //Path computation must be thread-safe to guarantee read consistency. In other words, we prevent concurrent read/write access to the
       // flow graph.
         //Base condition 1: Source Node or Dest Node is inactive; return null


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-605


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
The flow execution id is currently set twice - once during instantiation of PathFinder and also during findPath() call. This prevents correct tracking of Flow and job statuses.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Trivial change.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

