### PR TITLE
[GOBBLIN-607] Reduce logging in gobblin-runtime tests

### DIFF
--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/mapreduce/MRTaskFactoryTest.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/mapreduce/MRTaskFactoryTest.java
@@ -48,6 +48,7 @@ import org.apache.hadoop.mapreduce.Reducer;
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.log4j.AppenderSkeleton;
+import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.apache.log4j.spi.LoggingEvent;
@@ -77,6 +78,7 @@ public class MRTaskFactoryTest {
 
     TestAppender testAppender = new TestAppender();
     Logger logger = LogManager.getLogger(MRTask.class.getName());
+    logger.setLevel(Level.INFO);
     logger.addAppender(testAppender);
 
     EmbeddedGobblin embeddedGobblin = new EmbeddedGobblin("WordCounter")

--- a/gobblin-runtime/src/test/resources/log4j.xml
+++ b/gobblin-runtime/src/test/resources/log4j.xml
@@ -28,7 +28,7 @@
   </appender>
 
   <root>
-    <level value="info" />
+    <level value="warn" />
     <appender-ref ref="console" />
   </root>
 


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-607


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
There is too much logging the results in failure in Travis. Reduce the log level to WARN.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

