### PR TITLE
GOBBLIN-663: Fix Typesafe config resolution failure for non-HOCON strings

### DIFF
--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/test/java/org/apache/gobblin/service/FlowConfigResourceLocalHandlerTest.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/test/java/org/apache/gobblin/service/FlowConfigResourceLocalHandlerTest.java
@@ -1,0 +1,66 @@
+package org.apache.gobblin.service;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.Maps;
+import com.linkedin.data.template.StringMap;
+
+import org.apache.gobblin.runtime.api.FlowSpec;
+
+
+public class FlowConfigResourceLocalHandlerTest {
+  private static final String FLOW_GROUP_KEY = "flow.group";
+  private static final String FLOW_NAME_KEY = "flow.name";
+  private static final String SCHEDULE_KEY = "job.schedule";
+  private static final String RUN_IMMEDIATELY_KEY = "flow.runImmediately";
+
+  private static final String TEST_GROUP_NAME = "testGroup1";
+  private static final String TEST_FLOW_NAME = "testFlow1";
+  private static final String TEST_SCHEDULE = "0 1/0 * ? * *";
+  private static final String TEST_TEMPLATE_URI = "FS:///templates/test.template";
+
+  @Test
+  public void testCreateFlowSpecForConfig() throws URISyntaxException {
+    Map<String, String> flowProperties = Maps.newHashMap();
+    flowProperties.put("param1", "a:b:c*.d");
+
+    FlowConfig flowConfig = new FlowConfig().setId(new FlowId().setFlowGroup(TEST_GROUP_NAME).setFlowName(TEST_FLOW_NAME))
+        .setTemplateUris(TEST_TEMPLATE_URI).setSchedule(new Schedule().setCronSchedule(TEST_SCHEDULE).
+            setRunImmediately(true))
+        .setProperties(new StringMap(flowProperties));
+
+    FlowSpec flowSpec = FlowConfigResourceLocalHandler.createFlowSpecForConfig(flowConfig);
+    Assert.assertEquals(flowSpec.getConfig().getString(FLOW_GROUP_KEY), TEST_GROUP_NAME);
+    Assert.assertEquals(flowSpec.getConfig().getString(FLOW_NAME_KEY), TEST_FLOW_NAME);
+    Assert.assertEquals(flowSpec.getConfig().getString(SCHEDULE_KEY), TEST_SCHEDULE);
+    Assert.assertEquals(flowSpec.getConfig().getBoolean(RUN_IMMEDIATELY_KEY), true);
+    Assert.assertEquals(flowSpec.getConfig().getString("param1"), "a:b:c*.d");
+    Assert.assertEquals(flowSpec.getTemplateURIs().get().size(), 1);
+    Assert.assertTrue(flowSpec.getTemplateURIs().get().contains(new URI(TEST_TEMPLATE_URI)));
+
+    flowProperties = Maps.newHashMap();
+    flowProperties.put("param1", "value1");
+    flowProperties.put("param2", "${param1}-123");
+    flowProperties.put("param3", "\"a:b:c*.d\"");
+    flowConfig = new FlowConfig().setId(new FlowId().setFlowGroup(TEST_GROUP_NAME).setFlowName(TEST_FLOW_NAME))
+        .setTemplateUris(TEST_TEMPLATE_URI).setSchedule(new Schedule().setCronSchedule(TEST_SCHEDULE).
+            setRunImmediately(true))
+        .setProperties(new StringMap(flowProperties));
+    flowSpec = FlowConfigResourceLocalHandler.createFlowSpecForConfig(flowConfig);
+
+    Assert.assertEquals(flowSpec.getConfig().getString(FLOW_GROUP_KEY), TEST_GROUP_NAME);
+    Assert.assertEquals(flowSpec.getConfig().getString(FLOW_NAME_KEY), TEST_FLOW_NAME);
+    Assert.assertEquals(flowSpec.getConfig().getString(SCHEDULE_KEY), TEST_SCHEDULE);
+    Assert.assertEquals(flowSpec.getConfig().getBoolean(RUN_IMMEDIATELY_KEY), true);
+    Assert.assertEquals(flowSpec.getConfig().getString("param1"),"value1");
+    Assert.assertEquals(flowSpec.getConfig().getString("param2"),"value1-123");
+    Assert.assertEquals(flowSpec.getConfig().getString("param3"), "a:b:c*.d");
+    Assert.assertEquals(flowSpec.getTemplateURIs().get().size(), 1);
+    Assert.assertTrue(flowSpec.getTemplateURIs().get().contains(new URI(TEST_TEMPLATE_URI)));
+  }
+}

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/test/java/org/apache/gobblin/service/FlowConfigResourceLocalHandlerTest.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/test/java/org/apache/gobblin/service/FlowConfigResourceLocalHandlerTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.gobblin.service;
 
 import java.net.URI;


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-663


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
The change from 'parseMap' to 'parseString' inside FlowConfigResourceLocalHandler is backwards-incompatible i.e. it now only accepts valid HOCON strings. For literal strings in the REST.li request which may contain special characters such as ":" or "*" and which are forbidden by HOCON unless properly escaped, the request will fail with ConfigException. 

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Added a unit test in FlowConfigResourceLocalHandlerTest class.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

