### PR TITLE
GOBBLIN-674: Skip initialization of GitMonitoringService when gobblin…

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/MultiHopFlowCompiler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/MultiHopFlowCompiler.java
@@ -87,7 +87,8 @@ public class MultiHopFlowCompiler extends BaseFlowToJobSpecCompiler {
 
   public MultiHopFlowCompiler(Config config, Optional<Logger> log, boolean instrumentationEnabled) {
     super(config, log, instrumentationEnabled);
-    Optional<FSFlowCatalog> flowCatalog;
+    this.flowGraph = new BaseFlowGraph();
+    Optional<FSFlowCatalog> flowCatalog = Optional.absent();
     if (config.hasPath(ServiceConfigKeys.TEMPLATE_CATALOGS_FULLY_QUALIFIED_PATH_KEY)
         && StringUtils.isNotBlank(config.getString(ServiceConfigKeys.TEMPLATE_CATALOGS_FULLY_QUALIFIED_PATH_KEY))) {
       try {
@@ -96,9 +97,8 @@ public class MultiHopFlowCompiler extends BaseFlowToJobSpecCompiler {
         throw new RuntimeException("Cannot instantiate " + getClass().getName(), e);
       }
     } else {
-      flowCatalog = Optional.absent();
+      return;
     }
-    this.flowGraph = new BaseFlowGraph();
     Config gitFlowGraphConfig = this.config;
     if (this.config.hasPath(ConfigurationKeys.ENCRYPT_KEY_LOC)) {
       //Add encrypt.key.loc config to the config passed to GitFlowGraphMonitor
@@ -131,7 +131,9 @@ public class MultiHopFlowCompiler extends BaseFlowToJobSpecCompiler {
   @Override
   public void setActive(boolean active) {
     super.setActive(active);
-    this.gitFlowGraphMonitor.setActive(active);
+    if (this.gitFlowGraphMonitor != null) {
+      this.gitFlowGraphMonitor.setActive(active);
+    }
   }
 
   @Override


### PR DESCRIPTION
… template dirs is empty.

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-674


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
We skip initialization of GitMonitoringService inside MultiHopFlowCompiler when template directory config is empty.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Local test.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

