### PR TITLE
GOBBLIN-692: Add support to query last K flow executions in Gobblin-a…

### DIFF
--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-api/src/main/idl/org.apache.gobblin.service.flowstatuses.restspec.json
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-api/src/main/idl/org.apache.gobblin.service.flowstatuses.restspec.json
@@ -20,6 +20,10 @@
       "parameters" : [ {
         "name" : "flowId",
         "type" : "org.apache.gobblin.service.FlowId"
+      }, {
+        "name" : "count",
+        "type" : "int",
+        "optional" : true
       } ]
     } ],
     "entity" : {

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-api/src/main/snapshot/org.apache.gobblin.service.flowstatuses.snapshot.json
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-api/src/main/snapshot/org.apache.gobblin.service.flowstatuses.snapshot.json
@@ -220,6 +220,10 @@
         "parameters" : [ {
           "name" : "flowId",
           "type" : "org.apache.gobblin.service.FlowId"
+        }, {
+          "name" : "count",
+          "type" : "int",
+          "optional" : true
         } ]
       } ],
       "entity" : {

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-client/src/main/java/org/apache/gobblin/service/FlowStatusClient.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-client/src/main/java/org/apache/gobblin/service/FlowStatusClient.java
@@ -17,27 +17,27 @@
 
 package org.apache.gobblin.service;
 
-import com.google.common.base.Preconditions;
-import com.linkedin.restli.client.FindRequest;
-import com.linkedin.restli.common.CollectionResponse;
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.List;
 import java.util.Collections;
+import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
 import com.linkedin.common.callback.FutureCallback;
 import com.linkedin.common.util.None;
 import com.linkedin.r2.RemoteInvocationException;
 import com.linkedin.r2.transport.common.Client;
 import com.linkedin.r2.transport.common.bridge.client.TransportClientAdapter;
 import com.linkedin.r2.transport.http.client.HttpClientFactory;
+import com.linkedin.restli.client.FindRequest;
 import com.linkedin.restli.client.GetRequest;
 import com.linkedin.restli.client.Response;
 import com.linkedin.restli.client.RestClient;
+import com.linkedin.restli.common.CollectionResponse;
 import com.linkedin.restli.common.ComplexResourceKey;
 import com.linkedin.restli.common.EmptyRecord;
 
@@ -123,6 +123,33 @@ public class FlowStatusClient implements Closeable {
       return flowStatusList.get(0);
     }
   }
+
+  /**
+   * Get the latest flow status
+   * @param flowId identifier of flow status to get
+   * @return a list of {@link FlowStatus}es corresponding to the latest <code>count</code> executions.
+   * @throws RemoteInvocationException
+   */
+  public List<FlowStatus> getLatestFlowStatus(FlowId flowId, Integer count)
+      throws RemoteInvocationException {
+    LOG.debug("getFlowConfig with groupName " + flowId.getFlowGroup() + " flowName " +
+        flowId.getFlowName() + " count " + Integer.toString(count));
+
+    FindRequest<FlowStatus> findRequest = _flowstatusesRequestBuilders.findByLatestFlowStatus().flowIdParam(flowId).
+        addReqParam("count", count, Integer.class).build();
+
+    Response<CollectionResponse<FlowStatus>> response =
+        _restClient.get().sendRequest(findRequest).getResponse();
+
+    List<FlowStatus> flowStatusList = response.getEntity().getElements();
+
+    if (flowStatusList.isEmpty()) {
+      return null;
+    } else {
+      return flowStatusList;
+    }
+  }
+
 
   @Override
   public void close()

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/FlowStatusGenerator.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/FlowStatusGenerator.java
@@ -18,6 +18,8 @@
 package org.apache.gobblin.service.monitoring;
 
 import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import lombok.Builder;
 
@@ -33,20 +35,23 @@ public class FlowStatusGenerator {
   private final JobStatusRetriever jobStatusRetriever;
 
   /**
-   * Get the latest flow status.
+   * Get the flow statuses of last <code>count</code> (or fewer) executions
    * @param flowName
    * @param flowGroup
-   * @return the latest {@link FlowStatus}. null is returned if there is no flow execution found.
+   * @param count
+   * @return the latest <code>count</code>{@link FlowStatus}es. null is returned if there is no flow execution found.
    */
-  public FlowStatus getLatestFlowStatus(String flowName, String flowGroup) {
-    FlowStatus flowStatus = null;
-    long latestExecutionId = jobStatusRetriever.getLatestExecutionIdForFlow(flowName, flowGroup);
+  public List<FlowStatus> getLatestFlowStatus(String flowName, String flowGroup, int count) {
+    List<Long> flowExecutionIds = jobStatusRetriever.getLatestExecutionIdsForFlow(flowName, flowGroup, count);
 
-    if (latestExecutionId != -1l) {
-      flowStatus = getFlowStatus(flowName, flowGroup, latestExecutionId);
+    if (flowExecutionIds == null || flowExecutionIds.isEmpty()) {
+      return null;
     }
+    List<FlowStatus> flowStatuses =
+        flowExecutionIds.stream().map(flowExecutionId -> getFlowStatus(flowName, flowGroup, flowExecutionId))
+            .collect(Collectors.toList());
 
-    return flowStatus;
+    return flowStatuses;
   }
 
   /**

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/JobStatusRetriever.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/JobStatusRetriever.java
@@ -18,6 +18,7 @@
 package org.apache.gobblin.service.monitoring;
 
 import java.util.Iterator;
+import java.util.List;
 
 import com.google.common.collect.Iterators;
 
@@ -38,6 +39,11 @@ public abstract class JobStatusRetriever implements LatestFlowExecutionIdTracker
 
   public abstract Iterator<JobStatus> getJobStatusesForFlowExecution(String flowName, String flowGroup,
       long flowExecutionId, String jobName, String jobGroup);
+
+  public long getLatestExecutionIdForFlow(String flowName, String flowGroup) {
+    List<Long> lastKExecutionIds = getLatestExecutionIdsForFlow(flowName, flowGroup, 1);
+    return lastKExecutionIds != null && !lastKExecutionIds.isEmpty() ? lastKExecutionIds.get(0) : -1L;
+  }
 
   /**
    * Get the latest {@link JobStatus}es that belongs to the same latest flow execution. Currently, latest flow execution

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/LatestFlowExecutionIdTracker.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/LatestFlowExecutionIdTracker.java
@@ -17,6 +17,9 @@
 
 package org.apache.gobblin.service.monitoring;
 
+import java.util.List;
+
+
 /**
  * Tracks the latest flow execution Id.
  */
@@ -28,4 +31,12 @@ public interface LatestFlowExecutionIdTracker {
    * @return the latest flow execution id with the given flowName and flowGroup. -1 will be returned if no such execution found.
    */
   long getLatestExecutionIdForFlow(String flowName, String flowGroup);
+
+  /**
+   * @param flowName
+   * @param flowGroup
+   * @param count number of execution ids to return
+   * @return the latest <code>count</code> execution ids with the given flowName and flowGroup. null will be returned if no such execution found.
+   */
+  List<Long> getLatestExecutionIdsForFlow(String flowName, String flowGroup, int count);
 }


### PR DESCRIPTION
…s-a-Service (GaaS).

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-692


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Currently, REST APIs only support retrieving the latest execution of a flow. We enhance the APIs to query the last K executions where K is passed as a query parameter.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Enhance unit tests in FlowStatusTest and FsJobStatusRetrieverTest classes.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

