### PR TITLE
[GOBBLIN-734] Fix speculative safety checking in HiveWritable writer

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/writer/FsDataWriter.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/writer/FsDataWriter.java
@@ -345,6 +345,10 @@ public abstract class FsDataWriter<D> implements DataWriter<D>, FinalState, Meta
     return this.fs.makeQualified(this.outputFile).toString();
   }
 
+  /**
+   * Classes that extends this method needs to determine if writerAttemptIdOptional is present and to avoid
+   * problems of overriding, adding another checking on class type.
+   */
   @Override
   public boolean isSpeculativeAttemptSafe() {
     return this.writerAttemptIdOptional.isPresent() && this.getClass() == FsDataWriter.class;

--- a/gobblin-core/src/main/java/org/apache/gobblin/writer/HiveWritableHdfsDataWriter.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/writer/HiveWritableHdfsDataWriter.java
@@ -114,4 +114,9 @@ public class HiveWritableHdfsDataWriter extends FsDataWriter<Writable> {
 
     super.commit();
   }
+
+  @Override
+  public boolean isSpeculativeAttemptSafe() {
+    return this.writerAttemptIdOptional.isPresent() && this.getClass() == HiveWritableHdfsDataWriter.class;
+  }
 }

--- a/gobblin-core/src/test/resources/serde/serde.properties
+++ b/gobblin-core/src/test/resources/serde/serde.properties
@@ -16,7 +16,7 @@
 #
 
 avro.schema.url=gobblin-core/src/test/resources/serde/serde.avsc
-source.hadoop.file.input.paths=gobblin-core/src/test/resources/serde/serde.avro
+source.hadoop.file.input.paths=src/test/resources/serde/serde.avro
 serde.serializer.type=gobblin.converter.serde.OrcSerDeWrapper
 serde.serializer.input.format.type=org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
 serde.serializer.output.format.type=org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat

--- a/gobblin-core/src/test/resources/serde/serde.properties
+++ b/gobblin-core/src/test/resources/serde/serde.properties
@@ -16,7 +16,7 @@
 #
 
 avro.schema.url=gobblin-core/src/test/resources/serde/serde.avsc
-source.hadoop.file.input.paths=src/test/resources/serde/serde.avro
+source.hadoop.file.input.paths=gobblin-core/src/test/resources/serde/serde.avro
 serde.serializer.type=gobblin.converter.serde.OrcSerDeWrapper
 serde.serializer.input.format.type=org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
 serde.serializer.output.format.type=org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

Simple fix.

### JIRA
- [x] My PR addresses the following [Gobblin JIRA]
    - https://issues.apache.org/jira/browse/GOBBLIN-734


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

