### PR TITLE
[GOBBLIN-622] Avoid writing previous workunits in SourceState

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/SourceState.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/SourceState.java
@@ -301,9 +301,19 @@ public class SourceState extends State {
   @Override
   public void write(DataOutput out)
       throws IOException {
-    out.writeInt(this.previousWorkUnitStates.size());
-    for (WorkUnitState state : this.previousWorkUnitStates) {
-      state.write(out);
+    write(out, false);
+  }
+
+  public void write(DataOutput out, boolean writePreviousWorkUnitStates)
+      throws IOException {
+
+    if (!writePreviousWorkUnitStates) {
+      out.writeInt(0);
+    } else {
+      out.writeInt(this.previousWorkUnitStates.size());
+      for (WorkUnitState state : this.previousWorkUnitStates) {
+        state.write(out);
+      }
     }
     super.write(out);
   }

--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/SourceState.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/SourceState.java
@@ -301,7 +301,7 @@ public class SourceState extends State {
   @Override
   public void write(DataOutput out)
       throws IOException {
-    write(out, false);
+    write(out, true);
   }
 
   public void write(DataOutput out, boolean writePreviousWorkUnitStates)

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/JobState.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/JobState.java
@@ -523,10 +523,10 @@ public class JobState extends SourceState {
   @Override
   public void write(DataOutput out)
       throws IOException {
-    write(out, true);
+    write(out, true, true);
   }
 
-  public void write(DataOutput out, boolean writeTasks)
+  public void write(DataOutput out, boolean writeTasks, boolean writePreviousWorkUnitStates)
       throws IOException {
     Text text = new Text();
     text.set(this.jobName);
@@ -550,7 +550,7 @@ public class JobState extends SourceState {
     } else {
       out.writeInt(0);
     }
-    super.write(out);
+    super.write(out, writePreviousWorkUnitStates);
   }
 
   /**

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/mapreduce/MRJobLauncher.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/mapreduce/MRJobLauncher.java
@@ -119,6 +119,8 @@ public class MRJobLauncher extends AbstractJobLauncher {
   static final String INPUT_DIR_NAME = "input";
   private static final String OUTPUT_DIR_NAME = "output";
   private static final String WORK_UNIT_LIST_FILE_EXTENSION = ".wulist";
+  private static final String SERIALIZE_PREVIOUS_WORKUNIT_STATES_KEY = "MRJobLauncher.serializePreviousWorkunitStates";
+  private static final boolean DEFAULT_SERIALIZE_PREVIOUS_WORKUNIT_STATES = true;
 
   // Configuration that make uploading of jar files more reliable,
   // since multiple Gobblin Jobs are sharing the same jar directory.
@@ -384,7 +386,8 @@ public class MRJobLauncher extends AbstractJobLauncher {
     Path jobStateFilePath = new Path(mrJobDir, JOB_STATE_FILE_NAME);
     // Write the job state with an empty task set (work units are read by the mapper from a different file)
     try (DataOutputStream dataOutputStream = new DataOutputStream(fs.create(jobStateFilePath))) {
-      jobState.write(dataOutputStream, false);
+      jobState.write(dataOutputStream, false,
+          conf.getBoolean(SERIALIZE_PREVIOUS_WORKUNIT_STATES_KEY, DEFAULT_SERIALIZE_PREVIOUS_WORKUNIT_STATES));
     }
 
     job.getConfiguration().set(ConfigurationKeys.JOB_STATE_FILE_PATH_KEY, jobStateFilePath.toString());


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-622


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
  This is probably some legacy code that we persist all the previous workunits from source state to the disk (or state store). This cause our hdfs disk quota drain quickly and when each mapper task attempts to load all the workunits, it will reload this source state from the hdfs which cause a huge memory usage. 
   Removing this persistence logic helps save both the memory space and disk space.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

