### PR TITLE
[GOBBLIN-666] Data too long for column 'property_key'

### DIFF
--- a/gobblin-metastore/src/main/java/org/apache/gobblin/metastore/database/DatabaseJobHistoryStoreV103.java
+++ b/gobblin-metastore/src/main/java/org/apache/gobblin/metastore/database/DatabaseJobHistoryStoreV103.java
@@ -1,5 +1,15 @@
 package org.apache.gobblin.metastore.database;
 
+import org.apache.gobblin.metastore.JobHistoryStore;
+
+/**
+ * An implementation of {@link JobHistoryStore} backed by MySQL.
+ *
+ * <p>
+ *     The DDLs for the MySQL job history store can be found under metastore/src/main/resources.
+ * </p>
+ *
+ */
 @SupportedDatabaseVersion(isDefault = false, version = "1.0.3")
 public class DatabaseJobHistoryStoreV103 extends DatabaseJobHistoryStoreV101 implements VersionedDatabaseJobHistoryStore {
 

--- a/gobblin-metastore/src/main/java/org/apache/gobblin/metastore/database/DatabaseJobHistoryStoreV103.java
+++ b/gobblin-metastore/src/main/java/org/apache/gobblin/metastore/database/DatabaseJobHistoryStoreV103.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.gobblin.metastore.database;
 
 import org.apache.gobblin.metastore.JobHistoryStore;

--- a/gobblin-metastore/src/main/java/org/apache/gobblin/metastore/database/DatabaseJobHistoryStoreV103.java
+++ b/gobblin-metastore/src/main/java/org/apache/gobblin/metastore/database/DatabaseJobHistoryStoreV103.java
@@ -1,0 +1,6 @@
+package org.apache.gobblin.metastore.database;
+
+@SupportedDatabaseVersion(isDefault = false, version = "1.0.3")
+public class DatabaseJobHistoryStoreV103 extends DatabaseJobHistoryStoreV101 implements VersionedDatabaseJobHistoryStore {
+
+}

--- a/gobblin-metastore/src/main/resources/db/migration/V1_0_3__Update_Key_Length.sql
+++ b/gobblin-metastore/src/main/resources/db/migration/V1_0_3__Update_Key_Length.sql
@@ -15,5 +15,5 @@
 --  limitations under the License.
 --
 
-ALTER TABLE `gobblin_task_properties` MODIFY `property_key` VARCHAR(256);
-ALTER TABLE `gobblin_job_properties` MODIFY `property_key` VARCHAR(256);
+ALTER TABLE `gobblin_task_properties` MODIFY `property_key` VARCHAR(191);
+ALTER TABLE `gobblin_job_properties` MODIFY `property_key` VARCHAR(191);

--- a/gobblin-metastore/src/main/resources/db/migration/V1_0_3__Update_Key_Length.sql
+++ b/gobblin-metastore/src/main/resources/db/migration/V1_0_3__Update_Key_Length.sql
@@ -1,0 +1,19 @@
+--
+--  Licensed to the Apache Software Foundation (ASF) under one or more
+--  contributor license agreements.  See the NOTICE file distributed with
+--  this work for additional information regarding copyright ownership.
+--  The ASF licenses this file to You under the Apache License, Version 2.0
+--  (the "License"); you may not use this file except in compliance with
+--  the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+--  Unless required by applicable law or agreed to in writing, software
+--  distributed under the License is distributed on an "AS IS" BASIS,
+--  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--  See the License for the specific language governing permissions and
+--  limitations under the License.
+--
+
+ALTER TABLE `gobblin_task_properties` MODIFY `property_key` VARCHAR(256);
+ALTER TABLE `gobblin_job_properties` MODIFY `property_key` VARCHAR(256);

--- a/gobblin-metastore/src/test/java/org/apache/gobblin/metastore/DatabaseJobHistoryStoreV103Test.java
+++ b/gobblin-metastore/src/test/java/org/apache/gobblin/metastore/DatabaseJobHistoryStoreV103Test.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.gobblin.metastore;
 
 import org.testng.annotations.Test;

--- a/gobblin-metastore/src/test/java/org/apache/gobblin/metastore/DatabaseJobHistoryStoreV103Test.java
+++ b/gobblin-metastore/src/test/java/org/apache/gobblin/metastore/DatabaseJobHistoryStoreV103Test.java
@@ -1,0 +1,15 @@
+package org.apache.gobblin.metastore;
+
+import org.testng.annotations.Test;
+
+/**
+ * Unit tests for {@link DatabaseJobHistoryStore} V1.0.1.
+ *
+ */
+@Test(groups = {"gobblin.metastore"})
+public class DatabaseJobHistoryStoreV103Test extends DatabaseJobHistoryStoreTest {
+    @Override
+    protected String getVersion() {
+        return "1.0.3";
+    }
+}


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-666


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
- Increase the key size in mysql definition to the maximum for a varchar (767/4 = 191) to avoid MysqlDataTruncation exception

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
`DatabaseJobHistoryStoreV103Test`

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

