### PR TITLE
[GOBBLIN-647] Move early stop logic to task driver instance.

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
@@ -126,7 +126,7 @@ public class GobblinClusterConfigurationKeys {
   public static final String HELIX_JOB_TIMEOUT_SECONDS = "helix.job.timeout.seconds";
   public static final String DEFAULT_HELIX_JOB_TIMEOUT_SECONDS = "10800";
   public static final String HELIX_TASK_TIMEOUT_SECONDS = "helix.task.timeout.seconds";
-  public static final String HELIX_MAX_TASK_RETRIES_KEY = "helix.task.maxretries";
+  public static final String HELIX_TASK_MAX_ATTEMPTS_KEY = "helix.task.maxAttempts";
 
   public static final String HELIX_WORKFLOW_DELETE_TIMEOUT_SECONDS = GOBBLIN_CLUSTER_PREFIX + "workflowDeleteTimeoutSeconds";
   public static final long DEFAULT_HELIX_WORKFLOW_DELETE_TIMEOUT_SECONDS = 300;

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
@@ -127,4 +127,8 @@ public class GobblinClusterConfigurationKeys {
   public static final String DEFAULT_HELIX_JOB_TIMEOUT_SECONDS = "10800";
   public static final String HELIX_TASK_TIMEOUT_SECONDS = "helix.task.timeout.seconds";
   public static final String HELIX_MAX_TASK_RETRIES_KEY = "helix.task.maxretries";
+
+  public static final String HELIX_WORKFLOW_DELETE_TIMEOUT_SECONDS = GOBBLIN_CLUSTER_PREFIX + "workflowDeleteTimeoutSeconds";
+  public static final long DEFAULT_HELIX_WORKFLOW_DELETE_TIMEOUT_SECONDS = 300;
+
 }

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixDistributeJobExecutionLauncher.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixDistributeJobExecutionLauncher.java
@@ -88,10 +88,6 @@ class GobblinHelixDistributeJobExecutionLauncher implements JobExecutionLauncher
   protected Properties jobPlanningProps;
   protected HelixJobsMapping jobsMapping;
 
-  protected static final String PLANNING_WORK_UNIT_DIR_NAME = "_plan_workunits";
-  protected static final String PLANNING_TASK_STATE_DIR_NAME = "_plan_taskstates";
-  protected static final String PLANNING_JOB_STATE_DIR_NAME = "_plan_jobstates";
-
   protected static final String JOB_PROPS_PREFIX = "gobblin.jobProps.";
 
   private final long workFlowExpiryTimeSeconds;

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixDistributeJobExecutionLauncher.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixDistributeJobExecutionLauncher.java
@@ -19,7 +19,6 @@ package org.apache.gobblin.cluster;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -36,11 +35,9 @@ import org.apache.helix.task.JobConfig;
 import org.apache.helix.task.TaskConfig;
 import org.apache.helix.task.TaskDriver;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.typesafe.config.Config;
-import com.typesafe.config.ConfigValueFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -50,19 +47,16 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.gobblin.annotation.Alpha;
-import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.metrics.MetricContext;
 import org.apache.gobblin.metrics.Tag;
-import org.apache.gobblin.runtime.TaskState;
 import org.apache.gobblin.runtime.api.ExecutionResult;
 import org.apache.gobblin.runtime.api.JobExecutionLauncher;
 import org.apache.gobblin.runtime.api.JobExecutionMonitor;
 import org.apache.gobblin.runtime.api.JobSpec;
 import org.apache.gobblin.runtime.api.MonitoredObject;
-import org.apache.gobblin.runtime.util.StateStores;
-import org.apache.gobblin.source.extractor.partition.Partitioner;
 import org.apache.gobblin.util.ConfigUtils;
+import org.apache.gobblin.util.PathUtils;
 import org.apache.gobblin.util.PropertiesUtils;
 
 
@@ -92,7 +86,7 @@ class GobblinHelixDistributeJobExecutionLauncher implements JobExecutionLauncher
   protected TaskDriver helixTaskDriver;
   protected Properties sysProps;
   protected Properties jobPlanningProps;
-  protected StateStores stateStores;
+  protected HelixJobsMapping jobsMapping;
 
   protected static final String PLANNING_WORK_UNIT_DIR_NAME = "_plan_workunits";
   protected static final String PLANNING_TASK_STATE_DIR_NAME = "_plan_taskstates";
@@ -123,15 +117,9 @@ class GobblinHelixDistributeJobExecutionLauncher implements JobExecutionLauncher
     Config combined = ConfigUtils.propertiesToConfig(jobPlanningProps)
         .withFallback(ConfigUtils.propertiesToConfig(sysProps));
 
-    Config stateStoreJobConfig = combined
-        .withValue(ConfigurationKeys.STATE_STORE_FS_URI_KEY, ConfigValueFactory.fromAnyRef(
-            new URI(builder.appWorkDir.toUri().getScheme(), null, builder.appWorkDir.toUri().getHost(),
-                builder.appWorkDir.toUri().getPort(), null, null, null).toString()));
-
-    this.stateStores = new StateStores(stateStoreJobConfig,
-        builder.appWorkDir, PLANNING_TASK_STATE_DIR_NAME,
-        builder.appWorkDir, PLANNING_WORK_UNIT_DIR_NAME,
-        builder.appWorkDir, PLANNING_JOB_STATE_DIR_NAME);
+    this.jobsMapping = new HelixJobsMapping(combined,
+                                            PathUtils.getRootPath(builder.appWorkDir).toUri(),
+                                            builder.appWorkDir.toString());
 
     this.workFlowExpiryTimeSeconds = ConfigUtils.getLong(combined,
         GobblinClusterConfigurationKeys.HELIX_WORKFLOW_EXPIRY_TIME_SECONDS,
@@ -144,17 +132,17 @@ class GobblinHelixDistributeJobExecutionLauncher implements JobExecutionLauncher
 
   private void executeCancellation() {
     if (this.jobSubmitted) {
-      String planningName = getPlanningJobId(this.jobPlanningProps);
+      String planningJobId = getPlanningJobId(this.jobPlanningProps);
       try {
         if (this.cancellationRequested && !this.cancellationExecuted) {
           // TODO : fix this when HELIX-1180 is completed
           // work flow should never be deleted explicitly because it has a expiry time
           // If cancellation is requested, we should set the job state to CANCELLED/ABORT
-          this.helixTaskDriver.waitToStop(planningName, 10000L);
-          log.info("Stopped the workflow ", planningName);
+          this.helixTaskDriver.waitToStop(planningJobId, 10000L);
+          log.info("Stopped the workflow ", planningJobId);
         }
       } catch (InterruptedException e) {
-        throw new RuntimeException("Failed to stop workflow " + planningName + " in Helix", e);
+        throw new RuntimeException("Failed to stop workflow " + planningJobId + " in Helix", e);
       }
     }
   }
@@ -262,7 +250,7 @@ class GobblinHelixDistributeJobExecutionLauncher implements JobExecutionLauncher
         return waitForJobCompletion(planningId, planningId);
       } catch (Exception e) {
         log.error(planningId + " is not able to submit.");
-        return new DistributeJobResult(Optional.empty(), Optional.of(e));
+        return new DistributeJobResult(false);
       }
     }
   }
@@ -283,35 +271,19 @@ class GobblinHelixDistributeJobExecutionLauncher implements JobExecutionLauncher
     } catch (TimeoutException te) {
       HelixUtils.handleJobTimeout(workFlowName, jobName,
           helixManager, this, null);
-      return new DistributeJobResult(Optional.empty(), Optional.of(te));
+      return new DistributeJobResult(false);
     }
   }
 
-  //TODO: change below to Helix UserConentStore
-  @VisibleForTesting
+  //TODO: we will remove this logic after we change to polling model.
   protected DistributeJobResult getResultFromUserContent() {
-    String planningId = getPlanningJobId(this.jobPlanningProps);
-    try {
-      TaskState taskState = this.stateStores.getTaskStateStore().get(planningId, planningId, planningId);
-      return new DistributeJobResult(Optional.of(taskState.getProperties()), Optional.empty());
-    } catch (IOException e) {
-      return new DistributeJobResult(Optional.empty(), Optional.of(e));
-    }
+    return new DistributeJobResult(false);
   }
 
   @Getter
   @AllArgsConstructor
   static class DistributeJobResult implements ExecutionResult {
     boolean isEarlyStopped = false;
-    Optional<Properties> properties;
-    Optional<Throwable> throwable;
-    public DistributeJobResult(Optional<Properties> properties, Optional<Throwable> throwable) {
-      this.properties = properties;
-      this.throwable = throwable;
-      if (properties.isPresent()) {
-        isEarlyStopped = PropertiesUtils.getPropAsBoolean(this.properties.get(), Partitioner.IS_EARLY_STOPPED, "false");
-      }
-    }
   }
 
   private class DistributeJobMonitor extends FutureTask<ExecutionResult> implements JobExecutionMonitor {

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobFactory.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobFactory.java
@@ -25,24 +25,23 @@ import org.apache.helix.task.TaskCallbackContext;
 import org.apache.helix.task.TaskFactory;
 
 import com.typesafe.config.Config;
-import com.typesafe.config.ConfigValueFactory;
 
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.metrics.MetricContext;
-import org.apache.gobblin.runtime.util.StateStores;
 import org.apache.gobblin.util.ConfigUtils;
 import org.apache.gobblin.util.PathUtils;
 
 
 /**
- * An implementation of Helix's {@link TaskFactory} for {@link GobblinHelixJobTask}s.
+ * <p> A {@link TaskFactory} that creates {@link GobblinHelixJobTask}
+ * to run task driver logic.
  */
 @Slf4j
 class GobblinHelixJobFactory implements TaskFactory {
-  protected StateStores stateStores;
+  protected HelixJobsMapping jobsMapping;
 
   protected TaskRunnerSuiteBase.Builder builder;
   @Getter
@@ -50,25 +49,20 @@ class GobblinHelixJobFactory implements TaskFactory {
   @Getter
   protected GobblinHelixJobTask.GobblinHelixJobTaskMetrics jobTaskMetrics;
 
-  private void initializeStateStore(TaskRunnerSuiteBase.Builder builder) {
+  private void initJobMapping(TaskRunnerSuiteBase.Builder builder) {
     Config sysConfig = builder.getConfig();
     Path appWorkDir = builder.getAppWorkPath();
     URI rootPathUri = PathUtils.getRootPath(appWorkDir).toUri();
-    Config stateStoreJobConfig = sysConfig
-        .withValue(ConfigurationKeys.STATE_STORE_FS_URI_KEY,
-            ConfigValueFactory.fromAnyRef(rootPathUri.toString()));
-
-    this.stateStores = new StateStores(stateStoreJobConfig,
-        appWorkDir, GobblinHelixDistributeJobExecutionLauncher.PLANNING_TASK_STATE_DIR_NAME,
-        appWorkDir, GobblinHelixDistributeJobExecutionLauncher.PLANNING_WORK_UNIT_DIR_NAME,
-        appWorkDir, GobblinHelixDistributeJobExecutionLauncher.PLANNING_JOB_STATE_DIR_NAME);
+    this.jobsMapping = new HelixJobsMapping(sysConfig,
+                                            rootPathUri,
+                                            appWorkDir.toString());
   }
 
   public GobblinHelixJobFactory(TaskRunnerSuiteBase.Builder builder, MetricContext metricContext) {
 
     this.builder = builder;
-    // TODO: We can remove below initialization once Helix allow us to persist job resut in userContentStore
-    initializeStateStore(this.builder);
+    initJobMapping(this.builder);
+
     // initialize job related metrics (planning jobs)
     int metricsWindowSizeInMin = ConfigUtils.getInt(builder.getConfig(),
         ConfigurationKeys.METRIC_TIMER_WINDOW_SIZE_IN_MINUTES,
@@ -84,7 +78,7 @@ class GobblinHelixJobFactory implements TaskFactory {
   @Override
   public Task createNewTask(TaskCallbackContext context) {
     return new GobblinHelixJobTask(context,
-        this.stateStores,
+        this.jobsMapping,
         this.builder,
         this.launcherMetrics,
         this.jobTaskMetrics);

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobLauncher.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobLauncher.java
@@ -274,7 +274,7 @@ public class GobblinHelixJobLauncher extends AbstractJobLauncher {
 
     // Helix task attempts = retries + 1 (fallback to general task retry for backward compatibility)
     jobConfigBuilder.setMaxAttemptsPerTask(this.jobContext.getJobState().getPropAsInt(
-        GobblinClusterConfigurationKeys.HELIX_MAX_TASK_RETRIES_KEY,
+        GobblinClusterConfigurationKeys.HELIX_TASK_MAX_ATTEMPTS_KEY,
         this.jobContext.getJobState().getPropAsInt(
             ConfigurationKeys.MAX_TASK_RETRIES_KEY,
             ConfigurationKeys.DEFAULT_MAX_TASK_RETRIES)) + 1);

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobLauncher.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobLauncher.java
@@ -184,6 +184,10 @@ public class GobblinHelixJobLauncher extends AbstractJobLauncher {
     }
   }
 
+  public String getJobId() {
+    return this.jobContext.getJobId();
+  }
+
   @Override
   protected void runWorkUnits(List<WorkUnit> workUnits) throws Exception {
     try {

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/HelixJobsMapping.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/HelixJobsMapping.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.cluster;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Optional;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigValueFactory;
+
+import javax.annotation.Nullable;
+
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.configuration.State;
+import org.apache.gobblin.metastore.StateStore;
+import org.apache.gobblin.util.ClassAliasResolver;
+import org.apache.gobblin.util.ConfigUtils;
+
+
+/**
+ * <p> Any job that submitted to Helix will have a unique id.
+ * We need some mapping between the job name and the job id,
+ * in order to perform:
+ *
+ *  1) cancel a running job
+ *  2) delete a running job
+ *  3) block any incoming job with same name.
+ *
+ * <p> More complexity comes into the picture in the distributed
+ * ask driver mode, where we will have a job name, which maps to a
+ * planning job id and further maps to a real job id.
+ *
+ * <p> We will leverage the state store functionality. We will save
+ * job name as a storeName, and tableName. The planning job id and
+ * real job id will be saved in the state object.
+ */
+public class HelixJobsMapping {
+
+  public static final String DB_TABLE_KEY = "JobsMapping";
+
+  private StateStore stateStore;
+
+  public HelixJobsMapping(Config sysConfig, URI fsUri, String rootDir) {
+    String stateStoreType = ConfigUtils.getString(sysConfig, ConfigurationKeys.INTERMEDIATE_STATE_STORE_TYPE_KEY,
+        ConfigUtils.getString(sysConfig, ConfigurationKeys.STATE_STORE_TYPE_KEY,
+            ConfigurationKeys.DEFAULT_STATE_STORE_TYPE));
+
+    ClassAliasResolver<StateStore.Factory> resolver =
+        new ClassAliasResolver<>(StateStore.Factory.class);
+    StateStore.Factory stateStoreFactory;
+
+    try {
+      stateStoreFactory = resolver.resolveClass(stateStoreType).newInstance();
+    } catch (ClassNotFoundException cnfe) {
+      throw new RuntimeException(cnfe);
+    } catch (InstantiationException ie) {
+      throw new RuntimeException(ie);
+    } catch (IllegalAccessException iae) {
+      throw new RuntimeException(iae);
+    }
+
+    Config stateStoreJobConfig = sysConfig
+        .withValue(ConfigurationKeys.STATE_STORE_FS_URI_KEY, ConfigValueFactory.fromAnyRef(fsUri.toString()))
+        .withValue(ConfigurationKeys.STATE_STORE_ROOT_DIR_KEY, ConfigValueFactory.fromAnyRef(rootDir))
+        .withValue(ConfigurationKeys.STATE_STORE_DB_TABLE_KEY, ConfigValueFactory.fromAnyRef(DB_TABLE_KEY));
+
+    this.stateStore = stateStoreFactory.createStateStore(stateStoreJobConfig, State.class);
+  }
+
+  @Nullable
+  private State getOrCreate (String jobName) throws IOException {
+    if (this.stateStore.exists(jobName, jobName)) {
+      return this.stateStore.get(jobName, jobName, jobName);
+    }
+    return new State();
+  }
+
+  public void setPlanningJobId (String jobName, String planningJobId) throws IOException {
+    State state = getOrCreate(jobName);
+    state.setId(jobName);
+    state.setProp(GobblinClusterConfigurationKeys.PLANNING_ID_KEY, planningJobId);
+    this.stateStore.put(jobName, jobName, state);
+  }
+
+  public void setActualJobId (String jobName, String planningJobId, String actualJobId) throws IOException {
+    State state = getOrCreate(jobName);
+    state.setId(jobName);
+    state.setProp(GobblinClusterConfigurationKeys.PLANNING_ID_KEY, planningJobId);
+    state.setProp(ConfigurationKeys.JOB_ID_KEY, actualJobId);
+    this.stateStore.put(jobName, jobName, state);
+  }
+
+  private Optional<String> getId (String jobName, String idName) throws IOException {
+    State state = this.stateStore.get(jobName, jobName, jobName);
+    if (state == null) {
+      return Optional.empty();
+    }
+
+    String id = state.getProp(idName);
+
+    return id == null? Optional.empty() : Optional.of(id);
+  }
+
+  public Optional<String> getActualJobId (String jobName) throws IOException {
+    return getId(jobName, ConfigurationKeys.JOB_ID_KEY);
+  }
+
+  public Optional<String> getPlanningJobId (String jobName) throws IOException {
+    return getId(jobName, GobblinClusterConfigurationKeys.PLANNING_ID_KEY);
+  }
+}


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-647


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
  Early-stop feature requires a monitoring thread allocated on the manager instance. In distributed job launcher mode, we can move this early stop feature to the task-driver instance to avoid too many thread allocated on manager side. This also make coding easier because the early-stop looping logic on the task-driver is the same as we did for a normal helix job launcher.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
    ClusterIntegrationTest::testPlanningJobFactory()

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

