### PR TITLE
GOBBLIN-696: Provide an "explain" option to return a compiled flow wh…

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -135,6 +135,7 @@ public class ConfigurationKeys {
   public static final String FLOW_FAILURE_OPTION = "flow.failureOption";
   public static final String FLOW_APPLY_RETENTION = "flow.applyRetention";
   public static final String FLOW_APPLY_INPUT_RETENTION = "flow.applyInputRetention";
+  public static final String FLOW_EXPLAIN_KEY = "flow.explain";
 
   /**
    * Common topology configuration properties.

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-api/src/main/idl/org.apache.gobblin.service.flowconfigsV2.restspec.json
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-api/src/main/idl/org.apache.gobblin.service.flowconfigsV2.restspec.json
@@ -12,6 +12,9 @@
     },
     "supports" : [ "create", "delete", "get", "update" ],
     "methods" : [ {
+      "annotations" : {
+        "returnEntity" : { }
+      },
       "method" : "create",
       "doc" : "Create a flow configuration that the service will forward to execution instances for execution"
     }, {

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-api/src/main/pegasus/org/apache/gobblin/service/FlowConfig.pdsc
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-api/src/main/pegasus/org/apache/gobblin/service/FlowConfig.pdsc
@@ -24,6 +24,12 @@
       }
     },
     {
+      "name" : "explain",
+      "type" : "boolean",
+      "default" : false,
+      "doc" : "Return the compiled flow as a string. If enabled, the flow is not added."
+    },
+    {
       "name" : "properties",
       "type" : { "type" : "map", "values" : "string" },
       "doc" : "Properties for the flow. These properties are passed to the compiled Gobblin jobs."

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-api/src/main/snapshot/org.apache.gobblin.service.flowconfigsV2.snapshot.json
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-api/src/main/snapshot/org.apache.gobblin.service.flowconfigsV2.snapshot.json
@@ -79,28 +79,40 @@
     } ]
   }, {
     "type" : "record",
-    "name" : "EmptyRecord",
-    "namespace" : "com.linkedin.restli.common",
-    "doc" : "An literally empty record.  Intended as a marker to indicate the absence of content where a record type is required.  If used the underlying DataMap *must* be empty, EmptyRecordValidator is provided to help enforce this.  For example,  CreateRequest extends Request<EmptyRecord> to indicate it has no response body.   Also, a ComplexKeyResource implementation that has no ParamKey should have a signature like XyzResource implements ComplexKeyResource<XyzKey, EmptyRecord, Xyz>.",
-    "fields" : [ ],
-    "validate" : {
-      "com.linkedin.restli.common.EmptyRecordValidator" : { }
-    }
+    "name" : "FlowStatusId",
+    "namespace" : "org.apache.gobblin.service",
+    "doc" : "Identifier for a specific execution of a flow",
+    "fields" : [ {
+      "name" : "flowName",
+      "type" : "string",
+      "doc" : "Name of the flow"
+    }, {
+      "name" : "flowGroup",
+      "type" : "string",
+      "doc" : "Group of the flow. This defines the namespace for the flow."
+    }, {
+      "name" : "flowExecutionId",
+      "type" : "long",
+      "doc" : "Execution id for the flow"
+    } ]
   } ],
   "schema" : {
-    "name" : "flowconfigs",
+    "name" : "flowconfigsV2",
     "namespace" : "org.apache.gobblin.service",
-    "path" : "/flowconfigs",
+    "path" : "/flowconfigsV2",
     "schema" : "org.apache.gobblin.service.FlowConfig",
-    "doc" : "Resource for handling flow configuration requests\n\ngenerated from: org.apache.gobblin.service.FlowConfigsResource",
+    "doc" : "Resource for handling flow configuration requests\n\ngenerated from: org.apache.gobblin.service.FlowConfigsV2Resource",
     "collection" : {
       "identifier" : {
         "name" : "id",
         "type" : "org.apache.gobblin.service.FlowId",
-        "params" : "com.linkedin.restli.common.EmptyRecord"
+        "params" : "org.apache.gobblin.service.FlowStatusId"
       },
       "supports" : [ "create", "delete", "get", "update" ],
       "methods" : [ {
+        "annotations" : {
+          "returnEntity" : { }
+        },
         "method" : "create",
         "doc" : "Create a flow configuration that the service will forward to execution instances for execution"
       }, {
@@ -114,7 +126,7 @@
         "doc" : "Delete a configured flow. Running flows are not affected. The schedule will be removed for scheduled flows."
       } ],
       "entity" : {
-        "path" : "/flowconfigs/{id}"
+        "path" : "/flowconfigsV2/{id}"
       }
     }
   }

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-client/src/main/java/org/apache/gobblin/service/FlowConfigV2Client.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-client/src/main/java/org/apache/gobblin/service/FlowConfigV2Client.java
@@ -35,7 +35,7 @@ import com.linkedin.r2.RemoteInvocationException;
 import com.linkedin.r2.transport.common.Client;
 import com.linkedin.r2.transport.common.bridge.client.TransportClientAdapter;
 import com.linkedin.r2.transport.http.client.HttpClientFactory;
-import com.linkedin.restli.client.CreateIdRequest;
+import com.linkedin.restli.client.CreateIdEntityRequest;
 import com.linkedin.restli.client.DeleteRequest;
 import com.linkedin.restli.client.GetRequest;
 import com.linkedin.restli.client.Response;
@@ -44,7 +44,7 @@ import com.linkedin.restli.client.RestClient;
 import com.linkedin.restli.client.UpdateRequest;
 import com.linkedin.restli.common.ComplexResourceKey;
 import com.linkedin.restli.common.EmptyRecord;
-import com.linkedin.restli.common.IdResponse;
+import com.linkedin.restli.common.IdEntityResponse;
 
 
 /**
@@ -99,9 +99,9 @@ public class FlowConfigV2Client implements Closeable {
     LOG.debug("createFlowConfig with groupName " + flowConfig.getId().getFlowGroup() + " flowName " +
         flowConfig.getId().getFlowName());
 
-    CreateIdRequest<ComplexResourceKey<FlowId, FlowStatusId>, FlowConfig> request =
-        _flowconfigsV2RequestBuilders.create().input(flowConfig).build();
-    ResponseFuture<IdResponse<ComplexResourceKey<FlowId, FlowStatusId>>> flowConfigResponseFuture =
+    CreateIdEntityRequest<ComplexResourceKey<FlowId, FlowStatusId>, FlowConfig> request =
+        _flowconfigsV2RequestBuilders.createAndGet().input(flowConfig).build();
+    ResponseFuture<IdEntityResponse<ComplexResourceKey<FlowId, FlowStatusId>, FlowConfig>> flowConfigResponseFuture =
         _restClient.get().sendRequest(request);
 
     return createFlowStatusId(flowConfigResponseFuture.getResponse().getLocation().toString());

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-client/src/test/java/org/apache/gobblin/service/FlowConfigV2Test.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-client/src/test/java/org/apache/gobblin/service/FlowConfigV2Test.java
@@ -37,6 +37,7 @@ import com.google.inject.name.Names;
 import com.linkedin.data.template.StringMap;
 import com.linkedin.restli.server.resources.BaseResource;
 import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
 
 import org.apache.gobblin.config.ConfigBuilder;
 import org.apache.gobblin.configuration.ConfigurationKeys;
@@ -76,10 +77,12 @@ public class FlowConfigV2Test {
     Injector injector = Guice.createInjector(new Module() {
       @Override
       public void configure(Binder binder) {
-        binder.bind(FlowConfigsResourceHandler.class).annotatedWith(Names.named("flowConfigsV2ResourceHandler")).toInstance(new FlowConfigV2ResourceLocalHandler(flowCatalog));
+        binder.bind(FlowConfigsResourceHandler.class).annotatedWith(Names.named(FlowConfigsV2Resource.FLOW_CONFIG_GENERATOR_INJECT_NAME)).toInstance(new FlowConfigV2ResourceLocalHandler(flowCatalog));
         // indicate that we are in unit testing since the resource is being blocked until flow catalog changes have
         // been made
-        binder.bindConstant().annotatedWith(Names.named("readyToUse")).to(Boolean.TRUE);
+        binder.bindConstant().annotatedWith(Names.named(FlowConfigsV2Resource.INJECT_READY_TO_USE)).to(Boolean.TRUE);
+        binder.bind(RequesterService.class).annotatedWith(Names.named(FlowConfigsV2Resource.INJECT_REQUESTER_SERVICE)).toInstance(new NoopRequesterService(
+            ConfigFactory.empty()));
       }
     });
 

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowConfigV2ResourceLocalHandler.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowConfigV2ResourceLocalHandler.java
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 package org.apache.gobblin.service;
+import java.util.Map;
+
 import org.apache.commons.lang3.StringEscapeUtils;
 
 import com.linkedin.data.template.StringMap;
@@ -26,9 +28,12 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.runtime.api.FlowSpec;
+import org.apache.gobblin.runtime.spec_catalog.AddSpecResponse;
 import org.apache.gobblin.runtime.spec_catalog.FlowCatalog;
 @Slf4j
 public class FlowConfigV2ResourceLocalHandler extends FlowConfigResourceLocalHandler implements FlowConfigsResourceHandler {
+  public static final String GOBBLIN_SERVICE_JOB_SCHEDULER_LISTENER_CLASS = "org.apache.gobblin.service.modules.scheduler.GobblinServiceJobScheduler";
+
   public FlowConfigV2ResourceLocalHandler(FlowCatalog flowCatalog) {
     super(flowCatalog);
   }
@@ -37,9 +42,13 @@ public class FlowConfigV2ResourceLocalHandler extends FlowConfigResourceLocalHan
    * Add flowConfig locally and trigger all listeners iff @param triggerListener is set to true
    */
   public CreateKVResponse createFlowConfig(FlowConfig flowConfig, boolean triggerListener) throws FlowConfigLoggedException {
-    log.info("[GAAS-REST] Create called with flowGroup " + flowConfig.getId().getFlowGroup() + " flowName " + flowConfig.getId().getFlowName());
+    String createLog = "[GAAS-REST] Create called with flowGroup " + flowConfig.getId().getFlowGroup() + " flowName " + flowConfig.getId().getFlowName();
+    if (flowConfig.hasExplain()) {
+      createLog += " explain " + Boolean.toString(flowConfig.isExplain());
+    }
+    log.info(createLog);
     FlowSpec flowSpec = createFlowSpecForConfig(flowConfig);
-    String compiledFlow = this.flowCatalog.put(flowSpec, triggerListener);
+    Map<String, AddSpecResponse> responseMap = this.flowCatalog.put(flowSpec, triggerListener);
     FlowStatusId flowStatusId = new FlowStatusId()
         .setFlowName(flowSpec.getConfigAsProperties().getProperty(ConfigurationKeys.FLOW_NAME_KEY))
         .setFlowGroup(flowSpec.getConfigAsProperties().getProperty(ConfigurationKeys.FLOW_GROUP_KEY));
@@ -54,7 +63,9 @@ public class FlowConfigV2ResourceLocalHandler extends FlowConfigResourceLocalHan
       //This is an Explain request. So no resource is actually created.
       //Enrich original FlowConfig entity by adding the compiledFlow to the properties map.
       StringMap props = flowConfig.getProperties();
-      props.put("gobblin.flow.compiled", StringEscapeUtils.escapeJson(compiledFlow));
+      AddSpecResponse<String> addSpecResponse = responseMap.getOrDefault(GOBBLIN_SERVICE_JOB_SCHEDULER_LISTENER_CLASS, null);
+      props.put("gobblin.flow.compiled",
+          addSpecResponse != null ? StringEscapeUtils.escapeJson(addSpecResponse.getValue()) : "");
       flowConfig.setProperties(props);
       //Return response with 200 status code, since no resource is actually created.
       httpStatus = HttpStatus.S_200_OK;

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/MutableSpecCatalog.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/MutableSpecCatalog.java
@@ -19,6 +19,7 @@ package org.apache.gobblin.runtime.api;
 
 import java.net.URI;
 import java.util.Collection;
+import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
@@ -30,6 +31,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.apache.gobblin.instrumented.Instrumented;
 import org.apache.gobblin.metrics.ContextAwareTimer;
+import org.apache.gobblin.runtime.spec_catalog.AddSpecResponse;
 
 
 /**
@@ -37,12 +39,16 @@ import org.apache.gobblin.metrics.ContextAwareTimer;
  * programmatically. Note that specs in a spec catalog can change from the outside. This is covered
  * by the base SpecCatalog interface.
  */
-public interface MutableSpecCatalog<T> extends SpecCatalog {
+public interface MutableSpecCatalog extends SpecCatalog {
   /**
    * Registers a new {@link Spec}. If a {@link Spec} with the same {@link Spec#getUri()} exists,
    * it will be replaced.
+   * @param spec
+   * @return a map containing an entry for each {@link SpecCatalogListener} of the {@link SpecCatalog}, for which an action is triggered
+   * on adding a {@link Spec} to the {@link SpecCatalog}. The key for each entry is the name of the {@link SpecCatalogListener}
+   * and the value is the result of the the action taken by the listener returned as an instance of {@link AddSpecResponse}.
    * */
-  public T put(Spec spec);
+  public Map<String, AddSpecResponse> put(Spec spec);
 
   /**
    * Removes an existing {@link Spec} with the given URI.

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/MutableSpecCatalog.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/MutableSpecCatalog.java
@@ -22,14 +22,14 @@ import java.util.Collection;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.gobblin.instrumented.Instrumented;
-import org.apache.gobblin.metrics.ContextAwareTimer;
-
 import com.google.common.base.Optional;
 import com.typesafe.config.Config;
 
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+
+import org.apache.gobblin.instrumented.Instrumented;
+import org.apache.gobblin.metrics.ContextAwareTimer;
 
 
 /**
@@ -37,12 +37,12 @@ import lombok.extern.slf4j.Slf4j;
  * programmatically. Note that specs in a spec catalog can change from the outside. This is covered
  * by the base SpecCatalog interface.
  */
-public interface MutableSpecCatalog extends SpecCatalog {
+public interface MutableSpecCatalog<T> extends SpecCatalog {
   /**
    * Registers a new {@link Spec}. If a {@link Spec} with the same {@link Spec#getUri()} exists,
    * it will be replaced.
    * */
-  public void put(Spec spec);
+  public T put(Spec spec);
 
   /**
    * Removes an existing {@link Spec} with the given URI.

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/SpecCatalog.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/SpecCatalog.java
@@ -63,7 +63,7 @@ public interface SpecCatalog extends SpecCatalogListenersContainer, Instrumentab
   Spec getSpec(URI uri) throws SpecNotFoundException;
 
   @Slf4j
-  class StandardMetrics extends StandardMetricsBridge.StandardMetrics implements SpecCatalogListener {
+  class StandardMetrics extends StandardMetricsBridge.StandardMetrics implements SpecCatalogListener<Void> {
     public static final String NUM_ACTIVE_SPECS_NAME = "numActiveSpecs";
     public static final String TOTAL_ADD_CALLS = "totalAddCalls";
     public static final String TOTAL_DELETE_CALLS = "totalDeleteCalls";
@@ -119,9 +119,10 @@ public interface SpecCatalog extends SpecCatalogListenersContainer, Instrumentab
       Instrumented.updateTimer(Optional.of(this.timeForSpecCatalogGet), System.currentTimeMillis() - startTime, TimeUnit.MILLISECONDS);
     }
 
-    @Override public void onAddSpec(Spec addedSpec) {
+    @Override public Void onAddSpec(Spec addedSpec) {
       this.totalAddedSpecs.incrementAndGet();
       submitTrackingEvent(addedSpec, SPEC_ADDED_OPERATION_TYPE);
+      return null;
     }
 
     private void submitTrackingEvent(Spec spec, String operType) {

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/SpecCatalog.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/SpecCatalog.java
@@ -40,6 +40,7 @@ import org.apache.gobblin.metrics.ContextAwareGauge;
 import org.apache.gobblin.metrics.ContextAwareTimer;
 import org.apache.gobblin.metrics.GobblinTrackingEvent;
 import org.apache.gobblin.metrics.MetricContext;
+import org.apache.gobblin.runtime.spec_catalog.AddSpecResponse;
 import org.apache.gobblin.util.ConfigUtils;
 
 
@@ -63,7 +64,7 @@ public interface SpecCatalog extends SpecCatalogListenersContainer, Instrumentab
   Spec getSpec(URI uri) throws SpecNotFoundException;
 
   @Slf4j
-  class StandardMetrics extends StandardMetricsBridge.StandardMetrics implements SpecCatalogListener<Void> {
+  class StandardMetrics extends StandardMetricsBridge.StandardMetrics implements SpecCatalogListener {
     public static final String NUM_ACTIVE_SPECS_NAME = "numActiveSpecs";
     public static final String TOTAL_ADD_CALLS = "totalAddCalls";
     public static final String TOTAL_DELETE_CALLS = "totalDeleteCalls";
@@ -119,10 +120,10 @@ public interface SpecCatalog extends SpecCatalogListenersContainer, Instrumentab
       Instrumented.updateTimer(Optional.of(this.timeForSpecCatalogGet), System.currentTimeMillis() - startTime, TimeUnit.MILLISECONDS);
     }
 
-    @Override public Void onAddSpec(Spec addedSpec) {
+    @Override public AddSpecResponse onAddSpec(Spec addedSpec) {
       this.totalAddedSpecs.incrementAndGet();
       submitTrackingEvent(addedSpec, SPEC_ADDED_OPERATION_TYPE);
-      return null;
+      return new AddSpecResponse(null);
     }
 
     private void submitTrackingEvent(Spec spec, String operType) {

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/SpecCatalogListener.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/SpecCatalogListener.java
@@ -22,12 +22,13 @@ import java.util.Properties;
 
 import com.google.common.base.Objects;
 
+import org.apache.gobblin.runtime.spec_catalog.AddSpecResponse;
 import org.apache.gobblin.util.callbacks.Callback;
 
-public interface SpecCatalogListener<T> {
+public interface SpecCatalogListener {
   /** Invoked when a new {@link Spec} is added to the catalog and for all pre-existing specs on registration
    * of the listener.*/
-  T onAddSpec(Spec addedSpec);
+  AddSpecResponse onAddSpec(Spec addedSpec);
 
   /**
    * Invoked when a {@link Spec} gets removed from the catalog.
@@ -40,14 +41,14 @@ public interface SpecCatalogListener<T> {
   public void onUpdateSpec(Spec updatedSpec);
 
   /** A standard implementation of onAddSpec as a functional object */
-  public static class AddSpecCallback<T> extends Callback<SpecCatalogListener<T>, T> {
+  public static class AddSpecCallback extends Callback<SpecCatalogListener, AddSpecResponse> {
     private final Spec _addedSpec;
     public AddSpecCallback(Spec addedSpec) {
       super(Objects.toStringHelper("onAddSpec").add("addedSpec", addedSpec).toString());
       _addedSpec = addedSpec;
     }
 
-    @Override public T apply(SpecCatalogListener<T> listener) {
+    @Override public AddSpecResponse apply(SpecCatalogListener listener) {
       return listener.onAddSpec(_addedSpec);
     }
   }

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/SpecCatalogListener.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/SpecCatalogListener.java
@@ -24,10 +24,10 @@ import com.google.common.base.Objects;
 
 import org.apache.gobblin.util.callbacks.Callback;
 
-public interface SpecCatalogListener {
+public interface SpecCatalogListener<T> {
   /** Invoked when a new {@link Spec} is added to the catalog and for all pre-existing specs on registration
    * of the listener.*/
-  void onAddSpec(Spec addedSpec);
+  T onAddSpec(Spec addedSpec);
 
   /**
    * Invoked when a {@link Spec} gets removed from the catalog.
@@ -40,16 +40,15 @@ public interface SpecCatalogListener {
   public void onUpdateSpec(Spec updatedSpec);
 
   /** A standard implementation of onAddSpec as a functional object */
-  public static class AddSpecCallback extends Callback<SpecCatalogListener, Void> {
+  public static class AddSpecCallback<T> extends Callback<SpecCatalogListener<T>, T> {
     private final Spec _addedSpec;
     public AddSpecCallback(Spec addedSpec) {
       super(Objects.toStringHelper("onAddSpec").add("addedSpec", addedSpec).toString());
       _addedSpec = addedSpec;
     }
 
-    @Override public Void apply(SpecCatalogListener listener) {
-      listener.onAddSpec(_addedSpec);
-      return null;
+    @Override public T apply(SpecCatalogListener<T> listener) {
+      return listener.onAddSpec(_addedSpec);
     }
   }
 
@@ -89,4 +88,13 @@ public interface SpecCatalogListener {
       return null;
     }
   }
+
+  /**
+   * A default implementation to return the name of the {@link SpecCatalogListener}.
+   * @return
+   */
+  default String getName() {
+    return getClass().getName();
+  }
+
 }

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_catalog/AddSpecResponse.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_catalog/AddSpecResponse.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gobblin.runtime.spec_catalog;
+
+/**
+ * A generic class that allows listeners of a {@link org.apache.gobblin.runtime.api.SpecCatalog} to return a response when a
+ * {@link org.apache.gobblin.runtime.api.Spec} is added to the {@link org.apache.gobblin.runtime.api.SpecCatalog}.
+ * @param <T>
+ */
+public class AddSpecResponse<T> {
+  private T value;
+
+  public AddSpecResponse(T value) {
+    this.value = value;
+  }
+
+  public T getValue() {
+    return this.value;
+  }
+}

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_catalog/FlowCatalog.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_catalog/FlowCatalog.java
@@ -60,7 +60,7 @@ import org.apache.gobblin.util.callbacks.CallbacksDispatcher;
 
 
 @Alpha
-public class FlowCatalog extends AbstractIdleService implements SpecCatalog, MutableSpecCatalog<Map<String, AddSpecResponse>>, SpecSerDe {
+public class FlowCatalog extends AbstractIdleService implements SpecCatalog, MutableSpecCatalog, SpecSerDe {
   public static final String DEFAULT_FLOWSPEC_STORE_CLASS = FSSpecStore.class.getCanonicalName();
 
   protected final SpecCatalogListenersList listeners;
@@ -256,7 +256,7 @@ public class FlowCatalog extends AbstractIdleService implements SpecCatalog, Mut
       if (triggerListener) {
         AddSpecResponse<CallbacksDispatcher.CallbackResults<SpecCatalogListener, AddSpecResponse>> response = this.listeners.onAddSpec(spec);
         for (Map.Entry<SpecCatalogListener, CallbackResult<AddSpecResponse>> entry: response.getValue().getSuccesses().entrySet()) {
-          responseMap.put(entry.getKey().getName(), (AddSpecResponse) entry.getValue().getResult());
+          responseMap.put(entry.getKey().getName(), entry.getValue().getResult());
         }
       }
     } catch (IOException e) {

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_catalog/SpecCatalogListenersList.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_catalog/SpecCatalogListenersList.java
@@ -36,8 +36,8 @@ import org.apache.gobblin.runtime.api.Spec;
 import org.apache.gobblin.util.callbacks.CallbacksDispatcher;
 
 
-public class SpecCatalogListenersList implements SpecCatalogListener<CallbacksDispatcher.CallbackResults<SpecCatalogListener<Object>, Object>>, SpecCatalogListenersContainer, Closeable {
-  private final CallbacksDispatcher<SpecCatalogListener<Object>> _disp;
+public class SpecCatalogListenersList implements SpecCatalogListener, SpecCatalogListenersContainer, Closeable {
+  private final CallbacksDispatcher<SpecCatalogListener> _disp;
 
   public SpecCatalogListenersList() {
     this(Optional.<Logger>absent());
@@ -51,7 +51,7 @@ public class SpecCatalogListenersList implements SpecCatalogListener<CallbacksDi
     return _disp.getLog();
   }
 
-  public synchronized List<SpecCatalogListener<Object>> getListeners() {
+  public synchronized List<SpecCatalogListener> getListeners() {
     return _disp.getListeners();
   }
 
@@ -66,10 +66,10 @@ public class SpecCatalogListenersList implements SpecCatalogListener<CallbacksDi
   }
 
   @Override
-  public synchronized CallbacksDispatcher.CallbackResults<SpecCatalogListener<Object>, Object> onAddSpec(Spec addedSpec) {
+  public synchronized AddSpecResponse onAddSpec(Spec addedSpec) {
     Preconditions.checkNotNull(addedSpec);
     try {
-      return _disp.execCallbacks(new AddSpecCallback<>(addedSpec));
+      return new AddSpecResponse<>(_disp.execCallbacks(new AddSpecCallback(addedSpec)));
     } catch (InterruptedException e) {
       getLog().warn("onAddSpec interrupted.");
     }
@@ -103,7 +103,7 @@ public class SpecCatalogListenersList implements SpecCatalogListener<CallbacksDi
     _disp.close();
   }
 
-  public void callbackOneListener(Function<SpecCatalogListener<Object>, Object> callback,
+  public void callbackOneListener(Function<SpecCatalogListener, AddSpecResponse> callback,
       SpecCatalogListener listener) {
     try {
       _disp.execCallbacks(callback, listener);

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_catalog/TopologyCatalog.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_catalog/TopologyCatalog.java
@@ -26,12 +26,8 @@ import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 
-import javax.annotation.Nonnull;
-import lombok.Getter;
-
 import org.apache.commons.lang3.SerializationUtils;
 import org.apache.commons.lang3.reflect.ConstructorUtils;
-import org.apache.gobblin.runtime.api.FlowSpec;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,11 +37,15 @@ import com.google.common.util.concurrent.AbstractIdleService;
 import com.google.common.util.concurrent.Service;
 import com.typesafe.config.Config;
 
+import javax.annotation.Nonnull;
+import lombok.Getter;
+
 import org.apache.gobblin.annotation.Alpha;
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.instrumented.Instrumented;
 import org.apache.gobblin.metrics.MetricContext;
 import org.apache.gobblin.metrics.Tag;
+import org.apache.gobblin.runtime.api.FlowSpec;
 import org.apache.gobblin.runtime.api.GobblinInstanceEnvironment;
 import org.apache.gobblin.runtime.api.MutableSpecCatalog;
 import org.apache.gobblin.runtime.api.Spec;
@@ -60,7 +60,7 @@ import org.apache.gobblin.util.ClassAliasResolver;
 
 
 @Alpha
-public class TopologyCatalog extends AbstractIdleService implements SpecCatalog, MutableSpecCatalog, SpecSerDe {
+public class TopologyCatalog extends AbstractIdleService implements SpecCatalog, MutableSpecCatalog<Void>, SpecSerDe {
 
   public static final String DEFAULT_TOPOLOGYSPEC_STORE_CLASS = FSSpecStore.class.getCanonicalName();
 
@@ -154,7 +154,7 @@ public class TopologyCatalog extends AbstractIdleService implements SpecCatalog,
 
     if (state() == Service.State.RUNNING) {
       for (Spec spec : getSpecs()) {
-        SpecCatalogListener.AddSpecCallback addJobCallback = new SpecCatalogListener.AddSpecCallback(spec);
+        SpecCatalogListener.AddSpecCallback<Object> addJobCallback = new SpecCatalogListener.AddSpecCallback<>(spec);
         this.listeners.callbackOneListener(addJobCallback, specListener);
       }
     }
@@ -228,7 +228,7 @@ public class TopologyCatalog extends AbstractIdleService implements SpecCatalog,
   }
 
   @Override
-  public void put(Spec spec) {
+  public Void put(Spec spec) {
     try {
       Preconditions.checkState(state() == Service.State.RUNNING, String.format("%s is not running.", this.getClass().getName()));
       Preconditions.checkNotNull(spec);
@@ -240,6 +240,7 @@ public class TopologyCatalog extends AbstractIdleService implements SpecCatalog,
     } catch (IOException e) {
       throw new RuntimeException("Cannot add Spec to Spec store: " + spec, e);
     }
+    return null;
   }
 
   public void remove(URI uri) {

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_catalog/TopologyCatalog.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_catalog/TopologyCatalog.java
@@ -154,7 +154,7 @@ public class TopologyCatalog extends AbstractIdleService implements SpecCatalog,
 
     if (state() == Service.State.RUNNING) {
       for (Spec spec : getSpecs()) {
-        SpecCatalogListener.AddSpecCallback<Object> addJobCallback = new SpecCatalogListener.AddSpecCallback<>(spec);
+        SpecCatalogListener.AddSpecCallback addJobCallback = new SpecCatalogListener.AddSpecCallback(spec);
         this.listeners.callbackOneListener(addJobCallback, specListener);
       }
     }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GobblinServiceManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GobblinServiceManager.java
@@ -258,8 +258,14 @@ public class GobblinServiceManager implements ApplicationLauncher, StandardMetri
           binder.bindConstant()
               .annotatedWith(Names.named(FlowConfigsResource.INJECT_READY_TO_USE))
               .to(Boolean.TRUE);
+          binder.bindConstant()
+              .annotatedWith(Names.named(FlowConfigsV2Resource.INJECT_READY_TO_USE))
+              .to(Boolean.TRUE);
           binder.bind(RequesterService.class)
               .annotatedWith(Names.named(FlowConfigsResource.INJECT_REQUESTER_SERVICE))
+              .toInstance(new NoopRequesterService(config));
+          binder.bind(RequesterService.class)
+              .annotatedWith(Names.named(FlowConfigsV2Resource.INJECT_REQUESTER_SERVICE))
               .toInstance(new NoopRequesterService(config));
         }
       });

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/BaseFlowToJobSpecCompiler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/BaseFlowToJobSpecCompiler.java
@@ -54,6 +54,7 @@ import org.apache.gobblin.runtime.api.SpecNotFoundException;
 import org.apache.gobblin.runtime.api.TopologySpec;
 import org.apache.gobblin.runtime.job_catalog.FSJobCatalog;
 import org.apache.gobblin.runtime.job_spec.ResolvedJobSpec;
+import org.apache.gobblin.runtime.spec_catalog.AddSpecResponse;
 import org.apache.gobblin.service.ServiceConfigKeys;
 import org.apache.gobblin.service.ServiceMetricNames;
 import org.apache.gobblin.service.modules.flowgraph.Dag;
@@ -159,7 +160,7 @@ public abstract class BaseFlowToJobSpecCompiler implements SpecCompiler {
   }
 
   @Override
-  public synchronized Void onAddSpec(Spec addedSpec) {
+  public synchronized AddSpecResponse onAddSpec(Spec addedSpec) {
     TopologySpec spec = (TopologySpec) addedSpec;
     log.info ("Loading topology {}", spec.toLongString());
     for (Map.Entry entry: spec.getConfigAsProperties().entrySet()) {
@@ -167,7 +168,7 @@ public abstract class BaseFlowToJobSpecCompiler implements SpecCompiler {
     }
 
     topologySpecMap.put(addedSpec.getUri(), (TopologySpec) addedSpec);
-    return null;
+    return new AddSpecResponse(null);
   }
 
   public void onDeleteSpec(URI deletedSpecURI, String deletedSpecVersion) {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/BaseFlowToJobSpecCompiler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/BaseFlowToJobSpecCompiler.java
@@ -159,7 +159,7 @@ public abstract class BaseFlowToJobSpecCompiler implements SpecCompiler {
   }
 
   @Override
-  public synchronized void onAddSpec(Spec addedSpec) {
+  public synchronized Void onAddSpec(Spec addedSpec) {
     TopologySpec spec = (TopologySpec) addedSpec;
     log.info ("Loading topology {}", spec.toLongString());
     for (Map.Entry entry: spec.getConfigAsProperties().entrySet()) {
@@ -167,6 +167,7 @@ public abstract class BaseFlowToJobSpecCompiler implements SpecCompiler {
     }
 
     topologySpecMap.put(addedSpec.getUri(), (TopologySpec) addedSpec);
+    return null;
   }
 
   public void onDeleteSpec(URI deletedSpecURI, String deletedSpecVersion) {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/SpecCompiler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/SpecCompiler.java
@@ -33,7 +33,7 @@ import org.apache.gobblin.service.modules.spec.JobExecutionPlan;
  * Take in a logical {@link Spec} and compile corresponding materialized {@link Spec}s
  * and the mapping to {@link SpecExecutor} that they can be run on.
  */
-public interface SpecCompiler extends SpecCatalogListener<Void>, Instrumentable {
+public interface SpecCompiler extends SpecCatalogListener, Instrumentable {
   /***
    * Take in a logical {@link Spec} and compile corresponding materialized {@link Spec}s
    * and the mapping to {@link SpecExecutor} that they can be run on.

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/SpecCompiler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flow/SpecCompiler.java
@@ -33,7 +33,7 @@ import org.apache.gobblin.service.modules.spec.JobExecutionPlan;
  * Take in a logical {@link Spec} and compile corresponding materialized {@link Spec}s
  * and the mapping to {@link SpecExecutor} that they can be run on.
  */
-public interface SpecCompiler extends SpecCatalogListener, Instrumentable {
+public interface SpecCompiler extends SpecCatalogListener<Void>, Instrumentable {
   /***
    * Take in a logical {@link Spec} and compile corresponding materialized {@link Spec}s
    * and the mapping to {@link SpecExecutor} that they can be run on.

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/Dag.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/Dag.java
@@ -274,4 +274,20 @@ public class Dag<T> {
       return this.getValue().hashCode();
     }
   }
+
+  /**
+   * @return A string representation of the Dag as a JSON Array.
+   */
+  @Override
+  public String toString() {
+    StringBuffer sb = new StringBuffer();
+    sb.append("[");
+    for (DagNode node: this.getNodes()) {
+      sb.append(node.getValue().toString());
+      sb.append(",");
+    }
+    sb.delete(sb.length()-1, sb.length());
+    sb.append("]");
+    return sb.toString();
+  }
 }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/Orchestrator.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/Orchestrator.java
@@ -68,7 +68,7 @@ import org.apache.gobblin.util.ConfigUtils;
  * to {@link TopologyCatalog} and updates {@link SpecCompiler} state.
  */
 @Alpha
-public class Orchestrator implements SpecCatalogListener, Instrumentable {
+public class Orchestrator implements SpecCatalogListener<Void>, Instrumentable {
   protected final Logger _log;
   protected final SpecCompiler specCompiler;
   protected final Optional<TopologyCatalog> topologyCatalog;
@@ -153,11 +153,12 @@ public class Orchestrator implements SpecCatalogListener, Instrumentable {
 
   /** {@inheritDoc} */
   @Override
-  public void onAddSpec(Spec addedSpec) {
+  public Void onAddSpec(Spec addedSpec) {
     if (addedSpec instanceof TopologySpec) {
       _log.info("New Spec detected of type TopologySpec: " + addedSpec);
       this.specCompiler.onAddSpec(addedSpec);
     }
+    return null;
   }
 
   public void onDeleteSpec(URI deletedSpecURI, String deletedSpecVersion) {
@@ -193,6 +194,7 @@ public class Orchestrator implements SpecCatalogListener, Instrumentable {
     } catch (Exception e) {
       _log.error("Failed to update Spec: " + updatedSpec, e);
     }
+
   }
 
   public void orchestrate(Spec spec) throws Exception {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/Orchestrator.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/Orchestrator.java
@@ -53,6 +53,7 @@ import org.apache.gobblin.runtime.api.Spec;
 import org.apache.gobblin.runtime.api.SpecCatalogListener;
 import org.apache.gobblin.runtime.api.SpecProducer;
 import org.apache.gobblin.runtime.api.TopologySpec;
+import org.apache.gobblin.runtime.spec_catalog.AddSpecResponse;
 import org.apache.gobblin.runtime.spec_catalog.TopologyCatalog;
 import org.apache.gobblin.service.ServiceConfigKeys;
 import org.apache.gobblin.service.ServiceMetricNames;
@@ -68,7 +69,7 @@ import org.apache.gobblin.util.ConfigUtils;
  * to {@link TopologyCatalog} and updates {@link SpecCompiler} state.
  */
 @Alpha
-public class Orchestrator implements SpecCatalogListener<Void>, Instrumentable {
+public class Orchestrator implements SpecCatalogListener, Instrumentable {
   protected final Logger _log;
   protected final SpecCompiler specCompiler;
   protected final Optional<TopologyCatalog> topologyCatalog;
@@ -153,12 +154,12 @@ public class Orchestrator implements SpecCatalogListener<Void>, Instrumentable {
 
   /** {@inheritDoc} */
   @Override
-  public Void onAddSpec(Spec addedSpec) {
+  public AddSpecResponse onAddSpec(Spec addedSpec) {
     if (addedSpec instanceof TopologySpec) {
       _log.info("New Spec detected of type TopologySpec: " + addedSpec);
       this.specCompiler.onAddSpec(addedSpec);
     }
-    return null;
+    return new AddSpecResponse(null);
   }
 
   public void onDeleteSpec(URI deletedSpecURI, String deletedSpecVersion) {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobScheduler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobScheduler.java
@@ -49,6 +49,7 @@ import org.apache.gobblin.runtime.api.FlowSpec;
 import org.apache.gobblin.runtime.api.Spec;
 import org.apache.gobblin.runtime.api.SpecCatalogListener;
 import org.apache.gobblin.runtime.listeners.JobListener;
+import org.apache.gobblin.runtime.spec_catalog.AddSpecResponse;
 import org.apache.gobblin.runtime.spec_catalog.FlowCatalog;
 import org.apache.gobblin.runtime.spec_catalog.TopologyCatalog;
 import org.apache.gobblin.scheduler.BaseGobblinJob;
@@ -69,7 +70,7 @@ import org.apache.gobblin.util.PropertiesUtils;
  * and runs them via {@link Orchestrator}.
  */
 @Alpha
-public class GobblinServiceJobScheduler extends JobScheduler implements SpecCatalogListener<String> {
+public class GobblinServiceJobScheduler extends JobScheduler implements SpecCatalogListener {
   protected final Logger _log;
 
   protected final Optional<FlowCatalog> flowCatalog;
@@ -181,7 +182,7 @@ public class GobblinServiceJobScheduler extends JobScheduler implements SpecCata
 
   /** {@inheritDoc} */
   @Override
-  public String onAddSpec(Spec addedSpec) {
+  public AddSpecResponse onAddSpec(Spec addedSpec) {
     if (this.helixManager.isPresent() && !this.helixManager.get().isConnected()) {
       // Specs in store will be notified when Scheduler is added as listener to FlowCatalog, so ignore
       // .. Specs if in cluster mode and Helix is not yet initialized
@@ -241,7 +242,7 @@ public class GobblinServiceJobScheduler extends JobScheduler implements SpecCata
             this.flowCatalog.get().remove(flowSpec.getUri(), new Properties(), false);
           }
         }
-        return compiledFlow;
+        return new AddSpecResponse(compiledFlow);
       } catch (JobException je) {
         _log.error("{} Failed to schedule or run FlowSpec {}", serviceName,  addedSpec, je);
       }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/spec/JobExecutionPlan.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/spec/JobExecutionPlan.java
@@ -26,6 +26,7 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigRenderOptions;
 import com.typesafe.config.ConfigValueFactory;
 
 import lombok.Data;
@@ -38,7 +39,6 @@ import org.apache.gobblin.runtime.api.FlowSpec;
 import org.apache.gobblin.runtime.api.JobSpec;
 import org.apache.gobblin.runtime.api.SpecExecutor;
 import org.apache.gobblin.service.ExecutionStatus;
-import org.apache.gobblin.service.ServiceConfigKeys;
 import org.apache.gobblin.service.modules.flowgraph.FlowGraphConfigurationKeys;
 import org.apache.gobblin.service.modules.orchestration.DagManager;
 import org.apache.gobblin.service.modules.template_catalog.FSFlowCatalog;
@@ -165,5 +165,14 @@ public class JobExecutionPlan {
           StringUtils.appendIfMissing(StringUtils.prependIfMissing(flowSpec.getUri().getPath(), "/"), "/") + jobGroup
               + "/" + jobName, null);
     }
+  }
+
+  /**
+   * Render the JobSpec into a JSON string.
+   * @return a valid JSON string representation of the JobSpec.
+   */
+  @Override
+  public String toString() {
+    return jobSpec.getConfig().root().render(ConfigRenderOptions.concise());
   }
 }


### PR DESCRIPTION
…en a flow config is added.

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-696


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
We add support for an "explain" option in Gobblin-as-a-Service (GaaS) flow creation requests to return the expected output of flow compilation. The "explain" option allows end users to validate their FlowConfig requests by ensuring that: 1. the request results in a successful compilation and 2. that the compiled output is as expected. Further, the "explain" option allows users to query GaaS without any side-effects i.e. no FlowSpecs are actually created/scheduled on GaaS.  


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Enhanced unit tests. End-to-end testing against a locally deployed instance.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

