### PR TITLE
GOBBLIN-629: Skip updating statistics for Kafka partitions in KafkaExtractor when topic is skipped.

### DIFF
--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaExtractor.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaExtractor.java
@@ -370,8 +370,9 @@ public abstract class KafkaExtractor<S, D> extends EventBasedExtractor<S, D> {
 
   @Override
   public void close() throws IOException {
-
-    updateStatisticsForCurrentPartition();
+    if (currentPartitionIdx != INITIAL_PARTITION_IDX) {
+      updateStatisticsForCurrentPartition();
+    }
 
     Map<KafkaPartition, Map<String, String>> tagsForPartitionsMap = Maps.newHashMap();
 


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-629


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
If the extractor skips processing of a Kafka topic due to an error condition (e.g. SchemaRegistryTimeoutException), then the close() method on KafkaExtractor throws an ArrayIndexOutOfBoundsException when attempting to update statistics for the partitions of the topic. The correct behavior should be to skip the call to updateStatisticsForCurrentPartition(), when a topic is skipped.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tested in dev environment with an end-to-end pipeline.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

