### PR TITLE
GOBBLIN-744: Support cancellation of a Helix workflow via a DELETE Spec.

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/FsScheduledJobConfigurationManager.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/FsScheduledJobConfigurationManager.java
@@ -57,10 +57,15 @@ public class FsScheduledJobConfigurationManager extends ScheduledJobConfiguratio
     for (Pair<SpecExecutor.Verb, JobSpec> entry : jobSpecs) {
       JobSpec jobSpec = entry.getValue();
       SpecExecutor.Verb verb = entry.getKey();
-      if (verb.equals(SpecExecutor.Verb.ADD) || verb.equals(SpecExecutor.Verb.UPDATE)) {
+      if (verb.equals(SpecExecutor.Verb.ADD)) {
         // Handle addition
         this._jobCatalog.put(jobSpec);
         postNewJobConfigArrival(jobSpec.getUri().toString(), jobSpec.getConfigAsProperties());
+      } else if (verb.equals(SpecExecutor.Verb.UPDATE)) {
+        //Handle update.
+        //Overwrite the jobSpec in the jobCatalog and post an UpdateJobConfigArrivalEvent.
+        this._jobCatalog.put(jobSpec);
+        postUpdateJobConfigArrival(jobSpec.getUri().toString(), jobSpec.getConfigAsProperties());
       } else if (verb.equals(SpecExecutor.Verb.DELETE)) {
         // Handle delete
         this._jobCatalog.remove(jobSpec.getUri());

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/FsScheduledJobConfigurationManager.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/FsScheduledJobConfigurationManager.java
@@ -18,7 +18,6 @@ package org.apache.gobblin.cluster;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 
 import org.apache.commons.lang3.tuple.Pair;
@@ -31,7 +30,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.gobblin.runtime.api.FsSpecConsumer;
 import org.apache.gobblin.runtime.api.JobSpec;
 import org.apache.gobblin.runtime.api.MutableJobCatalog;
-import org.apache.gobblin.runtime.api.Spec;
 import org.apache.gobblin.runtime.api.SpecExecutor;
 
 
@@ -53,27 +51,26 @@ public class FsScheduledJobConfigurationManager extends ScheduledJobConfiguratio
 
   @Override
   protected void fetchJobSpecs() throws ExecutionException, InterruptedException {
-    List<Pair<SpecExecutor.Verb, Spec>> jobSpecs =
-        (List<Pair<SpecExecutor.Verb, Spec>>) this._specConsumer.changedSpecs().get();
+    List<Pair<SpecExecutor.Verb, JobSpec>> jobSpecs =
+        (List<Pair<SpecExecutor.Verb, JobSpec>>) this._specConsumer.changedSpecs().get();
 
-    for (Pair<SpecExecutor.Verb, Spec> entry : jobSpecs) {
-      Spec spec = entry.getValue();
+    for (Pair<SpecExecutor.Verb, JobSpec> entry : jobSpecs) {
+      JobSpec jobSpec = entry.getValue();
       SpecExecutor.Verb verb = entry.getKey();
       if (verb.equals(SpecExecutor.Verb.ADD) || verb.equals(SpecExecutor.Verb.UPDATE)) {
         // Handle addition
-        JobSpec jobSpec = (JobSpec) spec;
         this._jobCatalog.put(jobSpec);
         postNewJobConfigArrival(jobSpec.getUri().toString(), jobSpec.getConfigAsProperties());
       } else if (verb.equals(SpecExecutor.Verb.DELETE)) {
         // Handle delete
-        this._jobCatalog.remove(spec.getUri());
-        postDeleteJobConfigArrival(spec.getUri().toString(), new Properties());
+        this._jobCatalog.remove(jobSpec.getUri());
+        postDeleteJobConfigArrival(jobSpec.getUri().toString(), jobSpec.getConfigAsProperties());
       }
 
       try {
         //Acknowledge the successful consumption of the JobSpec back to the SpecConsumer, so that the
         //SpecConsumer can delete the JobSpec.
-        this._specConsumer.commit(spec);
+        this._specConsumer.commit(jobSpec);
       } catch (IOException e) {
         log.error("Error when committing to FsSpecConsumer: ", e);
       }

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
@@ -159,4 +159,7 @@ public class GobblinClusterConfigurationKeys {
   public static final String KILL_DUPLICATE_PLANNING_JOB = GOBBLIN_CLUSTER_PREFIX + "kill.duplicate.planningJob";
   public static final boolean DEFAULT_KILL_DUPLICATE_PLANNING_JOB = true;
 
+  public static final String SHOULD_CANCEL_RUNNING_JOB_ON_DELETE = GOBBLIN_CLUSTER_PREFIX + "shouldCancelRunningJobOnDelete";
+
+
 }

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
@@ -159,7 +159,6 @@ public class GobblinClusterConfigurationKeys {
   public static final String KILL_DUPLICATE_PLANNING_JOB = GOBBLIN_CLUSTER_PREFIX + "kill.duplicate.planningJob";
   public static final boolean DEFAULT_KILL_DUPLICATE_PLANNING_JOB = true;
 
-  public static final String SHOULD_CANCEL_RUNNING_JOB_ON_DELETE = GOBBLIN_CLUSTER_PREFIX + "shouldCancelRunningJobOnDelete";
-
-
+  public static final String CANCEL_RUNNING_JOB_ON_DELETE = GOBBLIN_CLUSTER_PREFIX + "job.cancelRunningJobOnDelete";
+  public static final String DEFAULT_CANCEL_RUNNING_JOB_ON_DELETE = "false";
 }

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SleepingTask.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SleepingTask.java
@@ -20,9 +20,9 @@ package org.apache.gobblin.cluster;
 import java.io.File;
 import java.io.IOException;
 
+import com.google.common.base.Throwables;
 import com.google.common.io.Files;
 
-import avro.shaded.com.google.common.base.Throwables;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.gobblin.runtime.TaskContext;

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SleepingTask.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SleepingTask.java
@@ -17,24 +17,51 @@
 
 package org.apache.gobblin.cluster;
 
+import java.io.IOException;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
 import avro.shaded.com.google.common.base.Throwables;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.gobblin.runtime.TaskContext;
+import org.apache.gobblin.runtime.TaskState;
 import org.apache.gobblin.runtime.task.BaseAbstractTask;
 
 @Slf4j
 public class SleepingTask extends BaseAbstractTask {
+  public static final String TASK_STATE_FILE_KEY = "task.state.file.path";
+
   private final long sleepTime;
+  private FileSystem fs;
+  private Path taskStateFile;
 
   public SleepingTask(TaskContext taskContext) {
     super(taskContext);
-    sleepTime = taskContext.getTaskState().getPropAsLong("data.publisher.sleep.time.in.seconds", 10L);
+    TaskState taskState = taskContext.getTaskState();
+    sleepTime = taskState.getPropAsLong("data.publisher.sleep.time.in.seconds", 10L);
+    taskStateFile = new Path(taskState.getProp(TASK_STATE_FILE_KEY));
+    try {
+      fs = FileSystem.getLocal(new Configuration());
+      //Delete any previous left over task state files
+      if (this.fs.exists(taskStateFile)) {
+        this.fs.delete(taskStateFile, false);
+      }
+    } catch (IOException e) {
+      log.error("Error creating SleepingTask.");
+      Throwables.propagate(e);
+    }
   }
 
   @Override
   public void run() {
     try {
+      if (!this.fs.exists(taskStateFile.getParent())) {
+        this.fs.mkdirs(taskStateFile.getParent());
+      }
+      this.fs.create(taskStateFile);
       long endTime = System.currentTimeMillis() + sleepTime * 1000;
       while (System.currentTimeMillis() <= endTime) {
         Thread.sleep(1000L);
@@ -46,6 +73,17 @@ public class SleepingTask extends BaseAbstractTask {
       log.error("Sleep interrupted.");
       Thread.currentThread().interrupt();
       Throwables.propagate(e);
+    } catch (IOException e) {
+      log.error("IOException encountered", e);
+      Throwables.propagate(e);
+    } finally {
+      try {
+        if (this.fs.exists(taskStateFile)) {
+          this.fs.delete(taskStateFile, false);
+        }
+      } catch (IOException e) {
+        log.warn("Error when attempting to delete {}", taskStateFile, e);
+      }
     }
   }
 }

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/suite/IntegrationJobCancelSuite.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/suite/IntegrationJobCancelSuite.java
@@ -26,11 +26,13 @@ import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
 import org.apache.gobblin.cluster.GobblinClusterConfigurationKeys;
+import org.apache.gobblin.cluster.SleepingTask;
 import org.apache.gobblin.configuration.ConfigurationKeys;
 
 
 public class IntegrationJobCancelSuite extends IntegrationBasicSuite {
   public static final String JOB_ID = "job_HelloWorldTestJob_1234";
+  public static final String TASK_STATE_FILE = "/tmp/IntegrationJobCancelSuite/taskState/_RUNNING";
 
   @Override
   protected Map<String, Config> overrideJobConfigs(Config rawJobConfig) {
@@ -38,7 +40,7 @@ public class IntegrationJobCancelSuite extends IntegrationBasicSuite {
         ConfigurationKeys.SOURCE_CLASS_KEY, "org.apache.gobblin.cluster.SleepingCustomTaskSource",
         ConfigurationKeys.JOB_ID_KEY, JOB_ID,
         GobblinClusterConfigurationKeys.HELIX_JOB_TIMEOUT_ENABLED_KEY, Boolean.TRUE,
-        GobblinClusterConfigurationKeys.HELIX_JOB_TIMEOUT_SECONDS, 10L))
+        GobblinClusterConfigurationKeys.HELIX_JOB_TIMEOUT_SECONDS, 10L, SleepingTask.TASK_STATE_FILE_KEY, TASK_STATE_FILE))
         .withFallback(rawJobConfig);
     return ImmutableMap.of("HelloWorldJob", newConfig);
   }

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/suite/IntegrationJobCancelViaSpecSuite.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/suite/IntegrationJobCancelViaSpecSuite.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.cluster.suite;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.Reader;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.io.DatumWriter;
+import org.apache.avro.specific.SpecificDatumWriter;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.Files;
+import com.google.common.io.Resources;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigParseOptions;
+import com.typesafe.config.ConfigSyntax;
+import com.typesafe.config.ConfigValueFactory;
+
+import org.apache.gobblin.cluster.FsScheduledJobConfigurationManager;
+import org.apache.gobblin.cluster.GobblinClusterConfigurationKeys;
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.runtime.api.FsSpecConsumer;
+import org.apache.gobblin.runtime.api.SpecExecutor;
+import org.apache.gobblin.runtime.job_spec.AvroJobSpec;
+import org.apache.gobblin.util.ConfigUtils;
+
+
+public class IntegrationJobCancelViaSpecSuite extends IntegrationJobCancelSuite {
+  public static final String JOB_ID = "job_HelloWorldTestJob_1235";
+  public static final String JOB_CATALOG_DIR = "/tmp/IntegrationJobCancelViaSpecSuite/jobCatalog";
+  public static final String FS_SPEC_CONSUMER_DIR = "/tmp/IntegrationJobCancelViaSpecSuite/jobSpecs";
+
+  public IntegrationJobCancelViaSpecSuite() throws IOException {
+    super();
+    Path jobCatalogDirPath = new Path(JOB_CATALOG_DIR);
+    FileSystem fs = FileSystem.getLocal(new Configuration());
+    if (!fs.exists(jobCatalogDirPath)) {
+      fs.mkdirs(jobCatalogDirPath);
+    }
+  }
+
+  private Map<String,String> getJobConfig() throws IOException {
+    try (InputStream resourceStream = Resources.getResource(JOB_CONF_NAME).openStream()) {
+      Reader reader = new InputStreamReader(resourceStream);
+      Config rawJobConfig =
+          ConfigFactory.parseReader(reader, ConfigParseOptions.defaults().setSyntax(ConfigSyntax.CONF));
+      rawJobConfig = rawJobConfig.withFallback(getClusterConfig());
+      Config newConfig = ConfigFactory.parseMap(ImmutableMap
+          .of(ConfigurationKeys.SOURCE_CLASS_KEY, "org.apache.gobblin.cluster.SleepingCustomTaskSource",
+              ConfigurationKeys.JOB_ID_KEY, JOB_ID, GobblinClusterConfigurationKeys.HELIX_JOB_TIMEOUT_ENABLED_KEY,
+              Boolean.TRUE, GobblinClusterConfigurationKeys.HELIX_JOB_TIMEOUT_SECONDS, 100L,
+              ConfigurationKeys.JOB_NAME_KEY, JOB_ID)).withFallback(rawJobConfig);
+      Properties jobProperties = ConfigUtils.configToProperties(newConfig);
+      Map<String, String> jobPropertiesAsMap = new HashMap<>();
+      for (String name : jobProperties.stringPropertyNames()) {
+        jobPropertiesAsMap.put(name, jobProperties.getProperty(name));
+      }
+      return jobPropertiesAsMap;
+    }
+  }
+
+  @Override
+  public Config getManagerConfig() {
+    Config managerConfig = super.getManagerConfig();
+    managerConfig = managerConfig.withValue(GobblinClusterConfigurationKeys.JOB_CONFIGURATION_MANAGER_KEY,
+        ConfigValueFactory.fromAnyRef(FsScheduledJobConfigurationManager.class.getName()))
+        .withValue(GobblinClusterConfigurationKeys.GOBBLIN_CLUSTER_PREFIX + ConfigurationKeys.JOB_CONFIG_FILE_GENERAL_PATH_KEY,
+            ConfigValueFactory.fromAnyRef(JOB_CATALOG_DIR))
+    .withValue(GobblinClusterConfigurationKeys.SPEC_CONSUMER_CLASS_KEY, ConfigValueFactory.fromAnyRef(FsSpecConsumer.class.getName()))
+        .withValue(GobblinClusterConfigurationKeys.JOB_SPEC_REFRESH_INTERVAL, ConfigValueFactory.fromAnyRef(5L))
+    .withValue(FsSpecConsumer.SPEC_PATH_KEY, ConfigValueFactory.fromAnyRef(FS_SPEC_CONSUMER_DIR));
+    return managerConfig;
+  }
+
+  public void addJobSpec(String jobSpecName, String verb) throws IOException {
+    Map<String, String> metadataMap = new HashMap<>();
+    metadataMap.put(FsSpecConsumer.VERB_KEY, verb);
+
+    Map<String, String> jobProperties = new HashMap<>();
+    if (SpecExecutor.Verb.ADD.name().equals(verb)) {
+      jobProperties = getJobConfig();
+    } else if (SpecExecutor.Verb.DELETE.name().equals(verb)) {
+      jobProperties.put(GobblinClusterConfigurationKeys.SHOULD_CANCEL_RUNNING_JOB_ON_DELETE, "true");
+    }
+
+    AvroJobSpec jobSpec = AvroJobSpec.newBuilder().
+        setUri(Files.getNameWithoutExtension(jobSpecName)).
+        setProperties(jobProperties).
+        setTemplateUri("FS:///").
+        setDescription("HelloWorldTestJob").
+        setVersion("1").
+        setMetadata(metadataMap).build();
+
+    DatumWriter<AvroJobSpec> datumWriter = new SpecificDatumWriter<>(AvroJobSpec.SCHEMA$);
+    DataFileWriter<AvroJobSpec> dataFileWriter = new DataFileWriter<>(datumWriter);
+
+    Path fsSpecConsumerPath = new Path(FS_SPEC_CONSUMER_DIR, jobSpecName);
+    FileSystem fs = fsSpecConsumerPath.getFileSystem(new Configuration());
+    OutputStream out = fs.create(fsSpecConsumerPath);
+
+    dataFileWriter.create(AvroJobSpec.SCHEMA$, out);
+    dataFileWriter.append(jobSpec);
+    dataFileWriter.close();
+  }
+}

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/suite/IntegrationJobRestartViaSpecSuite.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/suite/IntegrationJobRestartViaSpecSuite.java
@@ -52,13 +52,13 @@ import org.apache.gobblin.runtime.job_spec.AvroJobSpec;
 import org.apache.gobblin.util.ConfigUtils;
 
 
-public class IntegrationJobCancelViaSpecSuite extends IntegrationJobCancelSuite {
+public class IntegrationJobRestartViaSpecSuite extends IntegrationJobCancelSuite {
   public static final String JOB_ID = "job_HelloWorldTestJob_1235";
   public static final String JOB_CATALOG_DIR = "/tmp/IntegrationJobCancelViaSpecSuite/jobCatalog";
   public static final String FS_SPEC_CONSUMER_DIR = "/tmp/IntegrationJobCancelViaSpecSuite/jobSpecs";
   public static final String TASK_STATE_FILE = "/tmp/IntegrationJobCancelViaSpecSuite/taskState/_RUNNING";
 
-  public IntegrationJobCancelViaSpecSuite() throws IOException {
+  public IntegrationJobRestartViaSpecSuite() throws IOException {
     super();
     Path jobCatalogDirPath = new Path(JOB_CATALOG_DIR);
     FileSystem fs = FileSystem.getLocal(new Configuration());
@@ -114,6 +114,9 @@ public class IntegrationJobCancelViaSpecSuite extends IntegrationJobCancelSuite 
     if (SpecExecutor.Verb.ADD.name().equals(verb)) {
       jobProperties = getJobConfig();
     } else if (SpecExecutor.Verb.DELETE.name().equals(verb)) {
+      jobProperties.put(GobblinClusterConfigurationKeys.CANCEL_RUNNING_JOB_ON_DELETE, "true");
+    } else if (SpecExecutor.Verb.UPDATE.name().equals(verb)) {
+      jobProperties = getJobConfig();
       jobProperties.put(GobblinClusterConfigurationKeys.CANCEL_RUNNING_JOB_ON_DELETE, "true");
     }
 

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/FsSpecConsumer.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/FsSpecConsumer.java
@@ -78,6 +78,9 @@ public class FsSpecConsumer implements SpecConsumer<Spec> {
       return null;
     }
 
+    //Sort the {@link JobSpec}s in increasing order of their modification times.
+    //This is done so that the {JobSpec}s can be handled in FIFO order by the
+    //JobConfigurationManager and eventually, the GobblinHelixJobScheduler.
     Arrays.sort(fileStatuses, Comparator.comparingLong(FileStatus::getModificationTime));
 
     for (FileStatus fileStatus : fileStatuses) {

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/FsSpecConsumer.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/FsSpecConsumer.java
@@ -20,6 +20,8 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -62,7 +64,9 @@ public class FsSpecConsumer implements SpecConsumer<Spec> {
     }
   }
 
-  /** List of newly changed {@link Spec}s for execution on {@link SpecExecutor}. */
+  /** List of newly changed {@link Spec}s for execution on {@link SpecExecutor}.
+   * The {@link Spec}s are returned in the increasing order of their modification times.
+   */
   @Override
   public Future<? extends List<Pair<SpecExecutor.Verb, Spec>>> changedSpecs() {
     List<Pair<SpecExecutor.Verb, Spec>> specList = new ArrayList<>();
@@ -73,6 +77,8 @@ public class FsSpecConsumer implements SpecConsumer<Spec> {
       log.error("Error when listing files at path: {}", this.specDirPath.toString(), e);
       return null;
     }
+
+    Arrays.sort(fileStatuses, Comparator.comparingLong(FileStatus::getModificationTime));
 
     for (FileStatus fileStatus : fileStatuses) {
       DataFileReader<AvroJobSpec> dataFileReader;


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-744


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
This task supports the ability to interrupt and cancel a running job on a Gobblin Helix cluster via a DELETE Spec submitted to the JobConfigurationManager. The DELETE Spec should have "gobblin.cluster.shouldCancelRunningJobOnDelete" set to true for cancelling a running job. The default behavior is to simply delete the corresponding JobSpec from the JobCatalog. 

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
IntegrationJobCancelViaSpecSuite and ClusterIntegrationTest.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

