### PR TITLE
[GOBBLIN-680] Enhance error handling on task creation

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/GobblinMultiTaskAttempt.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/GobblinMultiTaskAttempt.java
@@ -18,6 +18,10 @@
 package org.apache.gobblin.runtime;
 
 import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+import java.lang.management.MemoryUsage;
+import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -359,7 +363,12 @@ public class GobblinMultiTaskAttempt {
         this.taskStateTracker.registerNewTask(task);
         task.setTaskFuture(this.taskExecutor.submit(task));
         tasks.add(task);
-      } catch (Exception e) {
+      } catch (Throwable e) {
+        if (e instanceof OutOfMemoryError) {
+          log.error("Encountering memory error in task creation/execution stage, please investigate memory usage:", e);
+          printMemoryUsage();
+        }
+
         if (task == null) {
           // task could not be created, so directly count down
           countDownLatch.countDown();
@@ -382,6 +391,24 @@ public class GobblinMultiTaskAttempt {
 
     return tasks;
   }
+
+  private void printMemoryUsage() {
+    MemoryMXBean memoryBean = ManagementFactory.getMemoryMXBean();
+    MemoryUsage heapMemory = memoryBean.getHeapMemoryUsage();
+    MemoryUsage nonHeapMemory = memoryBean.getNonHeapMemoryUsage();
+    String format = "%-15s%-15s%-15s%-15s";
+
+    this.log.info("Heap Memory");
+    this.log.info(String.format(format, "init", "used", "Committed", "max"));
+    this.log.info(String.format(format, heapMemory.getInit(), heapMemory.getUsed(),
+        heapMemory.getCommitted(), heapMemory.getMax()));
+
+    this.log.info("Non-heap Memory");
+    this.log.info(String.format(format, "init", "used", "Committed", "max"));
+    this.log.info(String.format(format, nonHeapMemory.getInit(), nonHeapMemory.getUsed(),
+        nonHeapMemory.getCommitted(), nonHeapMemory.getMax()));
+  }
+
 
   private Task createTaskRunnable(WorkUnitState workUnitState, CountDownLatch countDownLatch) {
     Optional<TaskFactory> taskFactoryOpt = TaskUtils.getTaskFactory(workUnitState);

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/task/TaskUtils.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/task/TaskUtils.java
@@ -18,6 +18,7 @@
 package org.apache.gobblin.runtime.task;
 
 import com.google.common.base.Optional;
+import java.util.Properties;
 import org.apache.gobblin.configuration.State;
 
 

--- a/gobblin-test-harness/src/test/java/org/apache/gobblin/TaskErrorIntegrationTest.java
+++ b/gobblin-test-harness/src/test/java/org/apache/gobblin/TaskErrorIntegrationTest.java
@@ -53,8 +53,6 @@ import org.apache.gobblin.source.extractor.DataRecordException;
 import org.apache.gobblin.source.extractor.Extractor;
 import org.apache.gobblin.source.workunit.WorkUnit;
 
-import static org.apache.gobblin.runtime.task.TaskUtils.*;
-
 
 @Test (singleThreaded = true)
 public class TaskErrorIntegrationTest extends BMNGRunner {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

In the process of creating `Task` object, especially in customized task execution framework, we usually see huge memory consumption in `Task` itself and it can run into `OutOfMemoryError` from time to time in one of our internal pipelines. `OutOfMemoryError` will not be caught by original implementation unfortunately since it is not an `Exception`. We added this implementation and corresponding testing code to make sure that, whenever there are virtual machine error like `OutOfMemoryError` happening, the `countDownLatch` is still being correctly handled. 


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-680] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-680


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

