### PR TITLE
[GOBBLIN-702] Compaction fix for reuse of OrcStruct

### DIFF
--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/orc/OrcKeyComparator.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/orc/OrcKeyComparator.java
@@ -47,7 +47,8 @@ public class OrcKeyComparator extends Configured implements RawComparator<OrcKey
       // output from the map phase, so use the schema defined for the map output key
       // and the data model non-raw compare() implementation.
       schema = TypeDescription.fromString(conf.get(OrcConf.MAPRED_SHUFFLE_KEY_SCHEMA.getAttribute()));
-      OrcStruct orcRecordModel = (OrcStruct) OrcStruct.createValue(schema);
+      OrcStruct orcRecordModel1 = (OrcStruct) OrcStruct.createValue(schema);
+      OrcStruct orcRecordModel2 = (OrcStruct) OrcStruct.createValue(schema);
 
       if (key1 == null) {
         key1 = new OrcKey();
@@ -59,25 +60,25 @@ public class OrcKeyComparator extends Configured implements RawComparator<OrcKey
         buffer = new DataInputBuffer();
       }
 
-      key1.key = orcRecordModel;
-      key2.key = orcRecordModel;
+      key1.key = orcRecordModel1;
+      key2.key = orcRecordModel2;
     }
   }
 
   @Override
   public int compare(byte[] b1, int s1, int l1, byte[] b2, int s2, int l2) {
     try {
-      buffer.reset(b1, s1, l1);                   // parse key1
+      buffer.reset(b1, s1, l1);      // parse key1
       key1.readFields(buffer);
 
-      buffer.reset(b2, s2, l2);                   // parse key2
+      buffer.reset(b2, s2, l2);      // parse key2
       key2.readFields(buffer);
 
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
 
-    return compare(key1, key2);                   // compare them
+    return compare(key1, key2);     // compare them
   }
 
   @Override

--- a/gobblin-modules/gobblin-orc-dep/build.gradle
+++ b/gobblin-modules/gobblin-orc-dep/build.gradle
@@ -46,6 +46,7 @@ configurations {
     exclude group: "commons-cli"
     exclude group: "org.apache.avro"
     exclude group: "org.apache.httpcomponents"
+    exclude group: "org.apache.hadoop"
   }
 }
 


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

There's a bug in Orc-Compaction as the `OrcStruct` is reusing underlying object. Adding unit test for that as well.

Also pull out hadoop dependency from orc fat jar. 


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-702] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-702


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

