### PR TITLE
GOBBLIN-627: Allow files in task output directory to be overwritten when renaming files with record count.

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -239,6 +239,7 @@ public class ConfigurationKeys {
   public static final String JOB_CONFIG_FILE_PATH_KEY = "job.config.path";
   public static final String TASK_FAILURE_EXCEPTION_KEY = "task.failure.exception";
   public static final String TASK_RETRIES_KEY = "task.retries";
+  public static final String TASK_IGNORE_CLOSE_FAILURES = "task.ignoreCloseFailures";
   public static final String JOB_FAILURES_KEY = "job.failures";
   public static final String JOB_TRACKING_URL_KEY = "job.tracking.url";
   public static final String FORK_STATE_KEY = "fork.state";

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/Task.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/Task.java
@@ -182,7 +182,7 @@ public class Task implements TaskIFace {
     this.jobId = this.taskState.getJobId();
     this.taskId = this.taskState.getTaskId();
     this.taskKey = this.taskState.getTaskKey();
-    this.isIgnoreCloseFailures = this.taskState.isIgnoreCloseFailures();
+    this.isIgnoreCloseFailures = this.taskState.getJobState().getPropAsBoolean(ConfigurationKeys.TASK_IGNORE_CLOSE_FAILURES, false);
     this.taskStateTracker = taskStateTracker;
     this.taskExecutor = taskExecutor;
     this.countDownLatch = countDownLatch;

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/TaskState.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/TaskState.java
@@ -88,8 +88,6 @@ public class TaskState extends WorkUnitState {
   private String taskKey;
   @Getter
   private Optional<String> taskAttemptId;
-  @Getter
-  private boolean ignoreCloseFailures;
 
   private long startTime = 0;
   private long endTime = 0;
@@ -106,7 +104,6 @@ public class TaskState extends WorkUnitState {
     this.jobId = workUnitState.getProp(ConfigurationKeys.JOB_ID_KEY);
     this.taskId = workUnitState.getProp(ConfigurationKeys.TASK_ID_KEY);
     this.taskKey = workUnitState.getProp(ConfigurationKeys.TASK_KEY_KEY, "unknown_task_key");
-    this.ignoreCloseFailures = workUnitState.getPropAsBoolean(ConfigurationKeys.TASK_IGNORE_CLOSE_FAILURES, true);
     this.taskAttemptId = Optional.fromNullable(workUnitState.getProp(ConfigurationKeys.TASK_ATTEMPT_ID_KEY));
     this.setId(this.taskId);
   }
@@ -116,7 +113,6 @@ public class TaskState extends WorkUnitState {
     addAll(taskState);
     this.jobId = taskState.getProp(ConfigurationKeys.JOB_ID_KEY);
     this.taskId = taskState.getProp(ConfigurationKeys.TASK_ID_KEY);
-    this.ignoreCloseFailures = taskState.getPropAsBoolean(ConfigurationKeys.TASK_IGNORE_CLOSE_FAILURES, true);
     this.taskAttemptId = taskState.getTaskAttemptId();
     this.setId(this.taskId);
   }

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/TaskState.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/TaskState.java
@@ -88,6 +88,9 @@ public class TaskState extends WorkUnitState {
   private String taskKey;
   @Getter
   private Optional<String> taskAttemptId;
+  @Getter
+  private boolean ignoreCloseFailures;
+
   private long startTime = 0;
   private long endTime = 0;
   private long duration;
@@ -103,6 +106,7 @@ public class TaskState extends WorkUnitState {
     this.jobId = workUnitState.getProp(ConfigurationKeys.JOB_ID_KEY);
     this.taskId = workUnitState.getProp(ConfigurationKeys.TASK_ID_KEY);
     this.taskKey = workUnitState.getProp(ConfigurationKeys.TASK_KEY_KEY, "unknown_task_key");
+    this.ignoreCloseFailures = workUnitState.getPropAsBoolean(ConfigurationKeys.TASK_IGNORE_CLOSE_FAILURES, true);
     this.taskAttemptId = Optional.fromNullable(workUnitState.getProp(ConfigurationKeys.TASK_ATTEMPT_ID_KEY));
     this.setId(this.taskId);
   }
@@ -112,6 +116,7 @@ public class TaskState extends WorkUnitState {
     addAll(taskState);
     this.jobId = taskState.getProp(ConfigurationKeys.JOB_ID_KEY);
     this.taskId = taskState.getProp(ConfigurationKeys.TASK_ID_KEY);
+    this.ignoreCloseFailures = taskState.getPropAsBoolean(ConfigurationKeys.TASK_IGNORE_CLOSE_FAILURES, true);
     this.taskAttemptId = taskState.getTaskAttemptId();
     this.setId(this.taskId);
   }

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/HadoopUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/HadoopUtils.java
@@ -40,10 +40,12 @@ import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileAlreadyExistsException;
+import org.apache.hadoop.fs.FileContext;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.fs.LocalFileSystem;
+import org.apache.hadoop.fs.Options;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathFilter;
 import org.apache.hadoop.fs.RawLocalFileSystem;
@@ -233,6 +235,22 @@ public class HadoopUtils {
     else {
       return fs.rename(src, dst);
     }
+  }
+
+  /**
+   * A wrapper around {@link FileContext#rename(Path, Path, Options.Rename...)}.
+   */
+  public static void renamePath(FileContext fc, Path oldName, Path newName) throws IOException {
+    renamePath(fc, oldName, newName, false);
+  }
+
+  /**
+   * A wrapper around {@link FileContext#rename(Path, Path, Options.Rename...)}}.
+   */
+  public static void renamePath(FileContext fc, Path oldName, Path newName, boolean overwrite)
+      throws IOException {
+    Options.Rename renameOptions = (overwrite) ? Options.Rename.OVERWRITE : Options.Rename.NONE;
+    fc.rename(oldName, newName, renameOptions);
   }
 
   /**


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-627


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
In FsDataWriter#close(), we rename files in task output directory with overwrite option enabled. This prevents failures in the close() method of the writer, in case previous attempts of the tasks already have already written files in the task output directory. 


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tested the changes in dev environment.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

