### PR TITLE
[GOBBLIN-685] Add dump jstack for EmbeddedGobblin

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/AbstractJobLauncher.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/AbstractJobLauncher.java
@@ -184,7 +184,7 @@ public abstract class AbstractJobLauncher implements JobLauncher {
       this.eventBus.register(this.jobContext);
 
       this.cancellationExecutor = Executors.newSingleThreadExecutor(
-          ExecutorsUtils.newThreadFactory(Optional.of(LOG), Optional.of("CancellationExecutor")));
+          ExecutorsUtils.newDaemonThreadFactory(Optional.of(LOG), Optional.of("CancellationExecutor")));
 
       this.runtimeMetricContext =
           this.jobContext.getJobMetricsOptional().transform(new Function<JobMetrics, MetricContext>() {

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/embedded/EmbeddedGobblin.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/embedded/EmbeddedGobblin.java
@@ -18,12 +18,17 @@
 package org.apache.gobblin.runtime.embedded;
 
 import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -139,6 +144,7 @@ public class EmbeddedGobblin {
   private FullTimeout launchTimeout = new FullTimeout(10, TimeUnit.SECONDS);
   private FullTimeout jobTimeout = new FullTimeout(10, TimeUnit.DAYS);
   private FullTimeout shutdownTimeout = new FullTimeout(10, TimeUnit.SECONDS);
+  private boolean dumpJStackOnTimeout = false;
   private List<GobblinInstancePluginFactory> plugins = Lists.newArrayList();
   private Optional<Path> jobFile = Optional.absent();
 
@@ -353,6 +359,14 @@ public class EmbeddedGobblin {
   }
 
   /**
+   * Enable dumping jstack when error happens.
+   */
+  public EmbeddedGobblin setDumpJStackOnTimeout(boolean dumpJStackOnTimeout) {
+    this.dumpJStackOnTimeout = dumpJStackOnTimeout;
+    return this;
+  }
+
+  /**
    * Enable state store.
    */
   public EmbeddedGobblin useStateStore(String rootDir) {
@@ -458,6 +472,7 @@ public class EmbeddedGobblin {
 
     boolean started = listener.awaitStarted(this.launchTimeout.getTimeout(), this.launchTimeout.getTimeUnit());
     if (!started) {
+      dumpJStackOnTimeout("Launch");
       log.warn("Timeout waiting for job to start. Aborting.");
       driver.stopAsync();
       driver.awaitTerminated(this.shutdownTimeout.getTimeout(), this.shutdownTimeout.getTimeUnit());
@@ -484,12 +499,34 @@ public class EmbeddedGobblin {
           driver.awaitTerminated(EmbeddedGobblin.this.shutdownTimeout.getTimeout(), EmbeddedGobblin.this.shutdownTimeout
               .getTimeUnit());
         } catch (TimeoutException te) {
+          dumpJStackOnTimeout("stop gobblin instance driver");
           log.error("Failed to shutdown Gobblin instance driver.");
         }
       }
     });
 
     return listener.getJobDriver();
+  }
+
+  private void dumpJStackOnTimeout(String loc) {
+    if (this.dumpJStackOnTimeout) {
+      log.info("=== Dump jstack ({}) ===", loc);
+      ThreadMXBean bean = ManagementFactory.getThreadMXBean();
+      ThreadInfo[] infos = bean.dumpAllThreads(true, true);
+      Set<Thread> threadSet = Thread.getAllStackTraces().keySet();
+      Map<Long, Thread> threadMap = new HashMap<>();
+      for (Thread t : threadSet) {
+        threadMap.put(t.getId(), t);
+      }
+
+      for (ThreadInfo info : infos) {
+        Thread thread = threadMap.get(info.getThreadId());
+        log.info("({}) {}",
+            thread == null ? "Unknown" : thread.isDaemon() ? "Daemon" : "Non-Daemon", info.toString());
+      }
+    } else {
+      log.info("Dump jstack ({}) is disabled.", loc);
+    }
   }
 
   private Configurable getSysConfig() {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-685


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
   In ticket https://jira01.corp.linkedin.com:8443/browse/ETL-8477, we don't know why the thread would timeout. So two actions were taken:
   1) When timeout happens, we will dump the jstack
   2) Make cancellation executor a daemon thread, so that if won't be the only hanging thread when no other non-daemon threads are active.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
   EmbeddedGobblinTest

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

