### PR TITLE
[GOBBLIN-660] Fix OracleExtractor datatype mapping

### DIFF
--- a/gobblin-modules/gobblin-parquet/src/main/java/org/apache/gobblin/converter/parquet/JsonElementConversionFactory.java
+++ b/gobblin-modules/gobblin-parquet/src/main/java/org/apache/gobblin/converter/parquet/JsonElementConversionFactory.java
@@ -105,6 +105,10 @@ public class JsonElementConversionFactory {
       case MAP:
         return new MapConverter(schema);
 
+      case DATE:
+      case TIMESTAMP:
+        return new StringConverter(schema, repeated);
+
       default:
         throw new UnsupportedOperationException(fieldType + " is unsupported");
     }

--- a/gobblin-modules/gobblin-parquet/src/main/java/org/apache/gobblin/converter/parquet/JsonSchema.java
+++ b/gobblin-modules/gobblin-parquet/src/main/java/org/apache/gobblin/converter/parquet/JsonSchema.java
@@ -55,7 +55,7 @@ public class JsonSchema extends Schema {
   private final InputType type;
 
   public enum InputType {
-    STRING, INT, LONG, FLOAT, DOUBLE, BOOLEAN, ARRAY, ENUM, RECORD, MAP
+    STRING, INT, LONG, FLOAT, DOUBLE, BOOLEAN, ARRAY, ENUM, RECORD, MAP, DATE, TIMESTAMP
   }
 
   public JsonSchema(JsonArray jsonArray) {

--- a/gobblin-modules/gobblin-parquet/src/test/resources/converter/JsonIntermediateToParquetConverter.json
+++ b/gobblin-modules/gobblin-parquet/src/test/resources/converter/JsonIntermediateToParquetConverter.json
@@ -5,7 +5,9 @@
       "b": 5.0,
       "c": 8.0,
       "d": true,
-      "e": "somestring"
+      "e": "somestring",
+      "f": "2018-01-01",
+      "g": 1545083047
     },
     "schema": [
       {
@@ -37,10 +39,22 @@
         "dataType": {
           "type": "string"
         }
+      },
+      {
+        "columnName": "f",
+        "dataType": {
+          "type": "date"
+        }
+      },
+      {
+        "columnName": "g",
+        "dataType": {
+          "type": "timestamp"
+        }
       }
     ],
-    "expectedRecord": "a: 5 ; b: 5.0 ; c: 8.0 ; d: true ; e: somestring ; ",
-    "expectedSchema": "message test_table{ ; required int32 a ;  ; required float b ;  ; required double c ;  ; required boolean d ;  ; required binary e (UTF8) ;  ; } ; "
+    "expectedRecord": "a: 5 ; b: 5.0 ; c: 8.0 ; d: true ; e: somestring ; f: 2018-01-01 ; g: 1545083047 ;",
+    "expectedSchema": "message test_table{ ; required int32 a ;  ; required float b ;  ; required double c ;  ; required boolean d ;  ; required binary e (UTF8) ;  ; required binary f (UTF8) ;  ; required binary g (UTF8) ;  ; } ; "
   },
   "array": {
     "record": {

--- a/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/source/jdbc/OracleExtractor.java
+++ b/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/source/jdbc/OracleExtractor.java
@@ -67,7 +67,7 @@ public class OracleExtractor extends JdbcExtractor {
   private static final String METADATA_SCHEMA_PSTMT_FORMAT =
       "SELECT " +
         "column_name, " +
-        "UPPER(data_type), " +
+        "LOWER(data_type), " +
         "NVL(data_length, 0) as length, " +
         "NVL(data_precision, 0) as precesion, " +
         "NVL(data_scale, 0) as scale, " +

--- a/gobblin-modules/gobblin-sql/src/test/java/org/apache/gobblin/source/jdbc/OracleExtractorTest.java
+++ b/gobblin-modules/gobblin-sql/src/test/java/org/apache/gobblin/source/jdbc/OracleExtractorTest.java
@@ -69,18 +69,17 @@ public class OracleExtractorTest {
   }
 
   @Test
-  public void testConstructSampleClause() throws Exception {
+  public void testConstructSampleClause() {
     String sClause = oracleExtractor.constructSampleClause();
     assertEquals(sClause.trim(), (" rownum <= " + oracleExtractor.getSampleRecordCount()).trim());
   }
 
   @Test
-  public void testRemoveSampleClauseFromQuery() throws Exception {
+  public void testRemoveSampleClauseFromQuery() {
     String q1Expected = "SELECT * FROM x WHERE 1=1";
     String q2Expected = "SELECT * FROM x WHERE 1=1 AND x.a < 10";
     String q3Expected = "SELECT * FROM x WHERE x.a < 10 AND 1=1";
     String q4Expected = "SELECT * FROM x WHERE x.a < 10 AND 1=1 AND x.b = 20";
-    String qEmptyClean = "";
 
     String q1Parsed = oracleExtractor.removeSampleClauseFromQuery(QUERY_1);
     String q2Parsed = oracleExtractor.removeSampleClauseFromQuery(QUERY_2);
@@ -94,7 +93,7 @@ public class OracleExtractorTest {
   }
 
   @Test
-  public void testExractSampleRecordCountFromQuery() throws Exception {
+  public void testExractSampleRecordCountFromQuery() {
     long res1 = oracleExtractor.exractSampleRecordCountFromQuery(QUERY_1);
     long res2 = oracleExtractor.exractSampleRecordCountFromQuery(QUERY_2);
     long res3 = oracleExtractor.exractSampleRecordCountFromQuery(QUERY_3);
@@ -113,7 +112,7 @@ public class OracleExtractorTest {
   /**
    * Build a mock implementation of Result using Mockito
    */
-  private ResultSet buildMockResultSet() throws Exception {
+  private ResultSet buildMockResultSet() {
 
     MockResultSet mrs = new MockResultSet(StringUtils.EMPTY);
     for (MockJdbcColumn column : COLUMNS) {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-660

### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
- Fix sql request with lower instead of upper will avoid returning always string type in  `convertDataType` from `QueryBasedExtractor`
- Manage DATE and TIMESTAMP type for parquet type converter

### Tests
- [x] My PR adds the following unit tests 
`JsonIntermediateToParquetGroupConverterTest`

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"