### PR TITLE
[GOBBLIN-713] Lazy load job specification from job catalog to avoid OOM issue.

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/JobCatalog.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/JobCatalog.java
@@ -18,6 +18,7 @@ package org.apache.gobblin.runtime.api;
 
 import java.net.URI;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -49,6 +50,10 @@ import org.apache.gobblin.util.ConfigUtils;
 public interface JobCatalog extends JobCatalogListenersContainer, Instrumentable, StandardMetricsBridge {
   /** Returns an immutable {@link Collection} of {@link JobSpec}s that are known to the catalog. */
   Collection<JobSpec> getJobs();
+
+  default Iterator<JobSpec> getJobSpecIterator() {
+    return getJobs().iterator();
+  }
 
   /** Metrics for the job catalog; null if
    * ({@link #isInstrumentationEnabled()}) is false. */

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/job_catalog/ImmutableFSJobCatalog.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/job_catalog/ImmutableFSJobCatalog.java
@@ -22,11 +22,13 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
 import javax.annotation.Nullable;
 
+import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -37,6 +39,7 @@ import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.typesafe.config.Config;
 
@@ -163,6 +166,41 @@ public class ImmutableFSJobCatalog extends JobCatalogBase implements JobCatalog 
     return Lists.transform(Lists.newArrayList(
         loader.loadPullFilesRecursively(loader.getRootDirectory(), this.sysConfig, shouldLoadGlobalConf())),
         this.converter);
+  }
+
+  /**
+   * Return an iterator that can fetch all the job specifications.
+   * Different than {@link #getJobs()}, this method prevents loading
+   * all the job configs into memory in the very beginning. Instead it
+   * only loads file paths initially and creates the JobSpec and the
+   * underlying {@link Config} during the iteration.
+   *
+   * @return an iterator that contains job specs (job specs can be null).
+   */
+  @Override
+  public synchronized Iterator<JobSpec> getJobSpecIterator() {
+    List<Path> jobFiles = loader.fetchJobFilesRecursively(loader.getRootDirectory());
+    Iterator<JobSpec> jobSpecIterator = Iterators.transform(jobFiles.iterator(), new Function<Path, JobSpec>() {
+      @Nullable
+      @Override
+      public JobSpec apply(@Nullable Path jobFile) {
+        if (jobFile == null) {
+          return null;
+        }
+
+        try {
+          Config config = ImmutableFSJobCatalog.this.loader.loadPullFile(jobFile,
+            ImmutableFSJobCatalog.this.sysConfig, ImmutableFSJobCatalog.this.shouldLoadGlobalConf());
+
+          return ImmutableFSJobCatalog.this.converter.apply(config);
+        } catch (IOException e) {
+          log.error("Cannot load job from {} due to {}", jobFile, ExceptionUtils.getFullStackTrace(e));
+          return null;
+        }
+      }
+    });
+
+    return jobSpecIterator;
   }
 
   /**

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/PullFileLoader.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/PullFileLoader.java
@@ -32,12 +32,14 @@ import java.util.Set;
 import org.apache.commons.configuration.ConfigurationConverter;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathFilter;
 
 import com.google.common.base.Charsets;
+import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableMap;
@@ -51,6 +53,7 @@ import com.typesafe.config.ConfigSyntax;
 
 import org.apache.gobblin.configuration.ConfigurationKeys;
 
+import javax.annotation.Nullable;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -155,61 +158,23 @@ public class PullFileLoader {
    * @return The loaded {@link Config}s.
    */
   public List<Config> loadPullFilesRecursively(Path path, Config sysProps, boolean loadGlobalProperties) {
-    try {
-      Config fallback = sysProps;
-      if (loadGlobalProperties && PathUtils.isAncestor(this.rootDirectory, path.getParent())) {
-        fallback = loadAncestorGlobalConfigs(path.getParent(), fallback);
-      }
-      return getSortedConfigs(loadPullFilesRecursivelyHelper(path, fallback, loadGlobalProperties));
-    } catch (IOException ioe) {
-      return Lists.newArrayList();
-    }
-  }
+    return Lists.transform(this.fetchJobFilesRecursively(path), new Function<Path, Config>() {
+      @Nullable
+      @Override
+      public Config apply(@Nullable Path jobFile) {
+        if (jobFile == null) {
+          return null;
+        }
 
-  private List<Config> getSortedConfigs(List<ConfigWithTimeStamp> configsWithTimeStamps) {
-    List<Config> sortedConfigs = Lists.newArrayList();
-    Collections.sort(configsWithTimeStamps, Comparator.comparingLong(o -> o.timeStamp));
-    for (ConfigWithTimeStamp configWithTimeStamp : configsWithTimeStamps) {
-      sortedConfigs.add(configWithTimeStamp.config);
-    }
-    return sortedConfigs;
-  }
-
-  private List<ConfigWithTimeStamp> loadPullFilesRecursivelyHelper(Path path, Config fallback, boolean loadGlobalProperties) {
-    List<ConfigWithTimeStamp> pullFiles = Lists.newArrayList();
-    try {
-      if (loadGlobalProperties) {
-        fallback = findAndLoadGlobalConfigInDirectory(path, fallback);
-      }
-
-      FileStatus[] statuses = this.fs.listStatus(path);
-      if (statuses == null) {
-        log.error("Path does not exist: " + path);
-        return pullFiles;
-      }
-
-      for (FileStatus status : statuses) {
         try {
-          if (status.isDirectory()) {
-            pullFiles.addAll(loadPullFilesRecursivelyHelper(status.getPath(), fallback, loadGlobalProperties));
-          } else if (this.javaPropsPullFileFilter.accept(status.getPath())) {
-            log.debug("modification time of {} is {}", status.getPath(), status.getModificationTime());
-            pullFiles.add(new ConfigWithTimeStamp(status.getModificationTime(), loadJavaPropsWithFallback(status.getPath(), fallback).resolve()));
-          } else if (this.hoconPullFileFilter.accept(status.getPath())) {
-            log.debug("modification time of {} is {}", status.getPath(), status.getModificationTime());
-            pullFiles.add(new ConfigWithTimeStamp(status.getModificationTime(), loadHoconConfigAtPath(status.getPath()).withFallback(fallback).resolve()));
-          }
-        } catch (IOException ioe) {
-          // Failed to load specific subpath, try with the other subpaths in this directory
-          log.error(String.format("Failed to load %s. Skipping.", status.getPath()));
+          return PullFileLoader.this.loadPullFile(jobFile,
+              sysProps, loadGlobalProperties);
+        } catch (IOException e) {
+          log.error("Cannot load job from {} due to {}", jobFile, ExceptionUtils.getFullStackTrace(e));
+          return null;
         }
       }
-
-      return pullFiles;
-    } catch (IOException ioe) {
-      log.error("Could not load properties at path: " + path, ioe);
-      return Lists.newArrayList();
-    }
+    });
   }
 
   public List<Path> fetchJobFilesRecursively(Path path) {


### PR DESCRIPTION
Lazy load job specification from job catalog to avoid OOM issue.

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-713


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
    Use iterator instead of a collection to handle the lazy loading of job specs. All the job spec's path is load first and then convert to the job spec during the iteration.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

