### PR TITLE
GOBBLIN-637: Create dag checkpoint dir on initialization to avoid NPE.

### DIFF
--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/FSDagStateStoreTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/FSDagStateStoreTest.java
@@ -52,11 +52,11 @@ public class FSDagStateStoreTest {
 
   @BeforeClass
   public void setUp() throws IOException {
+    this.checkpointDir = new File(dagStateStoreDir);
+    FileUtils.deleteDirectory(this.checkpointDir);
     Config config = ConfigFactory.empty().withValue(DagManager.DAG_STATESTORE_DIR, ConfigValueFactory.fromAnyRef(
         this.dagStateStoreDir));
     this._dagStateStore = new FSDagStateStore(config);
-    this.checkpointDir = new File(dagStateStoreDir);
-    FileUtils.deleteDirectory(this.checkpointDir);
   }
 
   /**
@@ -128,8 +128,8 @@ public class FSDagStateStoreTest {
 
   @Test (dependsOnMethods = "testCleanUp")
   public void testGetDags() throws IOException, URISyntaxException {
-    //Delete dag checkpoint dir
-    FileUtils.deleteDirectory(this.checkpointDir);
+    //Set up a new FSDagStateStore instance.
+    setUp();
     List<Long> flowExecutionIds = Lists.newArrayList(System.currentTimeMillis(), System.currentTimeMillis() + 1);
     for (int i = 0; i < 2; i++) {
       String flowGroupId = Integer.toString(i);


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-637


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
FSDagStateStore#getDags() throws a NPE if the dag checkpoint directory does not exist, since File#listFiles() returns null when the directory does not exist. The fix eagerly creates the checkpoint directory on instantiation of FSDagStateStore. 

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Unit tests in FSDagStateStoreTest.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

