### PR TITLE
GOBBLIN-684: Ensure buffered messages are flushed before close() in K…

### DIFF
--- a/gobblin-modules/gobblin-kafka-08/src/main/java/org/apache/gobblin/metrics/kafka/KafkaKeyValueProducerPusher.java
+++ b/gobblin-modules/gobblin-kafka-08/src/main/java/org/apache/gobblin/metrics/kafka/KafkaKeyValueProducerPusher.java
@@ -104,9 +104,10 @@ public class KafkaKeyValueProducerPusher<K, V> implements Pusher<Pair<K, V>> {
     }
 
     //Once the low watermark of MAX_NUM_FUTURES_TO_BUFFER is hit, start flushing messages from the futures
-    // buffer. In order to avoid blocking on newest messages, we only invoke future.get() on messages other than
-    // the ones added in this call. Since the "older" messages have a greater probability of already being delivered,
-    // future.get() on those messages should return immediately.
+    // buffer. In order to avoid blocking on newest messages added to futures queue, we only invoke future.get() on
+    // messages other than the ones added in this call. Since the "older" messages are likely already delivered,
+    // future.get() on those messages should return immediately. Note this does not completely avoid calling
+    // future.get() on the newest messages e.g. when multiple threads enter the if{} block concurrently, and invoke flush().
     if (this.futures.size() >= MAX_NUM_FUTURES_TO_BUFFER) {
       flush(numMessagesToFlush);
     }

--- a/gobblin-modules/gobblin-kafka-08/src/main/java/org/apache/gobblin/metrics/kafka/KafkaKeyValueProducerPusher.java
+++ b/gobblin-modules/gobblin-kafka-08/src/main/java/org/apache/gobblin/metrics/kafka/KafkaKeyValueProducerPusher.java
@@ -123,7 +123,7 @@ public class KafkaKeyValueProducerPusher<K, V> implements Pusher<Pair<K, V>> {
    * @param numRecordsToFlush
    */
   private void flush(long numRecordsToFlush) {
-    log.info("Flushing records from producer buffer");
+    log.debug("Flushing records from producer buffer");
     Future future;
     long numRecordsFlushed = 0L;
     while (((future = futures.poll()) != null) && (numRecordsFlushed++ < numRecordsToFlush)) {
@@ -133,12 +133,13 @@ public class KafkaKeyValueProducerPusher<K, V> implements Pusher<Pair<K, V>> {
         log.error("Exception encountered when flushing record", e);
       }
     }
-    log.info("Flushed {} records from producer buffer", numRecordsFlushed);
+    log.debug("Flushed {} records from producer buffer", numRecordsFlushed);
   }
 
   @Override
   public void close()
       throws IOException {
+    log.info("Flushing records before close");
     flush(Long.MAX_VALUE);
     this.closer.close();
   }

--- a/gobblin-modules/gobblin-kafka-08/src/main/java/org/apache/gobblin/metrics/kafka/KafkaProducerPusher.java
+++ b/gobblin-modules/gobblin-kafka-08/src/main/java/org/apache/gobblin/metrics/kafka/KafkaProducerPusher.java
@@ -99,9 +99,10 @@ public class KafkaProducerPusher implements Pusher<byte[]> {
     }
 
     //Once the low watermark of MAX_NUM_FUTURES_TO_BUFFER is hit, start flushing messages from the futures
-    // buffer. In order to avoid blocking on newest messages, we only invoke future.get() on messages other than
-    // the ones added in this call. Since the "older" messages have a greater probability of already being delivered,
-    // future.get() on those messages should return immediately.
+    // buffer. In order to avoid blocking on newest messages added to futures queue, we only invoke future.get() on
+    // messages other than the ones added in this call. Since the "older" messages are likely already delivered,
+    // future.get() on those messages should return immediately. Note this does not completely avoid calling
+    // future.get() on the newest messages e.g. when multiple threads enter the if{} block concurrently, and invoke flush().
     if (this.futures.size() >= MAX_NUM_FUTURES_TO_BUFFER) {
       flush(numMessagesToFlush);
     }

--- a/gobblin-modules/gobblin-kafka-08/src/main/java/org/apache/gobblin/metrics/kafka/KafkaProducerPusher.java
+++ b/gobblin-modules/gobblin-kafka-08/src/main/java/org/apache/gobblin/metrics/kafka/KafkaProducerPusher.java
@@ -49,8 +49,15 @@ public class KafkaProducerPusher implements Pusher<byte[]> {
   private final String topic;
   private final KafkaProducer<String, byte[]> producer;
   private final Closer closer;
+  //Queue to keep track of the futures returned by the Kafka asynchronous send() call. The futures queue is used
+  // to mimic the functionality of flush() call (available in Kafka 09 and later). Currently, there are no
+  // capacity limits on the size of the futures queue. In general, if queue capacity is enforced, a safe lower bound for queue
+  // capacity is MAX_NUM_FUTURES_TO_BUFFER + (numThreads * maxNumMessagesPerInterval), where numThreads equals the number of
+  // threads sharing the producer instance and maxNumMessagesPerInterval is the estimated maximum number of messages
+  // emitted by a thread per reporting interval.
   private final Queue<Future<RecordMetadata>> futures = new LinkedBlockingDeque<>();
 
+  //Low watermark for the size of the futures queue, to trigger flushing of messages.
   private static final long MAX_NUM_FUTURES_TO_BUFFER = 1000L;
 
   public KafkaProducerPusher(String brokers, String topic, Optional<Config> kafkaConfig) {
@@ -82,6 +89,7 @@ public class KafkaProducerPusher implements Pusher<byte[]> {
    * @param messages List of byte array messages to push to Kakfa.
    */
   public void pushMessages(List<byte[]> messages) {
+    long numMessagesToFlush = this.futures.size();
     for (byte[] message: messages) {
       this.futures.offer(producer.send(new ProducerRecord<>(topic, message), (recordMetadata, e) -> {
         if (e != null) {
@@ -90,11 +98,12 @@ public class KafkaProducerPusher implements Pusher<byte[]> {
       }));
     }
 
-    //Accumulate futures returned from send() into a buffer; will be used to simulate flush by calling get() on
-    // each of the accumulated futures.
+    //Once the low watermark of MAX_NUM_FUTURES_TO_BUFFER is hit, start flushing messages from the futures
+    // buffer. In order to avoid blocking on newest messages, we only invoke future.get() on messages other than
+    // the ones added in this call. Since the "older" messages have a greater probability of already being delivered,
+    // future.get() on those messages should return immediately.
     if (this.futures.size() >= MAX_NUM_FUTURES_TO_BUFFER) {
-      flush(MAX_NUM_FUTURES_TO_BUFFER);
-      this.futures.clear();
+      flush(numMessagesToFlush);
     }
   }
 

--- a/gobblin-modules/gobblin-kafka-08/src/main/java/org/apache/gobblin/metrics/kafka/KafkaProducerPusher.java
+++ b/gobblin-modules/gobblin-kafka-08/src/main/java/org/apache/gobblin/metrics/kafka/KafkaProducerPusher.java
@@ -117,7 +117,7 @@ public class KafkaProducerPusher implements Pusher<byte[]> {
    * @param numRecordsToFlush
    */
   private void flush(long numRecordsToFlush) {
-    log.info("Flushing records from producer buffer");
+    log.debug("Flushing records from producer buffer");
     Future future;
     long numRecordsFlushed = 0L;
     while (((future = futures.poll()) != null) && (numRecordsFlushed++ < numRecordsToFlush)) {
@@ -127,12 +127,13 @@ public class KafkaProducerPusher implements Pusher<byte[]> {
         log.error("Exception encountered when flushing record", e);
       }
     }
-    log.info("Flushed {} records from producer buffer", numRecordsFlushed);
+    log.debug("Flushed {} records from producer buffer", numRecordsFlushed);
   }
 
   @Override
   public void close()
       throws IOException {
+    log.info("Flushing records before close");
     flush(Long.MAX_VALUE);
     this.closer.close();
   }

--- a/gobblin-modules/gobblin-kafka-09/src/main/java/org/apache/gobblin/metrics/kafka/KafkaKeyValueProducerPusher.java
+++ b/gobblin-modules/gobblin-kafka-09/src/main/java/org/apache/gobblin/metrics/kafka/KafkaKeyValueProducerPusher.java
@@ -32,9 +32,9 @@ import com.google.common.base.Optional;
 import com.google.common.io.Closer;
 import com.typesafe.config.Config;
 
-import org.apache.gobblin.util.ConfigUtils;
-
 import lombok.extern.slf4j.Slf4j;
+
+import org.apache.gobblin.util.ConfigUtils;
 
 
 /**
@@ -91,6 +91,10 @@ public class KafkaKeyValueProducerPusher<K, V> implements Pusher<Pair<K, V>> {
   @Override
   public void close()
       throws IOException {
+    //Call flush() before invoking close() to ensure any buffered messages are immediately sent. This is required
+    //since close() only guarantees delivery of in-flight messages.
+    log.info("Flushing records from producer buffer");
+    this.producer.flush();
     this.closer.close();
   }
 

--- a/gobblin-modules/gobblin-kafka-09/src/main/java/org/apache/gobblin/metrics/kafka/KafkaProducerPusher.java
+++ b/gobblin-modules/gobblin-kafka-09/src/main/java/org/apache/gobblin/metrics/kafka/KafkaProducerPusher.java
@@ -87,6 +87,10 @@ public class KafkaProducerPusher implements Pusher<byte[]> {
   @Override
   public void close()
       throws IOException {
+    //Call flush() before invoking close() to ensure any buffered messages are immediately sent. This is required
+    //since close() only guarantees delivery of in-flight messages.
+    log.info("Flushing records from producer buffer");
+    this.producer.flush();
     this.closer.close();
   }
 

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/AbstractJobLauncher.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/AbstractJobLauncher.java
@@ -18,8 +18,6 @@
 package org.apache.gobblin.runtime;
 
 import java.io.IOException;
-import java.net.URI;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -28,10 +26,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.gobblin.util.HadoopUtils;
-import org.apache.gobblin.util.WriterUtils;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -48,12 +42,11 @@ import com.google.common.eventbus.EventBus;
 import com.google.common.io.Closer;
 import com.typesafe.config.ConfigFactory;
 
-import org.apache.gobblin.source.Source;
-import org.apache.gobblin.source.WorkUnitStreamSource;
-import org.apache.gobblin.source.workunit.BasicWorkUnitStream;
-import org.apache.gobblin.source.workunit.WorkUnitStream;
-import org.apache.gobblin.broker.gobblin_scopes.GobblinScopeTypes;
+import javax.annotation.Nullable;
+import lombok.RequiredArgsConstructor;
+
 import org.apache.gobblin.broker.SharedResourcesBrokerFactory;
+import org.apache.gobblin.broker.gobblin_scopes.GobblinScopeTypes;
 import org.apache.gobblin.broker.iface.SharedResourcesBroker;
 import org.apache.gobblin.commit.CommitSequence;
 import org.apache.gobblin.commit.CommitSequenceStore;
@@ -79,9 +72,13 @@ import org.apache.gobblin.runtime.locks.JobLockEventListener;
 import org.apache.gobblin.runtime.locks.JobLockException;
 import org.apache.gobblin.runtime.locks.LegacyJobLockFactoryManager;
 import org.apache.gobblin.runtime.util.JobMetrics;
+import org.apache.gobblin.source.Source;
+import org.apache.gobblin.source.WorkUnitStreamSource;
 import org.apache.gobblin.source.extractor.JobCommitPolicy;
+import org.apache.gobblin.source.workunit.BasicWorkUnitStream;
 import org.apache.gobblin.source.workunit.MultiWorkUnit;
 import org.apache.gobblin.source.workunit.WorkUnit;
+import org.apache.gobblin.source.workunit.WorkUnitStream;
 import org.apache.gobblin.util.ClassAliasResolver;
 import org.apache.gobblin.util.ClusterNameTags;
 import org.apache.gobblin.util.ExecutorsUtils;
@@ -89,9 +86,6 @@ import org.apache.gobblin.util.Id;
 import org.apache.gobblin.util.JobLauncherUtils;
 import org.apache.gobblin.util.ParallelRunner;
 import org.apache.gobblin.writer.initializer.WriterInitializerFactory;
-
-import javax.annotation.Nullable;
-import lombok.RequiredArgsConstructor;
 
 
 /**
@@ -971,6 +965,7 @@ public abstract class AbstractJobLauncher implements JobLauncher {
     } catch (Exception e) {
       throw new JobException("Failed to execute all JobListeners", e);
     } finally {
+      LOG.info("Submitting {}", timerEventName);
       timer.stop(this.eventMetadataGenerator.getMetadata(this.jobContext,
           EventName.getEnumFromEventId(timerEventName)));
     }


### PR DESCRIPTION
…afkaProducerPusher.

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-684


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Currently, when KafkaProducerPusher is closed, it invokes KafkaProducer#close(). However,close() only guarantees delivery of in-flight messages, not the messages in the producer buffer waiting to be sent out. This results in data loss.

The fix ensures that we call flush() before close(). As a result, any buffered messages are immediately pushed out and we block until the messages are acked. 

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tested in real deployment.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

