### PR TITLE
GOBBLIN-727: Skip commit in CloseOnFlushWriterWrapper if a commit has…

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/writer/CloseOnFlushWriterWrapper.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/writer/CloseOnFlushWriterWrapper.java
@@ -57,6 +57,8 @@ public class CloseOnFlushWriterWrapper<D> extends WriterWrapper<D> implements De
   private DataWriter<D> writer;
   private final Supplier<DataWriter<D>> writerSupplier;
   private boolean closed;
+  private boolean committed;
+
   // is the close functionality enabled?
   private final boolean closeOnFlush;
   private final ControlMessageHandler controlMessageHandler;
@@ -90,6 +92,7 @@ public class CloseOnFlushWriterWrapper<D> extends WriterWrapper<D> implements De
     if (this.closed) {
       this.writer = writerSupplier.get();
       this.closed = false;
+      this.committed = false;
     }
     this.writer.writeEnvelope(record);
   }
@@ -104,13 +107,15 @@ public class CloseOnFlushWriterWrapper<D> extends WriterWrapper<D> implements De
 
   @Override
   public void commit() throws IOException {
-    writer.commit();
+    if (!this.committed) {
+      writer.commit();
+      this.committed = true;
+    }
   }
 
   @Override
   public void cleanup() throws IOException {
     writer.cleanup();
-
   }
 
   @Override


### PR DESCRIPTION
… already been invoked on the underlying writer.

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-727


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
We skip commit() on the underlying writer if a commit has been previously invoked. Currently, duplicate commits on the underlying writer can result in Exceptions due to non-existing data in task staging location (as in the case of an FsDataWriter). 



### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tested with a Gobblin job running locally.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

