### PR TITLE
[GOBBLIN-676] Add record metadata support to the RecordEnvelope

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/converter/Converter.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/converter/Converter.java
@@ -111,6 +111,38 @@ public abstract class Converter<SI, SO, DI, DO> implements Closeable, FinalState
       throws DataConversionException;
 
   /**
+   * Converts a {@link RecordEnvelope}. This method can be overridden by implementations that need to manipulate the
+   * {@link RecordEnvelope}, such as to set watermarks or metadata.
+   * @param outputSchema output schema converted using the {@link Converter#convertSchema} method
+   * @param inputRecordEnvelope input record envelope with data record to be converted
+   * @param workUnitState a {@link WorkUnitState} object carrying configuration properties
+   * @return a {@link Flowable} emitting the converted {@link RecordEnvelope}s
+   * @throws DataConversionException
+   */
+  public Flowable<RecordEnvelope<DO>> convertRecordEnvelope(SO outputSchema, RecordEnvelope<DI> inputRecordEnvelope,
+      WorkUnitState workUnitState) throws DataConversionException {
+    Iterator<DO> convertedIterable = convertRecord(outputSchema,
+        inputRecordEnvelope.getRecord(), workUnitState).iterator();
+
+    if (!convertedIterable.hasNext()) {
+      inputRecordEnvelope.ack();
+      // if the iterable is empty, ack the record, return an empty flowable
+      return Flowable.empty();
+    }
+
+    DO firstRecord = convertedIterable.next();
+    if (!convertedIterable.hasNext()) {
+      // if the iterable has only one element, use RecordEnvelope.withRecord, which is more efficient
+      return Flowable.just(inputRecordEnvelope.withRecord(firstRecord));
+    } else {
+      // if the iterable has multiple records, use a ForkRecordBuilder
+      RecordEnvelope<DI>.ForkRecordBuilder<DO> forkRecordBuilder = inputRecordEnvelope.forkRecordBuilder();
+      return Flowable.just(firstRecord).concatWith(Flowable.fromIterable(() -> convertedIterable))
+          .map(forkRecordBuilder::childRecord).doOnComplete(forkRecordBuilder::close);
+    }
+  }
+
+  /**
    * Get final state for this object. By default this returns an empty {@link org.apache.gobblin.configuration.State}, but
    * concrete subclasses can add information that will be added to the task state.
    * @return Empty {@link org.apache.gobblin.configuration.State}.
@@ -149,26 +181,7 @@ public abstract class Converter<SI, SO, DI, DO> implements Closeable, FinalState
                 return Flowable.just(((ControlMessage<DO>) out));
               } else if (in instanceof RecordEnvelope) {
                 RecordEnvelope<DI> recordEnvelope = (RecordEnvelope<DI>) in;
-                Iterator<DO> convertedIterable = convertRecord(this.outputGlobalMetadata.getSchema(),
-                    recordEnvelope.getRecord(), workUnitState).iterator();
-
-                if (!convertedIterable.hasNext()) {
-                  // if the iterable is empty, ack the record, return an empty flowable
-                  in.ack();
-                  return Flowable.empty();
-                }
-
-                DO firstRecord = convertedIterable.next();
-                if (!convertedIterable.hasNext()) {
-                  // if the iterable has only one element, use RecordEnvelope.withRecord, which is more efficient
-                  return Flowable.just(recordEnvelope.withRecord(firstRecord));
-                } else {
-                  // if the iterable has multiple records, use a ForkRecordBuilder
-                  RecordEnvelope<DI>.ForkRecordBuilder<DO> forkRecordBuilder = recordEnvelope.forkRecordBuilder();
-                  return Flowable.just(firstRecord).concatWith(Flowable.fromIterable(() -> convertedIterable))
-                      .map(forkRecordBuilder::childRecord).doOnComplete(forkRecordBuilder::close);
-                }
-
+                return convertRecordEnvelope(this.outputGlobalMetadata.getSchema(), recordEnvelope, workUnitState);
               } else {
                 throw new UnsupportedOperationException();
               }

--- a/gobblin-api/src/main/java/org/apache/gobblin/converter/Converter.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/converter/Converter.java
@@ -119,7 +119,7 @@ public abstract class Converter<SI, SO, DI, DO> implements Closeable, FinalState
    * @return a {@link Flowable} emitting the converted {@link RecordEnvelope}s
    * @throws DataConversionException
    */
-  public Flowable<RecordEnvelope<DO>> convertRecordEnvelope(SO outputSchema, RecordEnvelope<DI> inputRecordEnvelope,
+  protected Flowable<RecordEnvelope<DO>> convertRecordEnvelope(SO outputSchema, RecordEnvelope<DI> inputRecordEnvelope,
       WorkUnitState workUnitState) throws DataConversionException {
     Iterator<DO> convertedIterable = convertRecord(outputSchema,
         inputRecordEnvelope.getRecord(), workUnitState).iterator();

--- a/gobblin-api/src/test/java/org/apache/gobblin/stream/RecordEnvelopeTest.java
+++ b/gobblin-api/src/test/java/org/apache/gobblin/stream/RecordEnvelopeTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.gobblin.stream;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
 
 import org.testng.Assert;
@@ -120,6 +122,129 @@ public class RecordEnvelopeTest {
     Assert.assertEquals(ackable.acked, 0);
     copy2.ack();
     Assert.assertEquals(ackable.acked, 1);
+  }
+
+  @Test
+  public void testRecordMetadata() {
+    RecordEnvelope<String> record = new RecordEnvelope<>("test", new MyWatermark(110));
+
+    record.setRecordMetadata("meta1", "value1");
+    Assert.assertEquals(record.getRecordMetadata("meta1"), "value1");
+  }
+
+  @Test
+  public void testRecordMetadataWithDerivedRecords() {
+    RecordEnvelope<String> record = new RecordEnvelope<>("test", new MyWatermark(110));
+
+    record.setRecordMetadata("meta1", "value1");
+    List list = new ArrayList();
+    list.add("item1");
+    record.setRecordMetadata("list", list);
+
+    RecordEnvelope<String>.ForkRecordBuilder<String> forkRecordBuilder = record.forkRecordBuilder();
+
+    RecordEnvelope<String> derived1 = forkRecordBuilder.childRecord("testDerived1");
+    RecordEnvelope<String> derived2 = forkRecordBuilder.childRecord("testDerived2");
+    RecordEnvelope<String> derived3 = derived2.withRecord("testDerived3");
+
+
+    forkRecordBuilder.close();
+
+    record.setRecordMetadata("meta2", "value2");
+    derived1.setRecordMetadata("meta3", "value3");
+    derived2.setRecordMetadata("meta4", "value4");
+    derived3.setRecordMetadata("meta5", "value5");
+
+    // clones should inherit the metadata at the time of the copy
+    Assert.assertEquals(record.getRecordMetadata("meta1"), "value1");
+    Assert.assertEquals(derived1.getRecordMetadata("meta1"), "value1");
+    Assert.assertEquals(derived2.getRecordMetadata("meta1"), "value1");
+    Assert.assertEquals(derived3.getRecordMetadata("meta1"), "value1");
+
+    // new entries should not affect any copies
+    Assert.assertEquals(record.getRecordMetadata("meta2"), "value2");
+    Assert.assertNull(derived1.getRecordMetadata("meta2"));
+    Assert.assertNull(derived2.getRecordMetadata("meta2"));
+    Assert.assertNull(derived3.getRecordMetadata("meta2"));
+
+    Assert.assertEquals(derived1.getRecordMetadata("meta3"), "value3");
+    Assert.assertNull(record.getRecordMetadata("meta3"));
+    Assert.assertNull(derived2.getRecordMetadata("meta3"));
+    Assert.assertNull(derived3.getRecordMetadata("meta3"));
+
+    Assert.assertEquals(derived2.getRecordMetadata("meta4"), "value4");
+    Assert.assertNull(derived1.getRecordMetadata("meta4"));
+    Assert.assertNull(derived3.getRecordMetadata("meta4"));
+    Assert.assertNull(record.getRecordMetadata("meta4"));
+
+    Assert.assertEquals(derived3.getRecordMetadata("meta5"), "value5");
+    Assert.assertNull(derived1.getRecordMetadata("meta5"));
+    Assert.assertNull(derived2.getRecordMetadata("meta5"));
+    Assert.assertNull(record.getRecordMetadata("meta5"));
+
+    // no deep copy for values
+    ((List)record.getRecordMetadata("list")).add("item2");
+    Assert.assertEquals(record.getRecordMetadata("list"), list);
+    Assert.assertEquals(derived1.getRecordMetadata("list"), list);
+    Assert.assertEquals(derived2.getRecordMetadata("list"), list);
+    Assert.assertEquals(derived3.getRecordMetadata("list"), list);
+  }
+
+  @Test
+  public void testRecordMetadataWithClones() {
+    RecordEnvelope<String> record = new RecordEnvelope<>("test", new MyWatermark(110));
+
+    record.setRecordMetadata("meta1", "value1");
+    List list = new ArrayList();
+    list.add("item1");
+    record.setRecordMetadata("list", list);
+
+    StreamEntity.ForkCloner cloner = record.forkCloner();
+
+    RecordEnvelope<String> copy1 = (RecordEnvelope<String>) cloner.getClone();
+    RecordEnvelope<String> copy2 = (RecordEnvelope<String>) cloner.getClone();
+    cloner.close();
+    RecordEnvelope<String> copy3 = (RecordEnvelope<String>)record.buildClone();
+
+
+    record.setRecordMetadata("meta2", "value2");
+    copy1.setRecordMetadata("meta3", "value3");
+    copy2.setRecordMetadata("meta4", "value4");
+    copy3.setRecordMetadata("meta5", "value5");
+
+    // clones should inherit the metadata at the time of the copy
+    Assert.assertEquals(record.getRecordMetadata("meta1"), "value1");
+    Assert.assertEquals(copy1.getRecordMetadata("meta1"), "value1");
+    Assert.assertEquals(copy2.getRecordMetadata("meta1"), "value1");
+    Assert.assertEquals(copy3.getRecordMetadata("meta1"), "value1");
+
+    // new entries should not affect any copies
+    Assert.assertEquals(record.getRecordMetadata("meta2"), "value2");
+    Assert.assertNull(copy1.getRecordMetadata("meta2"));
+    Assert.assertNull(copy2.getRecordMetadata("meta2"));
+    Assert.assertNull(copy3.getRecordMetadata("meta2"));
+
+    Assert.assertEquals(copy1.getRecordMetadata("meta3"), "value3");
+    Assert.assertNull(record.getRecordMetadata("meta3"));
+    Assert.assertNull(copy2.getRecordMetadata("meta3"));
+    Assert.assertNull(copy3.getRecordMetadata("meta3"));
+
+    Assert.assertEquals(copy2.getRecordMetadata("meta4"), "value4");
+    Assert.assertNull(copy1.getRecordMetadata("meta4"));
+    Assert.assertNull(copy3.getRecordMetadata("meta4"));
+    Assert.assertNull(record.getRecordMetadata("meta4"));
+
+    Assert.assertEquals(copy3.getRecordMetadata("meta5"), "value5");
+    Assert.assertNull(copy1.getRecordMetadata("meta5"));
+    Assert.assertNull(copy2.getRecordMetadata("meta5"));
+    Assert.assertNull(record.getRecordMetadata("meta5"));
+
+    // no deep copy for values
+    ((List)record.getRecordMetadata("list")).add("item2");
+    Assert.assertEquals(record.getRecordMetadata("list"), list);
+    Assert.assertEquals(copy1.getRecordMetadata("list"), list);
+    Assert.assertEquals(copy2.getRecordMetadata("list"), list);
+    Assert.assertEquals(copy3.getRecordMetadata("list"), list);
   }
 
   @AllArgsConstructor


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-676


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
The RecordEnvelope currently only has a watermark. Add a Map to it to store record-level metadata.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

