### PR TITLE
[GOBBLIN-618] Remove unnecessary methods from StandardMetricsBridge

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterManager.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterManager.java
@@ -63,10 +63,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.gobblin.annotation.Alpha;
 import org.apache.gobblin.cluster.event.ClusterManagerShutdownRequest;
 import org.apache.gobblin.configuration.ConfigurationKeys;
-import org.apache.gobblin.instrumented.Instrumented;
 import org.apache.gobblin.instrumented.StandardMetricsBridge;
-import org.apache.gobblin.metrics.GobblinMetrics;
-import org.apache.gobblin.metrics.MetricContext;
 import org.apache.gobblin.metrics.Tag;
 import org.apache.gobblin.runtime.api.MutableJobCatalog;
 import org.apache.gobblin.runtime.app.ApplicationException;
@@ -138,13 +135,11 @@ public class GobblinClusterManager implements ApplicationLauncher, StandardMetri
 
   private final String clusterName;
   private final Config config;
-  private final MetricContext metricContext;
 
   public GobblinClusterManager(String clusterName, String applicationId, Config config,
       Optional<Path> appWorkDirOptional) throws Exception {
     this.clusterName = clusterName;
     this.config = config;
-    this.metricContext = Instrumented.getMetricContext(ConfigUtils.configToState(config), this.getClass());
     this.isStandaloneMode = ConfigUtils.getBoolean(config, GobblinClusterConfigurationKeys.STANDALONE_CLUSTER_MODE_KEY,
         GobblinClusterConfigurationKeys.DEFAULT_STANDALONE_CLUSTER_MODE);
 
@@ -446,17 +441,8 @@ public class GobblinClusterManager implements ApplicationLauncher, StandardMetri
     list.addAll(this.jobScheduler.getStandardMetricsCollection());
     list.addAll(this.multiManager.getStandardMetricsCollection());
     list.addAll(this.jobCatalog.getStandardMetricsCollection());
+    list.addAll(this.jobConfigurationManager.getStandardMetricsCollection());
     return list;
-  }
-
-  @Override
-  public MetricContext getMetricContext() {
-    return this.metricContext;
-  }
-
-  @Override
-  public boolean isInstrumentationEnabled() {
-    return GobblinMetrics.isEnabled(ConfigUtils.configToProperties(this.config));
   }
 
   /**

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobScheduler.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobScheduler.java
@@ -38,8 +38,6 @@ import com.google.common.collect.Maps;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 
-import javax.annotation.Nonnull;
-
 import org.apache.gobblin.annotation.Alpha;
 import org.apache.gobblin.cluster.event.DeleteJobConfigArrivalEvent;
 import org.apache.gobblin.cluster.event.NewJobConfigArrivalEvent;
@@ -47,7 +45,6 @@ import org.apache.gobblin.cluster.event.UpdateJobConfigArrivalEvent;
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.instrumented.Instrumented;
 import org.apache.gobblin.instrumented.StandardMetricsBridge;
-import org.apache.gobblin.metrics.GobblinMetrics;
 import org.apache.gobblin.metrics.MetricContext;
 import org.apache.gobblin.metrics.Tag;
 import org.apache.gobblin.runtime.JobException;
@@ -123,17 +120,6 @@ public class GobblinHelixJobScheduler extends JobScheduler implements StandardMe
                                                                    metricsWindowSizeInMin);
 
     this.startServicesCompleted = false;
-  }
-
-  @Nonnull
-  @Override
-  public MetricContext getMetricContext() {
-    return this.metricContext;
-  }
-
-  @Override
-  public boolean isInstrumentationEnabled() {
-    return GobblinMetrics.isEnabled(this.properties);
   }
 
   @Override

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixMultiManager.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixMultiManager.java
@@ -54,7 +54,6 @@ import com.google.common.eventbus.EventBus;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.typesafe.config.Config;
 
-import javax.annotation.Nonnull;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -476,17 +475,6 @@ public class GobblinHelixMultiManager implements StandardMetricsBridge {
     public String getName() {
       return GobblinClusterManager.class.getName();
     }
-  }
-
-  @Nonnull
-  @Override
-  public MetricContext getMetricContext() {
-    return this.metricContext;
-  }
-
-  @Override
-  public boolean isInstrumentationEnabled() {
-    return true;
   }
 
   @Override

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinTaskRunner.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinTaskRunner.java
@@ -339,9 +339,6 @@ public class GobblinTaskRunner implements StandardMetricsBridge {
       List<String> tags = ConfigUtils.getStringList(this.config, GobblinClusterConfigurationKeys.HELIX_INSTANCE_TAGS_KEY);
       logger.info("Adding tags binding " + tags);
       tags.forEach(tag -> helixManager.getClusterManagmentTool().addInstanceTag(this.clusterName, this.helixInstanceName, tag));
-
-      List<String> tagsOnHelix = helixManager.getClusterManagmentTool().getInstanceConfig(this.clusterName, this.helixInstanceName).getTags();
-      tags.forEach(tag -> Preconditions.checkArgument(tagsOnHelix.contains(tag)));
     }
   }
 

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinTaskRunner.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinTaskRunner.java
@@ -339,6 +339,8 @@ public class GobblinTaskRunner implements StandardMetricsBridge {
       List<String> tags = ConfigUtils.getStringList(this.config, GobblinClusterConfigurationKeys.HELIX_INSTANCE_TAGS_KEY);
       logger.info("Adding tags binding " + tags);
       tags.forEach(tag -> helixManager.getClusterManagmentTool().addInstanceTag(this.clusterName, this.helixInstanceName, tag));
+      logger.info("Actual tags binding " + helixManager.getClusterManagmentTool()
+          .getInstanceConfig(this.clusterName, this.helixInstanceName).getTags());
     }
   }
 

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/JobConfigurationManager.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/JobConfigurationManager.java
@@ -36,6 +36,7 @@ import org.apache.gobblin.cluster.event.DeleteJobConfigArrivalEvent;
 import org.apache.gobblin.cluster.event.NewJobConfigArrivalEvent;
 import org.apache.gobblin.cluster.event.UpdateJobConfigArrivalEvent;
 import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.instrumented.StandardMetricsBridge;
 import org.apache.gobblin.util.ConfigUtils;
 import org.apache.gobblin.util.SchedulerUtils;
 
@@ -58,7 +59,7 @@ import org.apache.gobblin.util.SchedulerUtils;
  * @author Yinan Li
  */
 @Alpha
-public class JobConfigurationManager extends AbstractIdleService {
+public class JobConfigurationManager extends AbstractIdleService implements StandardMetricsBridge {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(JobConfigurationManager.class);
 

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/StreamingJobConfigurationManager.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/StreamingJobConfigurationManager.java
@@ -18,6 +18,7 @@
 package org.apache.gobblin.cluster;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.Collection;
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.ExecutionException;
@@ -38,6 +39,7 @@ import com.typesafe.config.Config;
 import lombok.Getter;
 
 import org.apache.gobblin.annotation.Alpha;
+import org.apache.gobblin.instrumented.StandardMetricsBridge;
 import org.apache.gobblin.runtime.api.JobSpec;
 import org.apache.gobblin.runtime.api.MutableJobCatalog;
 import org.apache.gobblin.runtime.api.Spec;
@@ -92,6 +94,15 @@ public class StreamingJobConfigurationManager extends JobConfigurationManager {
         | ClassNotFoundException e) {
       throw new RuntimeException("Could not construct SpecConsumer " +
           specExecutorInstanceConsumerClassName, e);
+    }
+  }
+
+  @Override
+  public Collection<StandardMetrics> getStandardMetricsCollection() {
+    if (this.specConsumer instanceof StandardMetricsBridge) {
+      return ((StandardMetricsBridge)specConsumer).getStandardMetricsCollection();
+    } else {
+      return ImmutableList.of();
     }
   }
 

--- a/gobblin-core-base/src/main/java/org/apache/gobblin/instrumented/StandardMetricsBridge.java
+++ b/gobblin-core-base/src/main/java/org/apache/gobblin/instrumented/StandardMetricsBridge.java
@@ -28,39 +28,15 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
 import org.apache.gobblin.metrics.ContextAwareMetric;
-import org.apache.gobblin.metrics.MetricContext;
-import org.apache.gobblin.metrics.Tag;
 
 /**
  * This interface indicates a class will expose its metrics to some external systems.
  */
-public interface StandardMetricsBridge extends Instrumentable {
-
-  /**
-   * Get a single standard metrics.
-   * Also see {@link #getStandardMetricsCollection}.
-   */
-  @Deprecated
-  default StandardMetrics getStandardMetrics() {
-    throw new UnsupportedOperationException("Deprecated API. Please use getStandardMetricsCollection.");
-  }
-
+public interface StandardMetricsBridge {
   /**
    * Get multiple standard metrics.
    */
   default Collection<StandardMetrics> getStandardMetricsCollection() {
-    return ImmutableList.of();
-  }
-
-  default void switchMetricContext(MetricContext context) {
-    throw new UnsupportedOperationException();
-  }
-
-  default void switchMetricContext(List<Tag<?>> tags) {
-    throw new UnsupportedOperationException();
-  }
-
-  default List<Tag<?>> generateTags(org.apache.gobblin.configuration.State state) {
     return ImmutableList.of();
   }
 

--- a/gobblin-modules/gobblin-service-kafka/src/main/java/org/apache/gobblin/service/StreamingKafkaSpecConsumer.java
+++ b/gobblin-modules/gobblin-service-kafka/src/main/java/org/apache/gobblin/service/StreamingKafkaSpecConsumer.java
@@ -31,24 +31,21 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.gobblin.instrumented.Instrumented;
-import org.apache.gobblin.instrumented.StandardMetricsBridge;
-import org.apache.gobblin.metrics.ContextAwareGauge;
-import org.apache.gobblin.metrics.ContextAwareMetric;
-import org.apache.gobblin.metrics.GobblinMetrics;
-import org.apache.gobblin.metrics.MetricContext;
-import org.apache.gobblin.metrics.Tag;
-
 import org.slf4j.Logger;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.AbstractIdleService;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.gobblin.instrumented.Instrumented;
+import org.apache.gobblin.instrumented.StandardMetricsBridge;
+import org.apache.gobblin.metrics.MetricContext;
 import org.apache.gobblin.runtime.api.JobSpec;
 import org.apache.gobblin.runtime.api.MutableJobCatalog;
 import org.apache.gobblin.runtime.api.Spec;
@@ -62,17 +59,12 @@ import org.apache.gobblin.util.ConfigUtils;
 
 import static org.apache.gobblin.service.SimpleKafkaSpecExecutor.SPEC_KAFKA_TOPICS_KEY;
 
-import javax.annotation.Nonnull;
-import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
-
 @Slf4j
 /**
  * SpecConsumer that consumes from kafka in a streaming manner
  * Implemented {@link AbstractIdleService} for starting up and shutting down.
  */
 public class StreamingKafkaSpecConsumer extends AbstractIdleService implements SpecConsumer<Spec>, Closeable, StandardMetricsBridge {
-  public static final String SPEC_STREAMING_BLOCKING_QUEUE_SIZE = "spec.StreamingBlockingQueueSize";
   private static final int DEFAULT_SPEC_STREAMING_BLOCKING_QUEUE_SIZE = 100;
   @Getter
   private final AvroJobSpecKafkaJobMonitor _jobMonitor;
@@ -80,7 +72,7 @@ public class StreamingKafkaSpecConsumer extends AbstractIdleService implements S
   private final MutableJobCatalog _jobCatalog;
   private final MetricContext _metricContext;
   private final Metrics _metrics;
-  private final boolean _isInstrumentedEnabled;
+
   public StreamingKafkaSpecConsumer(Config config, MutableJobCatalog jobCatalog, Optional<Logger> log) {
     String topic = config.getString(SPEC_KAFKA_TOPICS_KEY);
     Config defaults = ConfigFactory.parseMap(ImmutableMap.of(AvroJobSpecKafkaJobMonitor.TOPIC_KEY, topic,
@@ -92,7 +84,7 @@ public class StreamingKafkaSpecConsumer extends AbstractIdleService implements S
     } catch (IOException e) {
       throw new RuntimeException("Could not create job monitor", e);
     }
-    _isInstrumentedEnabled = GobblinMetrics.isEnabled(ConfigUtils.configToProperties(config));
+
     _jobCatalog = jobCatalog;
     _jobSpecQueue = new LinkedBlockingQueue<>(ConfigUtils.getInt(config, "SPEC_STREAMING_BLOCKING_QUEUE_SIZE",
         DEFAULT_SPEC_STREAMING_BLOCKING_QUEUE_SIZE));
@@ -235,18 +227,7 @@ public class StreamingKafkaSpecConsumer extends AbstractIdleService implements S
   }
 
   @Override
-  public StandardMetrics getStandardMetrics() {
-    return this._metrics;
-  }
-
-  @Nonnull
-  @Override
-  public MetricContext getMetricContext() {
-    return _metricContext;
-  }
-
-  @Override
-  public boolean isInstrumentationEnabled() {
-    return _isInstrumentedEnabled;
+  public Collection<StandardMetrics> getStandardMetricsCollection() {
+    return ImmutableList.of(this._metrics);
   }
 }

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/JobCatalog.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/JobCatalog.java
@@ -54,10 +54,6 @@ public interface JobCatalog extends JobCatalogListenersContainer, Instrumentable
    * ({@link #isInstrumentationEnabled()}) is false. */
   JobCatalog.StandardMetrics getMetrics();
 
-  default StandardMetricsBridge.StandardMetrics getStandardMetrics() {
-    return getMetrics();
-  }
-
   default Collection<StandardMetricsBridge.StandardMetrics> getStandardMetricsCollection() {
     return ImmutableList.of(getMetrics());
   }

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/SpecCatalog.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/SpecCatalog.java
@@ -33,6 +33,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.instrumented.GobblinMetricsKeys;
+import org.apache.gobblin.instrumented.Instrumentable;
 import org.apache.gobblin.instrumented.Instrumented;
 import org.apache.gobblin.instrumented.StandardMetricsBridge;
 import org.apache.gobblin.metrics.ContextAwareGauge;
@@ -42,17 +43,13 @@ import org.apache.gobblin.metrics.MetricContext;
 import org.apache.gobblin.util.ConfigUtils;
 
 
-public interface SpecCatalog extends SpecCatalogListenersContainer, StandardMetricsBridge {
+public interface SpecCatalog extends SpecCatalogListenersContainer, Instrumentable, StandardMetricsBridge {
   /** Returns an immutable {@link Collection} of {@link Spec}s that are known to the catalog. */
   Collection<Spec> getSpecs();
 
   /** Metrics for the spec catalog; null if
    * ({@link #isInstrumentationEnabled()}) is false. */
   SpecCatalog.StandardMetrics getMetrics();
-
-  default StandardMetricsBridge.StandardMetrics getStandardMetrics() {
-    return this.getMetrics();
-  }
 
   default Collection<StandardMetricsBridge.StandardMetrics> getStandardMetricsCollection() {
     return ImmutableList.of(this.getMetrics());
@@ -65,7 +62,7 @@ public interface SpecCatalog extends SpecCatalogListenersContainer, StandardMetr
   Spec getSpec(URI uri) throws SpecNotFoundException;
 
   @Slf4j
-  public static class StandardMetrics extends StandardMetricsBridge.StandardMetrics implements SpecCatalogListener {
+  class StandardMetrics extends StandardMetricsBridge.StandardMetrics implements SpecCatalogListener {
     public static final String NUM_ACTIVE_SPECS_NAME = "numActiveSpecs";
     public static final String TOTAL_ADD_CALLS = "totalAddCalls";
     public static final String TOTAL_DELETE_CALLS = "totalDeleteCalls";

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GobblinServiceManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GobblinServiceManager.java
@@ -59,7 +59,6 @@ import com.linkedin.restli.server.resources.BaseResource;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
-import javax.annotation.Nonnull;
 import lombok.Getter;
 
 import org.apache.gobblin.annotation.Alpha;
@@ -492,24 +491,8 @@ public class GobblinServiceManager implements ApplicationLauncher, StandardMetri
   }
 
   @Override
-  public StandardMetrics getStandardMetrics() {
-    return this.metrics;
-  }
-
-  @Override
   public Collection<StandardMetrics> getStandardMetricsCollection() {
     return ImmutableList.of(this.metrics);
-  }
-
-  @Nonnull
-  @Override
-  public MetricContext getMetricContext() {
-    return this.metricContext;
-  }
-
-  @Override
-  public boolean isInstrumentationEnabled() {
-    return false;
   }
 
   private class Metrics extends StandardMetrics {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-618


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
   Earlier any components that implements StandardMetricsBridge interface has to implements the Instrumentable interface as well. However this should not be required because the external system only relies on the getStandardMetricsCollection() API, instead of others. Hence remove those unused interfaces from StandardMetricsBridge class.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

