### PR TITLE
GOBBLIN-688: Make FsJobStatusRetriever config more scoped.

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/FsJobStatusRetriever.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/FsJobStatusRetriever.java
@@ -47,11 +47,14 @@ import org.apache.gobblin.metrics.event.TimingEvent;
  */
 @Slf4j
 public class FsJobStatusRetriever extends JobStatusRetriever {
+  public static final String CONF_PREFIX = "fsJobStatusRetriever";
+
   @Getter
   private final FileContextBasedFsStateStore<State> stateStore;
 
   public FsJobStatusRetriever(Config config) {
-    this.stateStore = (FileContextBasedFsStateStore<State>) new FileContextBasedFsStateStoreFactory().createStateStore(config, State.class);
+    this.stateStore = (FileContextBasedFsStateStore<State>) new FileContextBasedFsStateStoreFactory().
+        createStateStore(config.getConfig(CONF_PREFIX), State.class);
   }
 
   @Override

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/FsJobStatusRetrieverTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/FsJobStatusRetrieverTest.java
@@ -55,7 +55,8 @@ public class FsJobStatusRetrieverTest {
   @BeforeClass
   public void setUp() throws Exception {
     cleanUpDir(stateStoreDir);
-    Config config = ConfigFactory.empty().withValue(ConfigurationKeys.STATE_STORE_ROOT_DIR_KEY, ConfigValueFactory.fromAnyRef(stateStoreDir));
+    Config config = ConfigFactory.empty().withValue(FsJobStatusRetriever.CONF_PREFIX + "." + ConfigurationKeys.STATE_STORE_ROOT_DIR_KEY,
+        ConfigValueFactory.fromAnyRef(stateStoreDir));
     this.jobStatusRetriever = new FsJobStatusRetriever(config);
     this.fsStateStore = this.jobStatusRetriever.getStateStore();
   }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-688


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
The proposed enhancement adds a configuration prefix to FsJobStatusRetriever config to make it more scoped.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
FsJobStatusRetrieverTest. 

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

