### PR TITLE
GOBBLIN-653: Create JobSucceededTimer tracking event to accurately track successful Gobblin jobs.

### DIFF
--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/TimingEvent.java
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/TimingEvent.java
@@ -40,6 +40,7 @@ public class TimingEvent {
     public static final String JOB_CANCEL = "JobCancelTimer";
     public static final String JOB_COMPLETE = "JobCompleteTimer";
     public static final String JOB_FAILED = "JobFailedTimer";
+    public static final String JOB_SUCCEEDED = "JobSucceededTimer";
   }
 
   public static class RunJobTimings {


### PR DESCRIPTION

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-653


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
The JobCompleteTimer event is not sufficient to track successfully completed Gobblin jobs, since this timer event is emitted even in case of failed jobs. We introduce a new timing event that accurately tracks successful job completions. 

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tested the flow in dev environment both for the case:
1. When work units are created and 
2. When work units is empty.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

