### PR TITLE
GOBBLIN-659: Ensure MultiHopFlowCompiler is properly initialized before attempting flow orchestration.

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GobblinServiceManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GobblinServiceManager.java
@@ -87,6 +87,7 @@ import org.apache.gobblin.service.NoopRequesterService;
 import org.apache.gobblin.service.RequesterService;
 import org.apache.gobblin.service.Schedule;
 import org.apache.gobblin.service.ServiceConfigKeys;
+import org.apache.gobblin.service.modules.flow.MultiHopFlowCompiler;
 import org.apache.gobblin.service.modules.orchestration.DagManager;
 import org.apache.gobblin.service.modules.orchestration.Orchestrator;
 import org.apache.gobblin.service.modules.restli.GobblinServiceFlowConfigResourceHandler;
@@ -447,6 +448,9 @@ public class GobblinServiceManager implements ApplicationLauncher, StandardMetri
 
     // Notify now topologyCatalog has the right information
     this.topologyCatalog.getInitComplete().countDown();
+
+    //Activate the SpecCompiler, after the topologyCatalog has been initialized.
+    this.orchestrator.getSpecCompiler().setActive(true);
   }
 
   @Override

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/BaseFlowToJobSpecCompiler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/BaseFlowToJobSpecCompiler.java
@@ -95,6 +95,9 @@ public abstract class BaseFlowToJobSpecCompiler implements SpecCompiler {
   protected Optional<Meter> flowCompilationFailedMeter;
   @Getter
   protected Optional<Timer> flowCompilationTimer;
+  @Getter
+  @Setter
+  protected boolean active;
 
   public BaseFlowToJobSpecCompiler(Config config){
     this(config,true);
@@ -147,6 +150,12 @@ public abstract class BaseFlowToJobSpecCompiler implements SpecCompiler {
       throw new RuntimeException("Could not initialize FlowCompiler because of "
           + "TemplateCatalog initialization failure", e);
     }
+  }
+
+  @Override
+  public void awaitHealthy() throws InterruptedException {
+    //Do nothing
+    return;
   }
 
   @Override

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/SpecCompiler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/SpecCompiler.java
@@ -38,7 +38,7 @@ public interface SpecCompiler extends SpecCatalogListener, Instrumentable {
    * Take in a logical {@link Spec} and compile corresponding materialized {@link Spec}s
    * and the mapping to {@link SpecExecutor} that they can be run on.
    * All the specs generated from the compileFlow must have a
-   * {@link org.apache.gobblin.configuration.ConfigurationKeys.FLOW_EXECUTION_ID_KEY}
+   * {@value org.apache.gobblin.configuration.ConfigurationKeys#FLOW_EXECUTION_ID_KEY}
    * @param spec {@link Spec} to compile.
    * @return Map of materialized physical {@link Spec} and {@link SpecExecutor}.
    */
@@ -50,4 +50,21 @@ public interface SpecCompiler extends SpecCatalogListener, Instrumentable {
    * @return Map of {@link Spec} URI and {@link TopologySpec}
    */
   Map<URI, TopologySpec> getTopologySpecMap();
+
+  /**
+   * Mark the {@link SpecCompiler} active/inactive. Useful to trigger the initialization of {@link SpecCompiler}, if
+   * necessary, before it can start compiling {@link org.apache.gobblin.runtime.api.FlowSpec}s.
+   * @param active
+   */
+  void setActive(boolean active);
+
+  /**
+   * Waits for the {@link SpecCompiler} to become healthy. A {@link SpecCompiler} is healthy when all the component
+   * services it depends on have been successfully initialized. For instance, the {@link MultiHopFlowCompiler} is healthy
+   * when the {@link org.apache.gobblin.service.modules.flowgraph.DataNode}s and {@link org.apache.gobblin.service.modules.flowgraph.FlowEdge}s
+   * can be added to the {@link org.apache.gobblin.service.modules.flowgraph.FlowGraph}. The {@link org.apache.gobblin.service.modules.flowgraph.FlowEdge}
+   * instantiation in turn depends on the successful initialization of {@link org.apache.gobblin.runtime.spec_catalog.TopologyCatalog}, which
+   * instantiates all the configured {@link SpecExecutor}s.
+   */
+  public void awaitHealthy() throws InterruptedException;
 }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/Orchestrator.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/Orchestrator.java
@@ -197,6 +197,9 @@ public class Orchestrator implements SpecCatalogListener, Instrumentable {
     // Add below waiting because TopologyCatalog and FlowCatalog service can be launched at the same time
     this.topologyCatalog.get().getInitComplete().await();
 
+    //Wait for the SpecCompiler to become healthy.
+    this.getSpecCompiler().awaitHealthy();
+
     long startTime = System.nanoTime();
     if (spec instanceof FlowSpec) {
       TimingEvent flowCompilationTimer = this.eventSubmitter.isPresent()

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/core/GitFlowGraphMonitorTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/core/GitFlowGraphMonitorTest.java
@@ -24,6 +24,7 @@ import java.net.URISyntaxException;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 
 import org.apache.commons.io.FileUtils;
@@ -122,7 +123,7 @@ public class GitFlowGraphMonitorTest {
     //Create a FlowGraph instance with defaults
     this.flowGraph = new BaseFlowGraph();
 
-    this.gitFlowGraphMonitor = new GitFlowGraphMonitor(this.config, this.flowCatalog, this.flowGraph, topologySpecMap);
+    this.gitFlowGraphMonitor = new GitFlowGraphMonitor(this.config, this.flowCatalog, this.flowGraph, topologySpecMap, new CountDownLatch(1));
     this.gitFlowGraphMonitor.setActive(true);
   }
 

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/flow/MultiHopFlowCompilerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/flow/MultiHopFlowCompilerTest.java
@@ -618,6 +618,8 @@ public class MultiHopFlowCompilerTest {
     //Create a MultiHopFlowCompiler instance
     specCompiler = new MultiHopFlowCompiler(config, Optional.absent(), false);
 
+    specCompiler.setActive(true);
+
     //Ensure node1 is not present in the graph
     Assert.assertNull(specCompiler.getFlowGraph().getNode("node1"));
 


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-659


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
The MultiHopFlowCompiler needs to be properly initialized before Orchestrator starts processing flow requests. More precisely, the MultiHopFlowCompiler needs to initialize the DataNodes and FlowEdges on start up, before it can handle flow compilation requests. The MultiHopFlowCompiler in turn depends on the TopologyCatalog/TopologySpecFactory being initialized.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tested startup and flow orchestration for both the IdentityFlowToJobSpec and MultiHopFlowCompiler 
in dev environment.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

