### PR TITLE
[GOBBLIN-639] Change method to static for RequesterService serder

### DIFF
--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/RequesterService.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/RequesterService.java
@@ -48,23 +48,23 @@ public abstract class RequesterService {
    * {@link Config}, we first use Base64 to encode the json string,
    * then use URL encoding to remove characters like '+,/,='.
    */
-  public String serialize(List<ServiceRequester> requestersList) throws IOException {
-    String arrayToJson = objectMapper.writeValueAsString(requestersList);
-    String encodedString = Base64.getEncoder().encodeToString(arrayToJson.getBytes("UTF-8"));
-    return URLEncoder.encode(encodedString, "UTF-8");
+  public static String serialize(List<ServiceRequester> requesterList) throws IOException {
+    String jsonList = objectMapper.writeValueAsString(requesterList);
+    String base64Str = Base64.getEncoder().encodeToString(jsonList.getBytes("UTF-8"));
+    return URLEncoder.encode(base64Str, "UTF-8");
   }
 
   /**
    * <p> This implementation decode a given string encoded by
    * {@link #serialize(List)}.
    */
-  public List<ServiceRequester> deserialize(String encodedString) throws IOException {
-    String urlDecoded = URLDecoder.decode(encodedString, "UTF-8");
-    byte[] decodedBytes = Base64.getDecoder().decode(urlDecoded);
-    String serialized = new String(decodedBytes, "UTF-8");
+  public static List<ServiceRequester> deserialize(String encodedString) throws IOException {
+    String base64Str = URLDecoder.decode(encodedString, "UTF-8");
+    byte[] decodedBytes = Base64.getDecoder().decode(base64Str);
+    String jsonList = new String(decodedBytes, "UTF-8");
     TypeReference<List<ServiceRequester>> mapType = new TypeReference<List<ServiceRequester>>() {};
-    List<ServiceRequester> jsonToPersonList = objectMapper.readValue(serialized, mapType);
-    return jsonToPersonList;
+    List<ServiceRequester> requesterList = objectMapper.readValue(jsonList, mapType);
+    return requesterList;
   }
 
   protected abstract List<ServiceRequester> findRequesters(BaseResource resource);


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-639


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
  Serder method should be static because it doesn't use any membership variables.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

