### PR TITLE
[GOBBLIN-620] Fix the null pointer exception when catalog metrics is not enabled

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/JobCatalog.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/JobCatalog.java
@@ -55,7 +55,8 @@ public interface JobCatalog extends JobCatalogListenersContainer, Instrumentable
   JobCatalog.StandardMetrics getMetrics();
 
   default Collection<StandardMetricsBridge.StandardMetrics> getStandardMetricsCollection() {
-    return ImmutableList.of(getMetrics());
+    JobCatalog.StandardMetrics standardMetrics = getMetrics();
+    return standardMetrics == null? ImmutableList.of() : ImmutableList.of(standardMetrics);
   }
 
   /**

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/SpecCatalog.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/SpecCatalog.java
@@ -52,7 +52,8 @@ public interface SpecCatalog extends SpecCatalogListenersContainer, Instrumentab
   SpecCatalog.StandardMetrics getMetrics();
 
   default Collection<StandardMetricsBridge.StandardMetrics> getStandardMetricsCollection() {
-    return ImmutableList.of(this.getMetrics());
+    SpecCatalog.StandardMetrics standardMetrics = getMetrics();
+    return standardMetrics == null? ImmutableList.of() : ImmutableList.of(standardMetrics);
   }
 
   /**


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-620


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
   NPE is observed when we tried to get the standard metrics from the job catalog when metrics was enabled. A null pointer check is required if the metrics was not enabled, and in such case an empty collection is returned.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

