### PR TITLE
[GOBBLIN-634] Add requester information to flowconfigs

### DIFF
--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-client/src/test/java/org/apache/gobblin/service/FlowConfigTest.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-client/src/test/java/org/apache/gobblin/service/FlowConfigTest.java
@@ -82,10 +82,15 @@ public class FlowConfigTest {
     Injector injector = Guice.createInjector(new Module() {
        @Override
        public void configure(Binder binder) {
-         binder.bind(FlowConfigsResourceHandler.class).annotatedWith(Names.named(FlowConfigsResource.FLOW_CONFIG_GENERATOR_INJECT_NAME)).toInstance(new FlowConfigResourceLocalHandler(flowCatalog));
+         binder.bind(FlowConfigsResourceHandler.class)
+             .annotatedWith(Names.named(FlowConfigsResource.INJECT_FLOW_CONFIG_RESOURCE_HANDLER))
+             .toInstance(new FlowConfigResourceLocalHandler(flowCatalog));
+
          // indicate that we are in unit testing since the resource is being blocked until flow catalog changes have
          // been made
-         binder.bindConstant().annotatedWith(Names.named("readyToUse")).to(Boolean.TRUE);
+         binder.bindConstant().annotatedWith(Names.named(FlowConfigsResource.INJECT_READY_TO_USE)).to(Boolean.TRUE);
+         binder.bind(RequesterService.class)
+             .annotatedWith(Names.named(FlowConfigsResource.INJECT_REQUESTER_SERVICE)).toInstance(new NoopRequesterService(config));
        }
     });
 

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/NoopRequesterService.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/NoopRequesterService.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.service;
+
+import java.util.List;
+
+import com.google.common.collect.Lists;
+import com.linkedin.restli.server.resources.BaseResource;
+import com.typesafe.config.Config;
+
+
+/**
+ * Default requester service which does not track any requester information.
+ */
+public class NoopRequesterService extends RequesterService {
+
+  public NoopRequesterService(Config config) {
+    super(config);
+  }
+
+  @Override
+  public List<ServiceRequester> findRequesters(BaseResource resource) {
+    return Lists.newArrayList();
+  }
+}

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/RequesterService.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/RequesterService.java
@@ -50,7 +50,7 @@ public abstract class RequesterService {
    */
   public String serialize(List<ServiceRequester> requestersList) throws IOException {
     String arrayToJson = objectMapper.writeValueAsString(requestersList);
-    String encodedString = Base64.getEncoder().encodeToString(arrayToJson.getBytes());
+    String encodedString = Base64.getEncoder().encodeToString(arrayToJson.getBytes("UTF-8"));
     return URLEncoder.encode(encodedString, "UTF-8");
   }
 
@@ -61,7 +61,7 @@ public abstract class RequesterService {
   public List<ServiceRequester> deserialize(String encodedString) throws IOException {
     String urlDecoded = URLDecoder.decode(encodedString, "UTF-8");
     byte[] decodedBytes = Base64.getDecoder().decode(urlDecoded);
-    String serialized = new String(decodedBytes);
+    String serialized = new String(decodedBytes, "UTF-8");
     TypeReference<List<ServiceRequester>> mapType = new TypeReference<List<ServiceRequester>>() {};
     List<ServiceRequester> jsonToPersonList = objectMapper.readValue(serialized, mapType);
     return jsonToPersonList;

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/RequesterService.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/RequesterService.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.service;
+
+import java.io.IOException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.util.List;
+import java.util.Base64;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.type.TypeReference;
+import com.linkedin.restli.server.resources.BaseResource;
+import com.typesafe.config.Config;
+
+/**
+ * Use this class to get who sends the request.
+ */
+public abstract class RequesterService {
+
+  protected Config sysConfig;
+
+  public RequesterService(Config config) {
+    sysConfig = config;
+  }
+
+  public static final String REQUESTER_LIST = "gobblin.service.requester.list";
+
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+
+  /**
+   * <p> This implementation converts a given list to a json string.
+   * Due to json string may have reserved keyword that can confuse
+   * {@link Config}, we first use Base64 to encode the json string,
+   * then use URL encoding to remove characters like '+,/,='.
+   */
+  public String serialize(List<ServiceRequester> requestersList) throws IOException {
+    String arrayToJson = objectMapper.writeValueAsString(requestersList);
+    String encodedString = Base64.getEncoder().encodeToString(arrayToJson.getBytes());
+    return URLEncoder.encode(encodedString, "UTF-8");
+  }
+
+  /**
+   * <p> This implementation decode a given string encoded by
+   * {@link #serialize(List)}.
+   */
+  public List<ServiceRequester> deserialize(String encodedString) throws IOException {
+    String urlDecoded = URLDecoder.decode(encodedString, "UTF-8");
+    byte[] decodedBytes = Base64.getDecoder().decode(urlDecoded);
+    String serialized = new String(decodedBytes);
+    TypeReference<List<ServiceRequester>> mapType = new TypeReference<List<ServiceRequester>>() {};
+    List<ServiceRequester> jsonToPersonList = objectMapper.readValue(serialized, mapType);
+    return jsonToPersonList;
+  }
+
+  protected abstract List<ServiceRequester> findRequesters(BaseResource resource);
+}

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/ServiceRequester.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/ServiceRequester.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * A {@code ServiceRequester} represents who sends a request
+ * via a rest api. The requester have multiple attributes.
+ *
+ * 'name' indicates who is the sender.
+ * 'type' indicates if the sender is a user or a group or a specific application.
+ * 'from' indicates where this sender information is extracted.
+ *
+ * Please note that 'name' should be unique for the same 'type' of requester(s).
+ */
+@Getter
+@Setter
+@EqualsAndHashCode
+public class ServiceRequester {
+  private String name;  // requester name
+  private String type;  // requester can be user name, service name, group name, etc.
+  private String from;  // the location or context where this requester info is obtained
+  private Map<String, String> properties = new HashMap<>(); // additional information for future expansion
+
+  /*
+   * Default constructor is required for deserialization from json
+   */
+  public ServiceRequester() {
+  }
+
+  public ServiceRequester(String name, String type, String from) {
+    this.name = name;
+    this.type = type;
+    this.from = from;
+  }
+
+  public String toString() {
+    return "[name : " + name + " type : " + type + " from : "+ from + " additional : " + properties + "]";
+  }
+}

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/test/java/org/apache/gobblin/service/ServiceRequesterSerDerTest.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/test/java/org/apache/gobblin/service/ServiceRequesterSerDerTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.service;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+import org.apache.gobblin.config.ConfigBuilder;
+import org.apache.gobblin.util.ConfigUtils;
+
+
+@Test
+public class ServiceRequesterSerDerTest {
+
+  public void testSerDerWithEmptyRequester() throws IOException {
+    List<ServiceRequester> list = new ArrayList<>();
+
+    RequesterService rs = new NoopRequesterService(ConfigBuilder.create().build());
+    String serialize = rs.serialize(list);
+    Properties props = new Properties();
+
+    props.put(RequesterService.REQUESTER_LIST, serialize);
+
+    Config initConfig = ConfigBuilder.create().build();
+    Config config = initConfig.withFallback(ConfigFactory.parseString(props.toString()).resolve());
+
+    Properties props2 = ConfigUtils.configToProperties(config);
+    String serialize2 = props2.getProperty(RequesterService.REQUESTER_LIST);
+
+    Assert.assertTrue(serialize.equals(serialize2));
+    List<ServiceRequester> list2 = rs.deserialize(serialize);
+    Assert.assertTrue(list.equals(list2));
+  }
+
+  public void testSerDerWithConfig() throws IOException {
+    ServiceRequester sr1 = new ServiceRequester("kafkaetl", "user", "dv");
+    ServiceRequester sr2 = new ServiceRequester("gobblin", "group", "dv");
+    ServiceRequester sr3 = new ServiceRequester("crm-backend", "service", "cert");
+
+    List<ServiceRequester> list = new ArrayList<>();
+    sr1.getProperties().put("customKey", "${123}");
+    list.add(sr1);
+    list.add(sr2);
+    list.add(sr3);
+
+    RequesterService rs = new NoopRequesterService(ConfigBuilder.create().build());
+    String serialize = rs.serialize(list);
+    Properties props = new Properties();
+
+    props.put(RequesterService.REQUESTER_LIST, serialize);
+
+    Config initConfig = ConfigBuilder.create().build();
+    Config config = initConfig.withFallback(ConfigFactory.parseString(props.toString()).resolve());
+
+    Properties props2 = ConfigUtils.configToProperties(config);
+    String serialize2 = props2.getProperty(RequesterService.REQUESTER_LIST);
+
+    Assert.assertTrue(serialize.equals(serialize2));
+    List<ServiceRequester> list2 = rs.deserialize(serialize);
+    Assert.assertTrue(list.equals(list2));
+  }
+}

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GobblinServiceManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GobblinServiceManager.java
@@ -83,6 +83,8 @@ import org.apache.gobblin.service.FlowConfigsResource;
 import org.apache.gobblin.service.FlowConfigsResourceHandler;
 import org.apache.gobblin.service.FlowConfigsV2Resource;
 import org.apache.gobblin.service.FlowId;
+import org.apache.gobblin.service.NoopRequesterService;
+import org.apache.gobblin.service.RequesterService;
 import org.apache.gobblin.service.Schedule;
 import org.apache.gobblin.service.ServiceConfigKeys;
 import org.apache.gobblin.service.modules.orchestration.DagManager;
@@ -250,9 +252,18 @@ public class GobblinServiceManager implements ApplicationLauncher, StandardMetri
       Injector injector = Guice.createInjector(new Module() {
         @Override
         public void configure(Binder binder) {
-          binder.bind(FlowConfigsResourceHandler.class).annotatedWith(Names.named(FlowConfigsResource.FLOW_CONFIG_GENERATOR_INJECT_NAME)).toInstance(GobblinServiceManager.this.resourceHandler);
-          binder.bind(FlowConfigsResourceHandler.class).annotatedWith(Names.named(FlowConfigsV2Resource.FLOW_CONFIG_GENERATOR_INJECT_NAME)).toInstance(GobblinServiceManager.this.v2ResourceHandler);
-          binder.bindConstant().annotatedWith(Names.named("readyToUse")).to(Boolean.TRUE);
+          binder.bind(FlowConfigsResourceHandler.class)
+              .annotatedWith(Names.named(FlowConfigsResource.INJECT_FLOW_CONFIG_RESOURCE_HANDLER))
+              .toInstance(GobblinServiceManager.this.resourceHandler);
+          binder.bind(FlowConfigsResourceHandler.class)
+              .annotatedWith(Names.named(FlowConfigsV2Resource.FLOW_CONFIG_GENERATOR_INJECT_NAME))
+              .toInstance(GobblinServiceManager.this.v2ResourceHandler);
+          binder.bindConstant()
+              .annotatedWith(Names.named(FlowConfigsResource.INJECT_READY_TO_USE))
+              .to(Boolean.TRUE);
+          binder.bind(RequesterService.class)
+              .annotatedWith(Names.named(FlowConfigsResource.INJECT_REQUESTER_SERVICE))
+              .toInstance(new NoopRequesterService(config));
         }
       });
       this.restliServer = EmbeddedRestliServer.builder()


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-XXX


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
  1. This PR adds an abstract class naming 'RequesterService'. An instance of this class is responsible for getting information who sends a request to gobblin-service. The implementation are encapsulated via abstract method findRequesters(). 
  2. To describe who sends a request, this PR creates a class named 'ServiceRequester'.
  3. The RequesterService provides a seriale/deserialize method. We are thinking to use Json string to present 'ServiceRequester'. Due to the template resolving logic will first convert properties to a config type and then convert it back, a simple json string which might contain '[],{}', etl. will break the resolution logic. The workaround is to encode this json string to Base64, then encode with URLEncoder to get rid of '+,=,/'.
   4. We fixed the injection annotation issue by using Javax package because javax package is compatible for both javax injection and guice injection, but guice annotation only works for guice.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
   tests in gobblin-service package is run successfully.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

