### PR TITLE
[GOBBLIN-609] Change config store to append to path part of URI

### DIFF
--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/ConfigStoreUtils.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/ConfigStoreUtils.java
@@ -81,10 +81,11 @@ public class ConfigStoreUtils {
 
   public static URI getUriStringForTopic(String topicName, String commonPath, String configStoreUri)
       throws URISyntaxException {
-    Path path =
-        PathUtils.mergePaths(new Path(configStoreUri), PathUtils.mergePaths(new Path(commonPath), new Path(topicName)));
-    log.info("URI for topic is : " + path.toString());
-    return new URI(path.toString());
+    URI storeUri = new URI(configStoreUri);
+    Path path = PathUtils.mergePaths(new Path(storeUri.getPath()), PathUtils.mergePaths(new Path(commonPath), new Path(topicName)));
+    URI topicUri = new URI(storeUri.getScheme(), storeUri.getAuthority(), path.toString(), storeUri.getQuery(), storeUri.getFragment());
+    log.info("URI for topic is : " + topicUri.toString());
+    return topicUri;
   }
 
   public static Optional<Config> getConfigForTopic(Properties properties, String topicKey, ConfigClient configClient) {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-609


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

Previously, when getting config store by topic, the relative path is just added to the end of the config store URI. This is incorrect for URIs with a query portion, it should be added to the path portion of the URI.

Also modified `IvyConfigStoreFactory` to take HDFS location as part of the query since the path portion is being used for the relative path.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Manually tested

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

