### PR TITLE
[GOBBLIN-613] Using the hadoop tokens fetched by WormholePushJob instead of negotia…

### DIFF
--- a/gobblin-modules/gobblin-azkaban/src/main/java/org/apache/gobblin/azkaban/AzkabanJobLauncher.java
+++ b/gobblin-modules/gobblin-azkaban/src/main/java/org/apache/gobblin/azkaban/AzkabanJobLauncher.java
@@ -113,8 +113,9 @@ public class AzkabanJobLauncher extends AbstractJob implements ApplicationLaunch
   private static final String HADOOP_JAVA_JOB = "hadoopJava";
   private static final String JAVA_JOB = "java";
   private static final String GOBBLIN_JOB = "gobblin";
+  private static final String WORMHOLE_PUSH_JOB = "WormholePushJob";
   private static final Set<String> JOB_TYPES_WITH_AUTOMATIC_TOKEN =
-      Sets.newHashSet(HADOOP_JAVA_JOB, JAVA_JOB, GOBBLIN_JOB);
+      Sets.newHashSet(HADOOP_JAVA_JOB, JAVA_JOB, GOBBLIN_JOB, WORMHOLE_PUSH_JOB);
 
   private final Closer closer = Closer.create();
   private final JobLauncher jobLauncher;


### PR DESCRIPTION
…ting them via Gobblin

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [GOBBLIN-613](https://issues.apache.org/jira/browse/GOBBLIN-613) issues and references them in the PR title. 

### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
We use the Hadoop tokens provided by the WormholePushJob, instead of relying on Gobblin to negotiate them. Each WormohlePushJob is going to be run with the appropriate headless account and Gobblin does not have access to these keytabs from inside the Azkaban process. So, we need to include WormohlePushJob job type in the job types with automatic token.


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

