### PR TITLE
[GOBBLIN-737] Add support for Helix quota-based task scheduling

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
@@ -96,6 +96,9 @@ public class GobblinClusterConfigurationKeys {
   // job spec operation
   public static final String JOB_ALWAYS_DELETE = GOBBLIN_CLUSTER_PREFIX + "job.alwaysDelete";
 
+  // Job quota configuration as a comma separated list of name value pairs separated by a colon.
+  // Example: A:1,B:38,DEFAULT:1
+  public static final String HELIX_TASK_QUOTA_CONFIG_KEY = "gobblin.cluster.helixTaskQuotaConfig";
 
   /**
    * A path pointing to a directory that contains job execution files to be executed by Gobblin. This directory can

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterManager.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterManager.java
@@ -41,12 +41,14 @@ import org.apache.helix.Criteria;
 import org.apache.helix.HelixManager;
 import org.apache.helix.InstanceType;
 import org.apache.helix.messaging.handling.MessageHandlerFactory;
+import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.Message;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
+import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.eventbus.EventBus;
@@ -219,6 +221,39 @@ public class GobblinClusterManager implements ApplicationLauncher, StandardMetri
   }
 
   /**
+   * Configure Helix quota-based task scheduling
+   */
+  @VisibleForTesting
+  void configureHelixQuotaBasedTaskScheduling() {
+    // set up the cluster quota config
+    List<String> quotaConfigList = ConfigUtils.getStringList(this.config,
+        GobblinClusterConfigurationKeys.HELIX_TASK_QUOTA_CONFIG_KEY);
+
+    if (quotaConfigList.isEmpty()) {
+      return;
+    }
+
+    // retrieve the cluster config for updating
+    ClusterConfig clusterConfig = this.multiManager.getJobClusterHelixManager().getConfigAccessor()
+        .getClusterConfig(this.clusterName);
+    clusterConfig.resetTaskQuotaRatioMap();
+
+    for (String entry : quotaConfigList) {
+      List<String> quotaConfig = Splitter.on(":").limit(2).trimResults().omitEmptyStrings().splitToList(entry);
+
+      if (quotaConfig.size() < 2) {
+        throw new IllegalArgumentException(
+            "Quota configurations must be of the form <key1>:<value1>,<key2>:<value2>,...");
+      }
+
+      clusterConfig.setTaskQuotaRatio(quotaConfig.get(0), Integer.parseInt(quotaConfig.get(1)));
+    }
+
+    this.multiManager.getJobClusterHelixManager().getConfigAccessor()
+        .setClusterConfig(this.clusterName, clusterConfig); // Set the new ClusterConfig
+  }
+
+  /**
    * Start the Gobblin Cluster Manager.
    */
   @Override
@@ -227,6 +262,8 @@ public class GobblinClusterManager implements ApplicationLauncher, StandardMetri
 
     this.eventBus.register(this);
     this.multiManager.connect();
+
+    configureHelixQuotaBasedTaskScheduling();
 
     if (this.isStandaloneMode) {
       // standalone mode starts non-daemon threads later, so need to have this thread to keep process up


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-737


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
Support configuring Helix quota-based task scheduling through gobblin cluster configuration. The gobblin cluster config key "gobblin.cluster.helixTaskQuotaConfig" is added to store a value in the format "quota_type1:quota_value1,quota_type2:quota_value2,...". The config values are parsed and propagated to the Helix cluster configuration.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
GobblinClusterManagerTest

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

