### PR TITLE
[GOBBLIN-706]enable dynamic mappers

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -617,6 +617,7 @@ public class ConfigurationKeys {
   /** Specifies a static location in HDFS to upload jars to. Useful for sharing jars across different Gobblin runs.*/
   public static final String MR_JARS_DIR = "mr.jars.dir";
   public static final String MR_JOB_MAX_MAPPERS_KEY = "mr.job.max.mappers";
+  public static final String TARGET_MAPPER_SIZE = "target.mapper.size";
   public static final String MR_REPORT_METRICS_AS_COUNTERS_KEY = "mr.report.metrics.as.counters";
   public static final boolean DEFAULT_MR_REPORT_METRICS_AS_COUNTERS = false;
   public static final int DEFAULT_MR_JOB_MAX_MAPPERS = 100;

--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -617,7 +617,7 @@ public class ConfigurationKeys {
   /** Specifies a static location in HDFS to upload jars to. Useful for sharing jars across different Gobblin runs.*/
   public static final String MR_JARS_DIR = "mr.jars.dir";
   public static final String MR_JOB_MAX_MAPPERS_KEY = "mr.job.max.mappers";
-  public static final String TARGET_MAPPER_SIZE = "target.mapper.size";
+  public static final String MR_TARGET_MAPPER_SIZE = "mr.target.mapper.size";
   public static final String MR_REPORT_METRICS_AS_COUNTERS_KEY = "mr.report.metrics.as.counters";
   public static final boolean DEFAULT_MR_REPORT_METRICS_AS_COUNTERS = false;
   public static final int DEFAULT_MR_JOB_MAX_MAPPERS = 100;

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSource.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSource.java
@@ -264,12 +264,11 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
       KafkaWorkUnitPacker kafkaWorkUnitPacker = KafkaWorkUnitPacker.getInstance(this, state);
       int numOfMultiWorkunits = maxMapperNum;
       if(state.contains(ConfigurationKeys.MR_TARGET_MAPPER_SIZE)) {
-        double totalEstDataSize = kafkaWorkUnitPacker.getWorkUnitEstSizes(workUnits);
+        double totalEstDataSize = kafkaWorkUnitPacker.setWorkUnitEstSizes(workUnits);
         LOG.info(String.format("The total estimated data size is %.2f", totalEstDataSize));
         double targetMapperSize = state.getPropAsDouble(ConfigurationKeys.MR_TARGET_MAPPER_SIZE);
-        numOfMultiWorkunits = (int) (totalEstDataSize / targetMapperSize);
-        numOfMultiWorkunits = numOfMultiWorkunits>maxMapperNum? maxMapperNum:numOfMultiWorkunits;
-        numOfMultiWorkunits = numOfMultiWorkunits==0? 1: numOfMultiWorkunits;
+        numOfMultiWorkunits = (int) (totalEstDataSize / targetMapperSize) + 1;
+        numOfMultiWorkunits = Math.min(numOfMultiWorkunits, maxMapperNum);
       }
       List<WorkUnit> workUnitList = kafkaWorkUnitPacker.pack(workUnits, numOfMultiWorkunits);
       addTopicSpecificPropsToWorkUnits(workUnitList, topicSpecificStateMap);

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSource.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSource.java
@@ -259,14 +259,16 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
       // but aren't processed).
       createEmptyWorkUnitsForSkippedPartitions(workUnits, topicSpecificStateMap, state);
       //determine the number of mappers
-      int numOfMultiWorkunits =
+      int maxMapperNum =
           state.getPropAsInt(ConfigurationKeys.MR_JOB_MAX_MAPPERS_KEY, ConfigurationKeys.DEFAULT_MR_JOB_MAX_MAPPERS);
       KafkaWorkUnitPacker kafkaWorkUnitPacker = KafkaWorkUnitPacker.getInstance(this, state);
+      int numOfMultiWorkunits = maxMapperNum;
       if(state.contains(ConfigurationKeys.MR_TARGET_MAPPER_SIZE)) {
         double totalEstDataSize = kafkaWorkUnitPacker.getWorkUnitEstSizes(workUnits);
         LOG.info(String.format("The total estimated data size is %.2f", totalEstDataSize));
         double targetMapperSize = state.getPropAsDouble(ConfigurationKeys.MR_TARGET_MAPPER_SIZE);
         numOfMultiWorkunits = (int) (totalEstDataSize / targetMapperSize);
+        numOfMultiWorkunits = numOfMultiWorkunits>maxMapperNum? maxMapperNum:numOfMultiWorkunits;
         numOfMultiWorkunits = numOfMultiWorkunits==0? 1: numOfMultiWorkunits;
       }
       List<WorkUnit> workUnitList = kafkaWorkUnitPacker.pack(workUnits, numOfMultiWorkunits);

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSource.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSource.java
@@ -261,13 +261,15 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
       //determine the number of mappers
       int numOfMultiWorkunits =
           state.getPropAsInt(ConfigurationKeys.MR_JOB_MAX_MAPPERS_KEY, ConfigurationKeys.DEFAULT_MR_JOB_MAX_MAPPERS);
-      if(state.contains(ConfigurationKeys.TARGET_MAPPER_SIZE)) {
-        double totalEstDataSize = KafkaWorkUnitPacker.getInstance(this, state).getWorkUnitEstSizes(workUnits);
+      KafkaWorkUnitPacker kafkaWorkUnitPacker = KafkaWorkUnitPacker.getInstance(this, state);
+      if(state.contains(ConfigurationKeys.MR_TARGET_MAPPER_SIZE)) {
+        double totalEstDataSize = kafkaWorkUnitPacker.getWorkUnitEstSizes(workUnits);
         LOG.info(String.format("The total estimated data size is %.2f", totalEstDataSize));
-        double targetMapperSize = state.getPropAsDouble(ConfigurationKeys.TARGET_MAPPER_SIZE);
+        double targetMapperSize = state.getPropAsDouble(ConfigurationKeys.MR_TARGET_MAPPER_SIZE);
         numOfMultiWorkunits = (int) (totalEstDataSize / targetMapperSize);
+        numOfMultiWorkunits = numOfMultiWorkunits==0? 1: numOfMultiWorkunits;
       }
-      List<WorkUnit> workUnitList = KafkaWorkUnitPacker.getInstance(this, state).pack(workUnits, numOfMultiWorkunits);
+      List<WorkUnit> workUnitList = kafkaWorkUnitPacker.pack(workUnits, numOfMultiWorkunits);
       addTopicSpecificPropsToWorkUnits(workUnitList, topicSpecificStateMap);
       setLimiterReportKeyListToWorkUnits(workUnitList, getLimiterExtractorReportKeys());
       return workUnitList;

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSource.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSource.java
@@ -122,7 +122,6 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
       "gobblin.kafka.shouldEnableDatasetStateStore";
   public static final boolean DEFAULT_GOBBLIN_KAFKA_SHOULD_ENABLE_DATASET_STATESTORE = false;
   public static final String OFFSET_FETCH_TIMER = "offsetFetchTimer";
-  public static final String TARGET_MAPPER_SIZE = "target.mapper.size";
 
   private final Set<String> moveToLatestTopics = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
   private final Map<KafkaPartition, Long> previousOffsets = Maps.newConcurrentMap();
@@ -259,6 +258,7 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
       // Create empty WorkUnits for skipped partitions (i.e., partitions that have previous offsets,
       // but aren't processed).
       createEmptyWorkUnitsForSkippedPartitions(workUnits, topicSpecificStateMap, state);
+      //determine the number of mappers
       int numOfMultiWorkunits =
           state.getPropAsInt(ConfigurationKeys.MR_JOB_MAX_MAPPERS_KEY, ConfigurationKeys.DEFAULT_MR_JOB_MAX_MAPPERS);
       if(state.contains(ConfigurationKeys.TARGET_MAPPER_SIZE)) {

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaWorkUnitPacker.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaWorkUnitPacker.java
@@ -103,16 +103,6 @@ public abstract class KafkaWorkUnitPacker {
     }
   };
 
-  protected double setWorkUnitEstSizes(Map<String, List<WorkUnit>> workUnitsByTopic) {
-    double totalEstDataSize = 0;
-    for (List<WorkUnit> workUnitsForTopic : workUnitsByTopic.values()) {
-      for (WorkUnit workUnit : workUnitsForTopic) {
-        setWorkUnitEstSize(workUnit);
-        totalEstDataSize += getWorkUnitEstSize(workUnit);
-      }
-    }
-    return totalEstDataSize;
-  }
 
   private void setWorkUnitEstSize(WorkUnit workUnit) {
     workUnit.setProp(ESTIMATED_WORKUNIT_SIZE, this.sizeEstimator.calcEstimatedSize(workUnit));
@@ -362,11 +352,18 @@ public abstract class KafkaWorkUnitPacker {
         throw new IllegalArgumentException("WorkUnit packer type " + packerType + " not found");
     }
   }
-  public double getWorkUnitEstSizes(Map<String, List<WorkUnit>> workUnitsByTopic){
+
+  /**
+   * Calculate the total size of the workUnits and set the estimated size for each workUnit
+   * @param workUnitsByTopic
+   * @return the total size of the input workUnits
+   */
+  public double setWorkUnitEstSizes(Map<String, List<WorkUnit>> workUnitsByTopic) {
     double totalEstDataSize = 0;
     for (List<WorkUnit> workUnitsForTopic : workUnitsByTopic.values()) {
       for (WorkUnit workUnit : workUnitsForTopic) {
-        totalEstDataSize += this.sizeEstimator.calcEstimatedSize(workUnit);
+        setWorkUnitEstSize(workUnit);
+        totalEstDataSize += getWorkUnitEstSize(workUnit);
       }
     }
     return totalEstDataSize;

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaWorkUnitPacker.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaWorkUnitPacker.java
@@ -362,6 +362,16 @@ public abstract class KafkaWorkUnitPacker {
         throw new IllegalArgumentException("WorkUnit packer type " + packerType + " not found");
     }
   }
+  public double getWorkUnitEstSizes(Map<String, List<WorkUnit>> workUnitsByTopic){
+    double totalEstDataSize = 0;
+    for (List<WorkUnit> workUnitsForTopic : workUnitsByTopic.values()) {
+      for (WorkUnit workUnit : workUnitsForTopic) {
+        totalEstDataSize += this.sizeEstimator.calcEstimatedSize(workUnit);
+      }
+    }
+    return totalEstDataSize;
+    //return setWorkUnitEstSizes(workUnitsByTopic);
+  }
 
   /**
    * Group {@link WorkUnit}s into {@link MultiWorkUnit}s. Each input {@link WorkUnit} corresponds to

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaWorkUnitPacker.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaWorkUnitPacker.java
@@ -370,7 +370,6 @@ public abstract class KafkaWorkUnitPacker {
       }
     }
     return totalEstDataSize;
-    //return setWorkUnitEstSizes(workUnitsByTopic);
   }
 
   /**


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-706


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Today the number of mappers is hard coded and almost always reached, however, many mappers do very little work. This tends to cause small files and short jobs that are overhead dominated. The improvement here is to enable user add a job property named target.mapper.size to set the target mapper size and Gobblin will dynamically scale the number of mappers up and down depending on the total load. If the property is not set, the number of mappers will still be the vale of mr.job.max.mappers.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

