### PR TITLE
GOBBLIN-654: Fix the argument order of JobStatusRetriever APIs to reflect actual usage.

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/JobStatusRetriever.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/JobStatusRetriever.java
@@ -34,7 +34,7 @@ public abstract class JobStatusRetriever implements LatestFlowExecutionIdTracker
       long flowExecutionId);
 
   public abstract Iterator<JobStatus> getJobStatusesForFlowExecution(String flowName, String flowGroup,
-      long flowExecutionId, String jobGroup, String jobName);
+      long flowExecutionId, String jobName, String jobGroup);
 
   /**
    * Get the latest {@link JobStatus}es that belongs to the same latest flow execution. Currently, latest flow execution

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
@@ -349,7 +349,7 @@ public class DagManager extends AbstractIdleService {
       String jobName = jobConfig.getString(ConfigurationKeys.JOB_NAME_KEY);
 
       Iterator<JobStatus> jobStatusIterator =
-          this.jobStatusRetriever.getJobStatusesForFlowExecution(flowGroup, flowName, flowExecutionId, jobGroup, jobName);
+          this.jobStatusRetriever.getJobStatusesForFlowExecution(flowName, flowGroup, flowExecutionId, jobName, jobGroup);
       if (jobStatusIterator.hasNext()) {
         return jobStatusIterator.next();
       } else {

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagerTest.java
@@ -142,13 +142,13 @@ public class DagManagerTest {
 
     //Add a dag to the queue of dags
     this.queue.offer(dag);
-    Iterator<JobStatus> jobStatusIterator1 = getMockJobStatus(flowName, flowGroup, flowExecutionId, flowGroup, jobName0, String.valueOf(ExecutionStatus.RUNNING));
-    Iterator<JobStatus> jobStatusIterator2 = getMockJobStatus(flowName, flowGroup, flowExecutionId, flowGroup, jobName0, String.valueOf(ExecutionStatus.COMPLETE));
-    Iterator<JobStatus> jobStatusIterator3 = getMockJobStatus(flowName, flowGroup, flowExecutionId, flowGroup, jobName1, String.valueOf(ExecutionStatus.RUNNING));
-    Iterator<JobStatus> jobStatusIterator4 = getMockJobStatus(flowName, flowGroup, flowExecutionId, flowGroup, jobName2, String.valueOf(ExecutionStatus.RUNNING));
-    Iterator<JobStatus> jobStatusIterator5 = getMockJobStatus(flowName, flowGroup, flowExecutionId, flowGroup, jobName1, String.valueOf(ExecutionStatus.RUNNING));
-    Iterator<JobStatus> jobStatusIterator6 = getMockJobStatus(flowName, flowGroup, flowExecutionId, flowGroup, jobName2, String.valueOf(ExecutionStatus.COMPLETE));
-    Iterator<JobStatus> jobStatusIterator7 = getMockJobStatus(flowName, flowGroup, flowExecutionId, flowGroup, jobName1, String.valueOf(ExecutionStatus.COMPLETE));
+    Iterator<JobStatus> jobStatusIterator1 = getMockJobStatus(flowName, flowGroup, flowExecutionId, jobName0, flowGroup, String.valueOf(ExecutionStatus.RUNNING));
+    Iterator<JobStatus> jobStatusIterator2 = getMockJobStatus(flowName, flowGroup, flowExecutionId, jobName0, flowGroup, String.valueOf(ExecutionStatus.COMPLETE));
+    Iterator<JobStatus> jobStatusIterator3 = getMockJobStatus(flowName, flowGroup, flowExecutionId, jobName1, flowGroup, String.valueOf(ExecutionStatus.RUNNING));
+    Iterator<JobStatus> jobStatusIterator4 = getMockJobStatus(flowName, flowGroup, flowExecutionId, jobName2, flowGroup, String.valueOf(ExecutionStatus.RUNNING));
+    Iterator<JobStatus> jobStatusIterator5 = getMockJobStatus(flowName, flowGroup, flowExecutionId, jobName1, flowGroup, String.valueOf(ExecutionStatus.RUNNING));
+    Iterator<JobStatus> jobStatusIterator6 = getMockJobStatus(flowName, flowGroup, flowExecutionId, jobName2, flowGroup, String.valueOf(ExecutionStatus.COMPLETE));
+    Iterator<JobStatus> jobStatusIterator7 = getMockJobStatus(flowName, flowGroup, flowExecutionId, jobName1, flowGroup, String.valueOf(ExecutionStatus.COMPLETE));
 
     Mockito.when(_jobStatusRetriever.getJobStatusesForFlowExecution(Mockito.anyString(), Mockito.anyString(),
         Mockito.anyLong(), Mockito.anyString(), Mockito.anyString())).
@@ -223,23 +223,23 @@ public class DagManagerTest {
       //Add a dag to the queue of dags
       this.queue.offer(dag);
       Iterator<JobStatus> jobStatusIterator1 =
-          getMockJobStatus(flowName, flowGroup, flowExecutionId, flowGroup, jobName0, String.valueOf(ExecutionStatus.RUNNING));
+          getMockJobStatus(flowName, flowGroup, flowExecutionId, jobName0, flowGroup, String.valueOf(ExecutionStatus.RUNNING));
       Iterator<JobStatus> jobStatusIterator2 =
-          getMockJobStatus(flowName, flowGroup, flowExecutionId, flowGroup, jobName0, String.valueOf(ExecutionStatus.COMPLETE));
+          getMockJobStatus(flowName, flowGroup, flowExecutionId, jobName0, flowGroup, String.valueOf(ExecutionStatus.COMPLETE));
       Iterator<JobStatus> jobStatusIterator3 =
-          getMockJobStatus(flowName, flowGroup, flowExecutionId, flowGroup, jobName1, String.valueOf(ExecutionStatus.RUNNING));
+          getMockJobStatus(flowName, flowGroup, flowExecutionId, jobName1, flowGroup, String.valueOf(ExecutionStatus.RUNNING));
       Iterator<JobStatus> jobStatusIterator4 =
-          getMockJobStatus(flowName, flowGroup, flowExecutionId, flowGroup, jobName2, String.valueOf(ExecutionStatus.RUNNING));
+          getMockJobStatus(flowName, flowGroup, flowExecutionId, jobName2, flowGroup, String.valueOf(ExecutionStatus.RUNNING));
       Iterator<JobStatus> jobStatusIterator5 =
-          getMockJobStatus(flowName, flowGroup, flowExecutionId, flowGroup, jobName1, String.valueOf(ExecutionStatus.RUNNING));
+          getMockJobStatus(flowName, flowGroup, flowExecutionId, jobName1, flowGroup, String.valueOf(ExecutionStatus.RUNNING));
       Iterator<JobStatus> jobStatusIterator6 =
-          getMockJobStatus(flowName, flowGroup, flowExecutionId, flowGroup, jobName2, String.valueOf(ExecutionStatus.FAILED));
+          getMockJobStatus(flowName, flowGroup, flowExecutionId, jobName2, flowGroup, String.valueOf(ExecutionStatus.FAILED));
       Iterator<JobStatus> jobStatusIterator7 =
-          getMockJobStatus(flowName, flowGroup, flowExecutionId, flowGroup, jobName1, String.valueOf(ExecutionStatus.COMPLETE));
+          getMockJobStatus(flowName, flowGroup, flowExecutionId, jobName1, flowGroup, String.valueOf(ExecutionStatus.COMPLETE));
       Iterator<JobStatus> jobStatusIterator8 =
-          getMockJobStatus(flowName, flowGroup, flowExecutionId, flowGroup, jobName1, String.valueOf(ExecutionStatus.RUNNING));
+          getMockJobStatus(flowName, flowGroup, flowExecutionId, jobName1, flowGroup, String.valueOf(ExecutionStatus.RUNNING));
       Iterator<JobStatus> jobStatusIterator9 =
-          getMockJobStatus(flowName, flowGroup, flowExecutionId, flowGroup, jobName1, String.valueOf(ExecutionStatus.COMPLETE));
+          getMockJobStatus(flowName, flowGroup, flowExecutionId, jobName1, flowGroup, String.valueOf(ExecutionStatus.COMPLETE));
 
 
       Mockito.when(_jobStatusRetriever


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-654


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
The argument order for JobStatusRetriever#getJobStatusesForFlowExecution() do not match the actual usage in the implementation. This ticket fixes the argument order for the API.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tested pipeline in local environment.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

