### PR TITLE
[GOBBLIN-671] Close the underlying writer when a HiveWritableHdfsData…

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/writer/HiveWritableHdfsDataWriter.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/writer/HiveWritableHdfsDataWriter.java
@@ -44,6 +44,8 @@ public class HiveWritableHdfsDataWriter extends FsDataWriter<Writable> {
 
   protected final RecordWriter writer;
   protected final AtomicLong count = new AtomicLong(0);
+  // the close method may be invoked multiple times, but the underlying writer only supports close being called once
+  private boolean closed = false;
 
   public HiveWritableHdfsDataWriter(HiveWritableHdfsDataWriterBuilder<?> builder, State properties) throws IOException {
     super(builder, properties);
@@ -92,8 +94,24 @@ public class HiveWritableHdfsDataWriter extends FsDataWriter<Writable> {
   }
 
   @Override
+  public void close() throws IOException {
+    // close the underlying writer if not already closed. The close can only be called once for the underlying writer,
+    // so remember the state
+    if (!this.closed) {
+      this.writer.close(false);
+      this.closed = true;
+    }
+
+    super.close();
+  }
+
+  @Override
   public void commit() throws IOException {
-    this.writer.close(false);
+    if (!this.closed) {
+      this.writer.close(false);
+      this.closed = true;
+    }
+
     super.commit();
   }
 }

--- a/gobblin-core/src/test/java/org/apache/gobblin/writer/HiveWritableHdfsDataWriterTest.java
+++ b/gobblin-core/src/test/java/org/apache/gobblin/writer/HiveWritableHdfsDataWriterTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.writer;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.Properties;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.Files;
+
+import org.apache.gobblin.configuration.SourceState;
+import org.apache.gobblin.configuration.State;
+import org.apache.gobblin.configuration.WorkUnitState;
+
+public class HiveWritableHdfsDataWriterTest {
+  private FileSystem fs;
+  private File tmpDir;
+
+  @BeforeClass
+  public void setUp() throws IOException {
+    tmpDir = Files.createTempDir();
+    this.fs = FileSystem.get(new Configuration());
+  }
+
+  @AfterClass
+  public void cleanUp() throws IOException {
+    if (this.fs.exists(new Path(this.tmpDir.getAbsolutePath()))) {
+      if (!this.fs.delete(new Path(this.tmpDir.getAbsolutePath()), true)) {
+        throw new IOException("Failed to clean up path " + this.tmpDir);
+      }
+    }
+  }
+
+  /**
+   * Test that multiple close calls do not raise an error
+   */
+  @Test
+  public void testMultipleClose() throws IOException {
+    Properties properties = new Properties();
+    properties.load(new FileReader("gobblin-core/src/test/resources/writer/hive_writer.properties"));
+
+    properties.setProperty("writer.staging.dir", new Path(tmpDir.getAbsolutePath(), "output-staging").toString());
+    properties.setProperty("writer.output.dir", new Path(tmpDir.getAbsolutePath(), "output").toString());
+    properties.setProperty("writer.file.path", ".");
+
+    SourceState sourceState = new SourceState(new State(properties), ImmutableList.<WorkUnitState> of());
+
+    DataWriter writer = new HiveWritableHdfsDataWriterBuilder<>().withBranches(1)
+            .withWriterId("0").writeTo(Destination.of(Destination.DestinationType.HDFS, sourceState))
+            .writeInFormat(WriterOutputFormat.ORC).build();
+
+    writer.close();
+    // check for file existence
+    Assert.assertTrue(this.fs.exists(new Path(new Path(tmpDir.getAbsolutePath(), "output-staging"), "writer-output.orc")),
+        "staging file not found");
+
+    // closed again is okay
+    writer.close();
+    // commit after close is okay
+    writer.commit();
+    Assert.assertTrue(this.fs.exists(new Path(new Path(tmpDir.getAbsolutePath(), "output"), "writer-output.orc")),
+        "output file not found");
+  }
+}

--- a/gobblin-core/src/test/resources/writer/hive_writer.properties
+++ b/gobblin-core/src/test/resources/writer/hive_writer.properties
@@ -1,0 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+serde.serializer.type=ORC
+serde.deserializer.type=AVRO
+writer.file.name=writer-output.orc
+


### PR DESCRIPTION
…Writer is closed

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-671


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
Close the underlying writer when the HiveWritableHdfsDataWriter writer is closed(). This releases resources held by the underlying writer. Some writers like the OrcRecordWriter buffers a large amount of data and release the resources reduces the chance of OOMs.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
HiveWritableHdfsDataWriterTest

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

