### PR TITLE
GOBBLIN-665: Throw an exception if job orchestration fails on a SpecExecutor.

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
@@ -393,7 +393,11 @@ public class DagManager extends AbstractIdleService {
         TimingEvent jobOrchestrationTimer = this.eventSubmitter.isPresent() ? this.eventSubmitter.get().
             getTimingEvent(TimingEvent.LauncherTimings.JOB_ORCHESTRATED) : null;
 
-        producer.addSpec(jobSpec);
+        //Submit the job to the SpecProducer, which in turn performs the actual job submission to the SpecExecutor instance.
+        // The SpecProducer implementations submit the job to the underlying executor and return when the submission is complete,
+        // either successfully or unsuccessfully. To catch any exceptions in the job submission, the DagManagerThread
+        // blocks (by calling Future#get()) until the submission is completed.
+        producer.addSpec(jobSpec).get();
 
         if (jobOrchestrationTimer != null) {
           jobOrchestrationTimer.stop(jobMetadata);


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-665


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Currently SpecProducer#addSpec() returns a Future object. However, this future is ignored in the DagManager. As a result, any exceptions in the orchestration of the job will be ignored by the DagManager. By calling get() on the future, any exceptions in addSpec() will be explicitly thrown and corresponding JOB_FAILED timer events will be emitted to Kafka.  



### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tested in local set up.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

