### PR TITLE
GOBBLIN-678: Make flow.executionId available in the GaaS Flow config …

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/pathfinder/AbstractPathFinder.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/pathfinder/AbstractPathFinder.java
@@ -84,8 +84,8 @@ public abstract class AbstractPathFinder implements PathFinder {
       throws ReflectiveOperationException {
     this.flowGraph = flowGraph;
     this.flowSpec = flowSpec;
-    this.flowConfig = flowSpec.getConfig();
     this.flowExecutionId = FlowUtils.getOrCreateFlowExecutionId(flowSpec);
+    this.flowConfig = flowSpec.getConfig().withValue(ConfigurationKeys.FLOW_EXECUTION_ID_KEY, ConfigValueFactory.fromAnyRef(flowExecutionId));
 
     //Get src/dest DataNodes from the flow config
     String srcNodeId = ConfigUtils.getString(flowConfig, ServiceConfigKeys.FLOW_SOURCE_IDENTIFIER_KEY, "");

--- a/gobblin-service/src/test/resources/template_catalog/multihop/jobTemplates/distcp.template
+++ b/gobblin-service/src/test/resources/template_catalog/multihop/jobTemplates/distcp.template
@@ -25,7 +25,7 @@ state.store.fs.uri=${fs.uri}
 target.filebased.fs.uri=${destination.data.node.fs.uri}
 writer.fs.uri=${target.filebased.fs.uri}
 
-work.dir=/tmp/${user.to.proxy}
+work.dir=/tmp/${user.to.proxy}/${flow.executionId}
 
 # ====================================================================
 # Distcp configurations


### PR DESCRIPTION
…for use in job templates.

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-678


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Job templates would like to reference flow.executionId in the job properties (e.g. to create tmp directories that use execution id as part of the directory path). Currently, for scheduled jobs, the flow execution id is not made available in the flow config.  



### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
MultiHopFlowCompilerTest - changed job template to use flow.executionId and ensure the template is resolved during compilation.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

