### PR TITLE
[GOBBLIN-732] Pass UGI credentials to the app master and load dynamic…

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterUtils.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterUtils.java
@@ -28,7 +28,9 @@ import com.typesafe.config.Config;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.gobblin.annotation.Alpha;
+import org.apache.gobblin.configuration.DynamicConfigGenerator;
 import org.apache.gobblin.runtime.AbstractJobLauncher;
+import org.apache.gobblin.runtime.DynamicConfigGeneratorFactory;
 
 import static org.apache.gobblin.cluster.GobblinClusterConfigurationKeys.CLUSTER_WORK_DIR;
 
@@ -103,4 +105,28 @@ public class GobblinClusterUtils {
 
     return jobStateFilePath;
   }
+
+  /**
+   * Get the dynamic config from a {@link DynamicConfigGenerator}
+   * @param config input config
+   * @return  the dynamic config
+   */
+  public static Config getDynamicConfig(Config config) {
+    // load dynamic configuration and add them to the job properties
+    DynamicConfigGenerator dynamicConfigGenerator =
+        DynamicConfigGeneratorFactory.createDynamicConfigGenerator(config);
+    Config dynamicConfig = dynamicConfigGenerator.generateDynamicConfig(config);
+
+    return dynamicConfig;
+  }
+
+  /**
+   * Add dynamic config with higher precedence to the input config
+   * @param config input config
+   * @return a config combining the input config with the dynamic config
+   */
+  public static Config addDynamicConfig(Config config) {
+    return getDynamicConfig(config).withFallback(config);
+  }
+
 }

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixTask.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixTask.java
@@ -94,7 +94,8 @@ public class GobblinHelixTask implements Task {
                                jobStateFilePath,
                                builder.getFs(),
                                taskAttemptBuilder,
-                               stateStores);
+                               stateStores,
+                               builder.getDynamicConfig());
   }
 
   private void getInfoFromTaskConfig() {

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SingleTask.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SingleTask.java
@@ -55,15 +55,17 @@ public class SingleTask {
   private FileSystem _fs;
   private TaskAttemptBuilder _taskAttemptBuilder;
   private StateStores _stateStores;
+  private Config _dynamicConfig;
 
   SingleTask(String jobId, Path workUnitFilePath, Path jobStateFilePath, FileSystem fs,
-      TaskAttemptBuilder taskAttemptBuilder, StateStores stateStores) {
+      TaskAttemptBuilder taskAttemptBuilder, StateStores stateStores, Config dynamicConfig) {
     _jobId = jobId;
     _workUnitFilePath = workUnitFilePath;
     _jobStateFilePath = jobStateFilePath;
     _fs = fs;
     _taskAttemptBuilder = taskAttemptBuilder;
     _stateStores = stateStores;
+    _dynamicConfig = dynamicConfig;
   }
 
   public void run()
@@ -71,6 +73,9 @@ public class SingleTask {
     List<WorkUnit> workUnits = getWorkUnits();
 
     JobState jobState = getJobState();
+    // Add dynamic configuration to the job state
+    _dynamicConfig.entrySet().forEach(e -> jobState.setProp(e.getKey(), e.getValue().unwrapped().toString()));
+
     Config jobConfig = getConfigFromJobState(jobState);
 
     _logger.debug("SingleTask.run: jobId {} workUnitFilePath {} jobStateFilePath {} jobState {} jobConfig {}",

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SingleTaskRunner.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SingleTaskRunner.java
@@ -116,7 +116,7 @@ class SingleTaskRunner {
     final TaskAttemptBuilder taskAttemptBuilder = getTaskAttemptBuilder(stateStores);
 
     this.task = new SingleTask(this.jobId, new Path(this.workUnitFilePath), jobStateFilePath, fs,
-        taskAttemptBuilder, stateStores);
+        taskAttemptBuilder, stateStores, GobblinClusterUtils.getDynamicConfig(this.clusterConfig));
   }
 
   private TaskAttemptBuilder getTaskAttemptBuilder(final StateStores stateStores) {

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/TaskRunnerSuiteBase.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/TaskRunnerSuiteBase.java
@@ -82,7 +82,8 @@ public abstract class TaskRunnerSuiteBase {
 
   @Getter
   public static class Builder {
-    private Config config;
+    private final Config config;
+    private final Config dynamicConfig;
     private HelixManager jobHelixManager;
     private Optional<ContainerMetrics> containerMetrics;
     private FileSystem fs;
@@ -92,6 +93,7 @@ public abstract class TaskRunnerSuiteBase {
     private String instanceName;
 
     public Builder(Config config) {
+      this.dynamicConfig = GobblinClusterUtils.getDynamicConfig(config);
       this.config = config;
     }
 

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinApplicationMaster.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinApplicationMaster.java
@@ -50,6 +50,7 @@ import com.typesafe.config.ConfigFactory;
 import org.apache.gobblin.annotation.Alpha;
 import org.apache.gobblin.cluster.GobblinClusterConfigurationKeys;
 import org.apache.gobblin.cluster.GobblinClusterManager;
+import org.apache.gobblin.cluster.GobblinClusterUtils;
 import org.apache.gobblin.util.JvmUtils;
 import org.apache.gobblin.util.logs.Log4jConfigurationHelper;
 import org.apache.gobblin.yarn.event.DelegationTokenUpdatedEvent;
@@ -72,8 +73,8 @@ public class GobblinApplicationMaster extends GobblinClusterManager {
 
   public GobblinApplicationMaster(String applicationName, ContainerId containerId, Config config,
       YarnConfiguration yarnConfiguration) throws Exception {
-    super(applicationName, containerId.getApplicationAttemptId().getApplicationId().toString(), config,
-        Optional.<Path>absent());
+    super(applicationName, containerId.getApplicationAttemptId().getApplicationId().toString(),
+        GobblinClusterUtils.addDynamicConfig(config), Optional.<Path>absent());
 
     GobblinYarnLogSource gobblinYarnLogSource = new GobblinYarnLogSource();
     if (gobblinYarnLogSource.isLogSourcePresent()) {

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnTaskRunner.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnTaskRunner.java
@@ -47,6 +47,7 @@ import com.google.common.util.concurrent.Service;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
+import org.apache.gobblin.cluster.GobblinClusterUtils;
 import org.apache.gobblin.cluster.GobblinTaskRunner;
 import org.apache.gobblin.cluster.GobblinClusterConfigurationKeys;
 import org.apache.gobblin.util.JvmUtils;
@@ -60,8 +61,8 @@ public class GobblinYarnTaskRunner extends GobblinTaskRunner {
 
   public GobblinYarnTaskRunner(String applicationName, String helixInstanceName, ContainerId containerId, Config config,
       Optional<Path> appWorkDirOptional) throws Exception {
-    super(applicationName, helixInstanceName, getApplicationId(containerId), getTaskRunnerId(containerId), config,
-        appWorkDirOptional);
+    super(applicationName, helixInstanceName, getApplicationId(containerId), getTaskRunnerId(containerId),
+        GobblinClusterUtils.addDynamicConfig(config), appWorkDirOptional);
   }
 
   @Override


### PR DESCRIPTION
… config in workers

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-732


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
Azkaban generates hadoop tokens and secrets in the HADOOP_TOKEN_FILE_LOCATION file. If this is present the propagate the credentials to the application master and workers. Also load the dynamic configuration in the workers if configured.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Ran an Azkaban workflow to validate. The yarn integration test is not functional and the config propagation can't be tested with a unit test.

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

