### PR TITLE
[GOBBLIN-736] Skip flush and control message handlers on closed write…

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/writer/CloseOnFlushWriterWrapper.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/writer/CloseOnFlushWriterWrapper.java
@@ -169,6 +169,11 @@ public class CloseOnFlushWriterWrapper<D> extends WriterWrapper<D> implements De
   }
 
   private void flush(boolean close) throws IOException {
+    // nothing to flush, so don't call flush on the underlying writer since it may not support flush after close
+    if (this.closed) {
+      return;
+    }
+
     this.writer.flush();
 
     // commit data then close the writer
@@ -184,6 +189,11 @@ public class CloseOnFlushWriterWrapper<D> extends WriterWrapper<D> implements De
   private class CloseOnFlushWriterMessageHandler implements ControlMessageHandler {
     @Override
     public void handleMessage(ControlMessage message) {
+      // nothing to do if already closed, so don't call then underlying handler since it may not work on closed objects
+      if (CloseOnFlushWriterWrapper.this.closed) {
+        return;
+      }
+
       ControlMessageHandler underlyingHandler = CloseOnFlushWriterWrapper.this.writer.getMessageHandler();
 
       // let underlying writer handle the control messages first


### PR DESCRIPTION
…rs in the CloseOnFlushWriterWrapper

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-736


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
The CloseOnFlushWriterWrapper calls operations on the underlying handler to handle flush and metadata update control messages. These operations should not be done on a closed writer since the underlying writer may raise errors for closed objects. Added early returns when a closed writer is detected.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Added test cases to CloseOnFlushWriterWrapperTest.

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

