### PR TITLE
[GOBBLIN-755] add delimiter to hive queries

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/query/HiveAvroORCQueryGenerator.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/query/HiveAvroORCQueryGenerator.java
@@ -858,7 +858,7 @@ public class HiveAvroORCQueryGenerator {
           }
           if (typeEvolved) {
             ddl.add(String.format("USE %s%n", finalDbName));
-            ddl.add(String.format("ALTER TABLE `%s` CHANGE COLUMN %s %s %s COMMENT '%s'",
+            ddl.add(String.format("ALTER TABLE `%s` CHANGE COLUMN `%s` %s %s COMMENT '%s'",
                 finalTableName, evolvedColumn.getKey(), evolvedColumn.getKey(), evolvedColumn.getValue(),
                 escapeStringForHive(destinationField.getComment())));
           }
@@ -876,7 +876,7 @@ public class HiveAvroORCQueryGenerator {
         // .. hence specifying 'use dbName' as a precursor to rename
         // Refer: HIVE-2496
         ddl.add(String.format("USE %s%n", finalDbName));
-        ddl.add(String.format("ALTER TABLE `%s` ADD COLUMNS (%s %s COMMENT 'from flatten_source %s')",
+        ddl.add(String.format("ALTER TABLE `%s` ADD COLUMNS (`%s` %s COMMENT 'from flatten_source %s')",
             finalTableName, evolvedColumn.getKey(), evolvedColumn.getValue(), flattenSource));
       }
     }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/query/HiveAvroORCQueryGenerator.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/query/HiveAvroORCQueryGenerator.java
@@ -858,7 +858,7 @@ public class HiveAvroORCQueryGenerator {
           }
           if (typeEvolved) {
             ddl.add(String.format("USE %s%n", finalDbName));
-            ddl.add(String.format("ALTER TABLE `%s` CHANGE COLUMN `%s` %s %s COMMENT '%s'",
+            ddl.add(String.format("ALTER TABLE `%s` CHANGE COLUMN `%s` `%s` %s COMMENT '%s'",
                 finalTableName, evolvedColumn.getKey(), evolvedColumn.getKey(), evolvedColumn.getValue(),
                 escapeStringForHive(destinationField.getComment())));
           }

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/conversion/hive/converter/HiveSchemaEvolutionTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/conversion/hive/converter/HiveSchemaEvolutionTest.java
@@ -220,7 +220,7 @@ public class HiveSchemaEvolutionTest {
             outputSchema, isEvolutionEnabled, hiveColumns, destinationTableMeta);
     Assert.assertEquals(generateEvolutionDDL.size(), 2);
     Assert.assertEquals(generateEvolutionDDL.get(1),
-        "ALTER TABLE `sourceSchema` ADD COLUMNS (parentFieldRecord__nestedFieldInt int "
+        "ALTER TABLE `sourceSchema` ADD COLUMNS (`parentFieldRecord__nestedFieldInt` int "
             + "COMMENT 'from flatten_source parentFieldRecord.nestedFieldInt')",
         "Generated evolution DDL did not match for evolution enabled");
 


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below! @zxcware please review


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-XXX


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
add the delimiter around all column names in hive queries

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
updated the test case

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

