### PR TITLE
GOBBLIN-667: Pass encrypt.key.loc configuration to GitFlowGraphMonitor.

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/MultiHopFlowCompiler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/MultiHopFlowCompiler.java
@@ -95,7 +95,13 @@ public class MultiHopFlowCompiler extends BaseFlowToJobSpecCompiler {
       throw new RuntimeException("Cannot instantiate " + getClass().getName(), e);
     }
     this.flowGraph = new BaseFlowGraph();
-    this.gitFlowGraphMonitor = new GitFlowGraphMonitor(this.config, flowCatalog, this.flowGraph, this.topologySpecMap, this.getInitComplete());
+    Config gitFlowGraphConfig = this.config;
+    if (this.config.hasPath(ConfigurationKeys.ENCRYPT_KEY_LOC)) {
+      //Add encrypt.key.loc config to the config passed to GitFlowGraphMonitor
+      gitFlowGraphConfig = this.config
+          .withValue(GitFlowGraphMonitor.GIT_FLOWGRAPH_MONITOR_PREFIX + "." + ConfigurationKeys.ENCRYPT_KEY_LOC, config.getValue(ConfigurationKeys.ENCRYPT_KEY_LOC));
+    }
+    this.gitFlowGraphMonitor = new GitFlowGraphMonitor(gitFlowGraphConfig, flowCatalog, this.flowGraph, this.topologySpecMap, this.getInitComplete());
     this.serviceManager = new ServiceManager(Lists.newArrayList(this.gitFlowGraphMonitor));
     addShutdownHook();
     //Start the git flow graph monitor


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-667


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Currently, the encrypt.key.loc is passed to GitFlowGraphMonitor needs to be statically set in the configuration of gobblin-service. This change makes this config available to the monitor dynamically. 

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tested in local environment.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

