### PR TITLE
GOBBLIN-616: Add ability to fork jobs when concatenating Dags.

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -176,6 +176,7 @@ public class ConfigurationKeys {
   public static final String WORK_UNIT_ENABLE_TRACKING_LOGS = "workunit.enableTrackingLogs";
 
   public static final String JOB_DEPENDENCIES = "job.dependencies";
+  public static final String JOB_ISLEAF = "job.isLeaf";
   public static final String JOB_RUN_ONCE_KEY = "job.runonce";
   public static final String JOB_DISABLED_KEY = "job.disabled";
   public static final String JOB_JAR_FILES_KEY = "job.jars";

--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -176,7 +176,7 @@ public class ConfigurationKeys {
   public static final String WORK_UNIT_ENABLE_TRACKING_LOGS = "workunit.enableTrackingLogs";
 
   public static final String JOB_DEPENDENCIES = "job.dependencies";
-  public static final String JOB_ISLEAF = "job.isLeaf";
+  public static final String JOB_FORK_ON_CONCAT = "job.forkOnConcat";
   public static final String JOB_RUN_ONCE_KEY = "job.runonce";
   public static final String JOB_DISABLED_KEY = "job.disabled";
   public static final String JOB_JAR_FILES_KEY = "job.jars";

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/Dag.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/Dag.java
@@ -20,8 +20,10 @@ package org.apache.gobblin.service.modules.flowgraph;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import com.google.common.collect.Lists;
 
@@ -101,6 +103,21 @@ public class Dag<T> {
    * @return the concatenated dag
    */
   public Dag<T> concatenate(Dag<T> other) {
+    return concatenate(other, new HashSet<>());
+  }
+
+  /**
+   * Concatenate two dags together. Join the "other" dag to "this" dag and return "this" dag.
+   * The concatenate method ensures that all the jobs of "this" dag (which may have multiple end nodes)
+   * are completed before starting any job of the "other" dag. This is done by adding each endNode of this dag as
+   * a parent of every startNode of the other dag.
+   *
+   * @param other dag to concatenate to this dag
+   * @param leafNodes a set of nodes from this dag which are marked as leaf nodes. Each of these nodes will be added
+   *                  to the list of end nodes of the concatenated dag.
+   * @return the concatenated dag
+   */
+  public Dag<T> concatenate(Dag<T> other, Set<DagNode<T>> leafNodes) {
     if (other == null || other.isEmpty()) {
       return this;
     }
@@ -108,13 +125,18 @@ public class Dag<T> {
       return other;
     }
     for (DagNode node : this.endNodes) {
-      this.parentChildMap.put(node, Lists.newArrayList());
-      for (DagNode otherNode : other.startNodes) {
-        this.parentChildMap.get(node).add(otherNode);
-        otherNode.addParentNode(node);
+      if (!leafNodes.contains(node)) {
+        this.parentChildMap.put(node, Lists.newArrayList());
+        for (DagNode otherNode : other.startNodes) {
+          this.parentChildMap.get(node).add(otherNode);
+          otherNode.addParentNode(node);
+        }
+        this.endNodes = other.endNodes;
       }
-      this.endNodes = other.endNodes;
     }
+
+    //Each node which is a leaf node is added to list of end nodes
+    other.endNodes.addAll(leafNodes);
     //Append all the entries from the other dag's parentChildMap to this dag's parentChildMap
     for (Map.Entry<DagNode, List<DagNode<T>>> entry: other.parentChildMap.entrySet()) {
       this.parentChildMap.put(entry.getKey(), entry.getValue());
@@ -177,10 +199,7 @@ public class Dag<T> {
         return false;
       }
       DagNode that = (DagNode) o;
-      if (!this.getValue().equals(that.getValue())) {
-        return false;
-      }
-      return true;
+      return this.getValue().equals(that.getValue());
     }
 
     @Override

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/Dag.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/Dag.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -148,11 +147,7 @@ public class Dag<T> {
     this.endNodes = other.endNodes;
 
     //Append all the entries from the other dag's parentChildMap to this dag's parentChildMap
-    for (Iterator<Map.Entry<DagNode, List<DagNode<T>>>> iterator = other.parentChildMap.entrySet().iterator();
-        iterator.hasNext(); ) {
-      Map.Entry<DagNode, List<DagNode<T>>> entry = iterator.next();
-      this.parentChildMap.put(entry.getKey(), entry.getValue());
-    }
+    this.parentChildMap.putAll(other.parentChildMap);
 
     //If there exists a node in the other dag with no parent nodes, add it to the list of start nodes of the
     // concatenated dag.

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/flow/FlowGraphPathTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/flow/FlowGraphPathTest.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gobblin.service.modules.flow;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigValueFactory;
+
+import org.apache.gobblin.config.ConfigBuilder;
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.runtime.api.JobSpec;
+import org.apache.gobblin.runtime.api.SpecExecutor;
+import org.apache.gobblin.runtime.spec_executorInstance.InMemorySpecExecutor;
+import org.apache.gobblin.service.modules.flowgraph.Dag;
+import org.apache.gobblin.service.modules.spec.JobExecutionPlan;
+import org.apache.gobblin.service.modules.spec.JobExecutionPlanDagFactory;
+
+public class FlowGraphPathTest {
+
+  /**
+   * A method to create a {@link Dag <JobExecutionPlan>}.
+   * @return a Dag.
+   */
+  public Dag<JobExecutionPlan> buildDag(int numNodes, int startNodeId, boolean isForkable) throws URISyntaxException {
+    List<JobExecutionPlan> jobExecutionPlans = new ArrayList<>();
+    Config baseConfig = ConfigBuilder.create().
+        addPrimitive(ConfigurationKeys.FLOW_GROUP_KEY, "group0").
+        addPrimitive(ConfigurationKeys.FLOW_NAME_KEY, "flow0").
+        addPrimitive(ConfigurationKeys.FLOW_EXECUTION_ID_KEY, System.currentTimeMillis()).
+        addPrimitive(ConfigurationKeys.JOB_GROUP_KEY, "group0").build();
+    for (int i = startNodeId; i < startNodeId + numNodes; i++) {
+      String suffix = Integer.toString(i);
+      Config jobConfig = baseConfig.withValue(ConfigurationKeys.JOB_NAME_KEY, ConfigValueFactory.fromAnyRef("job" + suffix));
+      if (isForkable && (i == startNodeId + numNodes - 1)) {
+        jobConfig = jobConfig.withValue(ConfigurationKeys.JOB_FORK_ON_CONCAT, ConfigValueFactory.fromAnyRef(true));
+      }
+      if (i > startNodeId) {
+        jobConfig = jobConfig.withValue(ConfigurationKeys.JOB_DEPENDENCIES, ConfigValueFactory.fromAnyRef("job" + (i  - 1)));
+      }
+      JobSpec js = JobSpec.builder("test_job" + suffix).withVersion(suffix).withConfig(jobConfig).
+          withTemplate(new URI("job" + suffix)).build();
+      SpecExecutor specExecutor = InMemorySpecExecutor.createDummySpecExecutor(new URI("job" + i));
+      JobExecutionPlan jobExecutionPlan = new JobExecutionPlan(js, specExecutor);
+      jobExecutionPlans.add(jobExecutionPlan);
+    }
+    return new JobExecutionPlanDagFactory().createDag(jobExecutionPlans);
+  }
+
+  @Test
+  public void testConcatenate() throws URISyntaxException {
+    //Dag1: "job0->job1", Dag2: "job2->job3"
+    Dag<JobExecutionPlan> dag1 = buildDag(2, 0, false);
+    Dag<JobExecutionPlan> dag2 = buildDag(2, 2, false);
+    Dag<JobExecutionPlan> dagNew = FlowGraphPath.concatenate(dag1, dag2);
+
+    //Expected result: "job0"->"job1"->"job2"->"job3"
+    Assert.assertEquals(dagNew.getStartNodes().size(), 1);
+    Assert.assertEquals(dagNew.getEndNodes().size(), 1);
+    Assert.assertEquals(dagNew.getNodes().size(), 4);
+    Assert.assertEquals(dagNew.getStartNodes().get(0).getValue().getJobSpec().getConfig().getString(ConfigurationKeys.JOB_NAME_KEY), "job0");
+    Assert.assertEquals(dagNew.getEndNodes().get(0).getValue().getJobSpec().getConfig().getString(ConfigurationKeys.JOB_NAME_KEY), "job3");
+    Assert.assertEquals(dagNew.getEndNodes().get(0).getValue().getJobSpec().getConfig().getString(ConfigurationKeys.JOB_DEPENDENCIES), "job2");
+
+    //Dag1: "job0", Dag2: "job1->job2", "job0" forkable
+    dag1 = buildDag(1, 0, true);
+    dag2 = buildDag(2, 1, false);
+    dagNew = FlowGraphPath.concatenate(dag1, dag2);
+
+    //Expected result: "job0", "job1" -> "job2"
+    Assert.assertEquals(dagNew.getStartNodes().size(), 2);
+    Assert.assertEquals(dagNew.getEndNodes().size(), 2);
+    Assert.assertEquals(dagNew.getNodes().size(), 3);
+    Assert.assertEquals(dagNew.getStartNodes().get(0).getValue().getJobSpec().getConfig().getString(ConfigurationKeys.JOB_NAME_KEY), "job0");
+    Assert.assertEquals(dagNew.getStartNodes().get(1).getValue().getJobSpec().getConfig().getString(ConfigurationKeys.JOB_NAME_KEY), "job1");
+    Assert.assertEquals(dagNew.getEndNodes().get(0).getValue().getJobSpec().getConfig().getString(ConfigurationKeys.JOB_NAME_KEY), "job2");
+    Assert.assertEquals(dagNew.getEndNodes().get(0).getValue().getJobSpec().getConfig().getString(ConfigurationKeys.JOB_DEPENDENCIES), "job1");
+    Assert.assertEquals(dagNew.getEndNodes().get(1).getValue().getJobSpec().getConfig().getString(ConfigurationKeys.JOB_NAME_KEY), "job0");
+    Assert.assertFalse(dagNew.getEndNodes().get(1).getValue().getJobSpec().getConfig().hasPath(ConfigurationKeys.JOB_DEPENDENCIES));
+
+    //Dag1: "job0->job1", Dag2: "job2->job3", "job1" forkable
+    dag1 = buildDag(2, 0, true);
+    dag2 = buildDag(2, 2, false);
+    dagNew = FlowGraphPath.concatenate(dag1, dag2);
+
+    //Expected result: "job0" -> "job1"
+    //                        \-> "job2" -> "job3"
+    Assert.assertEquals(dagNew.getStartNodes().size(), 1);
+    Assert.assertEquals(dagNew.getEndNodes().size(), 2);
+    Assert.assertEquals(dagNew.getNodes().size(), 4);
+    Assert.assertEquals(dagNew.getStartNodes().get(0).getValue().getJobSpec().getConfig().getString(ConfigurationKeys.JOB_NAME_KEY), "job0");
+    Assert.assertEquals(dagNew.getEndNodes().get(0).getValue().getJobSpec().getConfig().getString(ConfigurationKeys.JOB_NAME_KEY), "job3");
+    Assert.assertEquals(dagNew.getEndNodes().get(0).getValue().getJobSpec().getConfig().getString(ConfigurationKeys.JOB_DEPENDENCIES), "job2");
+    Assert.assertEquals(dagNew.getEndNodes().get(1).getValue().getJobSpec().getConfig().getString(ConfigurationKeys.JOB_NAME_KEY), "job1");
+    Assert.assertEquals(dagNew.getEndNodes().get(1).getValue().getJobSpec().getConfig().getString(ConfigurationKeys.JOB_DEPENDENCIES), "job0");
+
+    //Dag1: "job0", Dag2: "job1"
+    dag1 = buildDag(1, 0, true);
+    dag2 = buildDag(1, 1, false);
+    dagNew = FlowGraphPath.concatenate(dag1, dag2);
+
+    //Expected result: "job0","job1"
+    Assert.assertEquals(dagNew.getStartNodes().size(), 2);
+    Assert.assertEquals(dagNew.getEndNodes().size(), 2);
+    Assert.assertEquals(dagNew.getNodes().size(), 2);
+    Assert.assertEquals(dagNew.getStartNodes().get(0).getValue().getJobSpec().getConfig().getString(ConfigurationKeys.JOB_NAME_KEY), "job0");
+    Assert.assertEquals(dagNew.getStartNodes().get(1).getValue().getJobSpec().getConfig().getString(ConfigurationKeys.JOB_NAME_KEY), "job1");
+    Assert.assertFalse(dagNew.getStartNodes().get(1).getValue().getJobSpec().getConfig().hasPath(ConfigurationKeys.JOB_DEPENDENCIES));
+    Assert.assertFalse(dagNew.getStartNodes().get(1).getValue().getJobSpec().getConfig().hasPath(ConfigurationKeys.JOB_DEPENDENCIES));
+
+
+  }
+
+
+}

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/flowgraph/DagTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/flowgraph/DagTest.java
@@ -23,21 +23,25 @@ import java.util.Set;
 
 import org.testng.Assert;
 import org.testng.annotations.Test;
+import org.testng.collections.Sets;
 
 import com.google.common.collect.Lists;
 
 import lombok.extern.slf4j.Slf4j;
+
+import org.apache.gobblin.service.modules.flowgraph.Dag.DagNode;
+import org.apache.gobblin.service.modules.spec.JobExecutionPlan;
 
 
 @Slf4j
 public class DagTest {
   @Test
   public void testInitialize() {
-    Dag.DagNode<String> dagNode1 = new Dag.DagNode<>("val1");
-    Dag.DagNode<String> dagNode2 = new Dag.DagNode<>("val2");
-    Dag.DagNode<String> dagNode3 = new Dag.DagNode<>("val3");
-    Dag.DagNode<String> dagNode4 = new Dag.DagNode<>("val4");
-    Dag.DagNode<String> dagNode5 = new Dag.DagNode<>("val5");
+    DagNode<String> dagNode1 = new DagNode<>("val1");
+    DagNode<String> dagNode2 = new DagNode<>("val2");
+    DagNode<String> dagNode3 = new DagNode<>("val3");
+    DagNode<String> dagNode4 = new DagNode<>("val4");
+    DagNode<String> dagNode5 = new DagNode<>("val5");
 
     dagNode2.addParentNode(dagNode1);
     dagNode3.addParentNode(dagNode1);
@@ -45,7 +49,7 @@ public class DagTest {
     dagNode4.addParentNode(dagNode3);
     dagNode5.addParentNode(dagNode3);
 
-    List<Dag.DagNode<String>> dagNodeList = Lists.newArrayList(dagNode1, dagNode2, dagNode3, dagNode4, dagNode5);
+    List<DagNode<String>> dagNodeList = Lists.newArrayList(dagNode1, dagNode2, dagNode3, dagNode4, dagNode5);
     Dag<String> dag = new Dag<>(dagNodeList);
     //Test startNodes and endNodes
     Assert.assertEquals(dag.getStartNodes().size(), 1);
@@ -55,10 +59,10 @@ public class DagTest {
     Assert.assertEquals(dag.getEndNodes().get(1).getValue(), "val5");
 
 
-    Dag.DagNode startNode = dag.getStartNodes().get(0);
+    DagNode startNode = dag.getStartNodes().get(0);
     Assert.assertEquals(dag.getChildren(startNode).size(), 2);
     Set<String> childSet = new HashSet<>();
-    for (Dag.DagNode<String> node: dag.getChildren(startNode)) {
+    for (DagNode<String> node: dag.getChildren(startNode)) {
       childSet.add(node.getValue());
     }
     Assert.assertTrue(childSet.contains("val2"));
@@ -70,7 +74,7 @@ public class DagTest {
     Assert.assertEquals(dag.getChildren(dagNode2).size(), 1);
     Assert.assertEquals(dag.getChildren(dagNode2).get(0).getValue(), "val4");
 
-    for (Dag.DagNode<String> node: dag.getChildren(dagNode3)) {
+    for (DagNode<String> node: dag.getChildren(dagNode3)) {
       childSet.add(node.getValue());
     }
     Assert.assertTrue(childSet.contains("val4"));
@@ -83,11 +87,11 @@ public class DagTest {
 
   @Test
   public void testConcatenate() {
-    Dag.DagNode<String> dagNode1 = new Dag.DagNode<>("val1");
-    Dag.DagNode<String> dagNode2 = new Dag.DagNode<>("val2");
-    Dag.DagNode<String> dagNode3 = new Dag.DagNode<>("val3");
-    Dag.DagNode<String> dagNode4 = new Dag.DagNode<>("val4");
-    Dag.DagNode<String> dagNode5 = new Dag.DagNode<>("val5");
+    DagNode<String> dagNode1 = new DagNode<>("val1");
+    DagNode<String> dagNode2 = new DagNode<>("val2");
+    DagNode<String> dagNode3 = new DagNode<>("val3");
+    DagNode<String> dagNode4 = new DagNode<>("val4");
+    DagNode<String> dagNode5 = new DagNode<>("val5");
 
     dagNode2.addParentNode(dagNode1);
     dagNode3.addParentNode(dagNode1);
@@ -95,21 +99,20 @@ public class DagTest {
     dagNode4.addParentNode(dagNode3);
     dagNode5.addParentNode(dagNode3);
 
-    List<Dag.DagNode<String>> dagNodeList = Lists.newArrayList(dagNode1, dagNode2, dagNode3, dagNode4, dagNode5);
+    List<DagNode<String>> dagNodeList = Lists.newArrayList(dagNode1, dagNode2, dagNode3, dagNode4, dagNode5);
     Dag<String> dag1 = new Dag<>(dagNodeList);
 
-    Dag.DagNode<String> dagNode6 = new Dag.DagNode<>("val6");
-    Dag.DagNode<String> dagNode7 = new Dag.DagNode<>("val7");
-    Dag.DagNode<String> dagNode8 = new Dag.DagNode<>("val8");
+    DagNode<String> dagNode6 = new DagNode<>("val6");
+    DagNode<String> dagNode7 = new DagNode<>("val7");
+    DagNode<String> dagNode8 = new DagNode<>("val8");
     dagNode8.addParentNode(dagNode6);
     dagNode8.addParentNode(dagNode7);
     Dag<String> dag2 = new Dag<>(Lists.newArrayList(dagNode6, dagNode7, dagNode8));
 
-    //Concatenate the two dags
     Dag<String> dagNew = dag1.concatenate(dag2);
 
     //Ensure end nodes of first dag are no longer end nodes
-    for (Dag.DagNode<String> dagNode: Lists.newArrayList(dagNode6, dagNode7)) {
+    for (DagNode<String> dagNode : Lists.newArrayList(dagNode6, dagNode7)) {
       Assert.assertEquals(dagNew.getParents(dagNode).size(), 2);
       Set<String> set = new HashSet<>();
       set.add(dagNew.getParents(dagNode).get(0).getValue());
@@ -118,7 +121,7 @@ public class DagTest {
       Assert.assertTrue(set.contains("val5"));
     }
 
-    for (Dag.DagNode<String> dagNode: Lists.newArrayList(dagNode4, dagNode5)) {
+    for (DagNode<String> dagNode : Lists.newArrayList(dagNode4, dagNode5)) {
       Assert.assertEquals(dagNew.getChildren(dagNode).size(), 2);
       Set<String> set = new HashSet<>();
       set.add(dagNew.getChildren(dagNode).get(0).getValue());
@@ -127,8 +130,8 @@ public class DagTest {
       Assert.assertTrue(set.contains("val7"));
     }
 
-    for (Dag.DagNode<String> dagNode: Lists.newArrayList(dagNode6, dagNode7)) {
-      List<Dag.DagNode<String>> nextNodes = dagNew.getChildren(dagNode);
+    for (DagNode<String> dagNode : Lists.newArrayList(dagNode6, dagNode7)) {
+      List<DagNode<String>> nextNodes = dagNew.getChildren(dagNode);
       Assert.assertEquals(nextNodes.size(), 1);
       Assert.assertEquals(nextNodes.get(0).getValue(), "val8");
     }
@@ -142,12 +145,35 @@ public class DagTest {
   }
 
   @Test
+  public void testConcatenateLeafNodes() {
+    DagNode<String> dagNode1 = new DagNode<>("val1");
+    DagNode<String> dagNode2 = new DagNode<>("val2");
+    DagNode<String> dagNode3 = new DagNode<>("val3");
+
+    dagNode2.addParentNode(dagNode1);
+    dagNode3.addParentNode(dagNode1);
+
+    Dag<String> dag1 = new Dag<>(Lists.newArrayList(dagNode1, dagNode2, dagNode3));
+    DagNode<String> dagNode4 = new DagNode<>("val4");
+    Dag<String> dag2 = new Dag<>(Lists.newArrayList(dagNode4));
+
+    Set<DagNode<String>> leafNodes = Sets.newHashSet();
+    leafNodes.add(dagNode3);
+    Dag<String> dagNew = dag1.concatenate(dag2, leafNodes);
+
+    Assert.assertEquals(dagNew.getEndNodes().size(), 2);
+    Assert.assertEquals(dagNew.getEndNodes().get(0).getValue(), "val4");
+    Assert.assertEquals(dagNew.getEndNodes().get(1).getValue(), "val3");
+    Assert.assertEquals(dagNew.getChildren(dagNode3).size(), 0);
+  }
+
+  @Test
   public void testMerge() {
-    Dag.DagNode<String> dagNode1 = new Dag.DagNode<>("val1");
-    Dag.DagNode<String> dagNode2 = new Dag.DagNode<>("val2");
-    Dag.DagNode<String> dagNode3 = new Dag.DagNode<>("val3");
-    Dag.DagNode<String> dagNode4 = new Dag.DagNode<>("val4");
-    Dag.DagNode<String> dagNode5 = new Dag.DagNode<>("val5");
+    DagNode<String> dagNode1 = new DagNode<>("val1");
+    DagNode<String> dagNode2 = new DagNode<>("val2");
+    DagNode<String> dagNode3 = new DagNode<>("val3");
+    DagNode<String> dagNode4 = new DagNode<>("val4");
+    DagNode<String> dagNode5 = new DagNode<>("val5");
 
     dagNode2.addParentNode(dagNode1);
     dagNode3.addParentNode(dagNode1);
@@ -155,12 +181,12 @@ public class DagTest {
     dagNode4.addParentNode(dagNode3);
     dagNode5.addParentNode(dagNode3);
 
-    List<Dag.DagNode<String>> dagNodeList = Lists.newArrayList(dagNode1, dagNode2, dagNode3, dagNode4, dagNode5);
+    List<DagNode<String>> dagNodeList = Lists.newArrayList(dagNode1, dagNode2, dagNode3, dagNode4, dagNode5);
     Dag<String> dag1 = new Dag<>(dagNodeList);
 
-    Dag.DagNode<String> dagNode6 = new Dag.DagNode<>("val6");
-    Dag.DagNode<String> dagNode7 = new Dag.DagNode<>("val7");
-    Dag.DagNode<String> dagNode8 = new Dag.DagNode<>("val8");
+    DagNode<String> dagNode6 = new DagNode<>("val6");
+    DagNode<String> dagNode7 = new DagNode<>("val7");
+    DagNode<String> dagNode8 = new DagNode<>("val8");
     dagNode8.addParentNode(dagNode6);
     dagNode8.addParentNode(dagNode7);
     Dag<String> dag2 = new Dag<>(Lists.newArrayList(dagNode6, dagNode7, dagNode8));
@@ -170,11 +196,11 @@ public class DagTest {
 
     //Test the startNodes
     Assert.assertEquals(dagNew.getStartNodes().size(), 3);
-    for (Dag.DagNode<String> dagNode: Lists.newArrayList(dagNode1, dagNode6, dagNode7)) {
+    for (DagNode<String> dagNode: Lists.newArrayList(dagNode1, dagNode6, dagNode7)) {
       Assert.assertTrue(dagNew.getStartNodes().contains(dagNode));
       Assert.assertEquals(dagNew.getParents(dagNode).size(), 0);
       if (dagNode == dagNode1) {
-        List<Dag.DagNode<String>> nextNodes = dagNew.getChildren(dagNode);
+        List<DagNode<String>> nextNodes = dagNew.getChildren(dagNode);
         Assert.assertEquals(nextNodes.size(), 2);
         Assert.assertTrue(nextNodes.contains(dagNode2));
         Assert.assertTrue(nextNodes.contains(dagNode3));
@@ -186,7 +212,7 @@ public class DagTest {
 
     //Test the endNodes
     Assert.assertEquals(dagNew.getEndNodes().size(), 3);
-    for (Dag.DagNode<String> dagNode: Lists.newArrayList(dagNode4, dagNode5, dagNode8)) {
+    for (DagNode<String> dagNode: Lists.newArrayList(dagNode4, dagNode5, dagNode8)) {
       Assert.assertTrue(dagNew.getEndNodes().contains(dagNode));
       Assert.assertEquals(dagNew.getChildren(dagNode).size(), 0);
       if (dagNode == dagNode8) {

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/flowgraph/DagTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/flowgraph/DagTest.java
@@ -30,7 +30,6 @@ import com.google.common.collect.Lists;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.gobblin.service.modules.flowgraph.Dag.DagNode;
-import org.apache.gobblin.service.modules.spec.JobExecutionPlan;
 
 
 @Slf4j
@@ -145,7 +144,7 @@ public class DagTest {
   }
 
   @Test
-  public void testConcatenateLeafNodes() {
+  public void testConcatenateForkNodes() {
     DagNode<String> dagNode1 = new DagNode<>("val1");
     DagNode<String> dagNode2 = new DagNode<>("val2");
     DagNode<String> dagNode3 = new DagNode<>("val3");
@@ -157,9 +156,9 @@ public class DagTest {
     DagNode<String> dagNode4 = new DagNode<>("val4");
     Dag<String> dag2 = new Dag<>(Lists.newArrayList(dagNode4));
 
-    Set<DagNode<String>> leafNodes = Sets.newHashSet();
-    leafNodes.add(dagNode3);
-    Dag<String> dagNew = dag1.concatenate(dag2, leafNodes);
+    Set<DagNode<String>> forkNodes = Sets.newHashSet();
+    forkNodes.add(dagNode3);
+    Dag<String> dagNew = dag1.concatenate(dag2, forkNodes);
 
     Assert.assertEquals(dagNew.getEndNodes().size(), 2);
     Assert.assertEquals(dagNew.getEndNodes().get(0).getValue(), "val4");


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-616


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
We add the ability to fork jobs when concatenating 2 dags, as part of constructing a multi-hop path. An example use case is to allow retention jobs on each hop of the path to run in parallel to the distcp jobs along a multi-hop path, thus preventing the data copy on a subsequent hop from being blocked on a retention job on a previous hop. 

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Added test cases to DagTest and FlowGraphPathTest classes.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

