### PR TITLE
[GOBBLIN-761]Only instantiate topic-specific configStore object when topic.name is available

### DIFF
--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/policy/HiveRegistrationPolicyBase.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/policy/HiveRegistrationPolicyBase.java
@@ -137,10 +137,12 @@ public class HiveRegistrationPolicyBase implements HiveRegistrationPolicy {
 
     // Get Topic-specific config object doesn't require any runtime-set properties in prop object, safe to initialize
     // in constructor.
-    Timer.Context context = this.metricContext.timer(CONFIG_FOR_TOPIC_TIMER).time();
-    configForTopic =
-        ConfigStoreUtils.getConfigForTopic(this.props.getProperties(), KafkaSource.TOPIC_NAME, this.configClient);
-    context.close();
+    if (this.props.getProperties().containsKey(KafkaSource.TOPIC_NAME)) {
+      Timer.Context context = this.metricContext.timer(CONFIG_FOR_TOPIC_TIMER).time();
+      configForTopic =
+          ConfigStoreUtils.getConfigForTopic(this.props.getProperties(), KafkaSource.TOPIC_NAME, this.configClient);
+      context.close();
+    }
   }
 
   /**


### PR DESCRIPTION
… available

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
    - https://issues.apache.org/jira/browse/GOBBLIN-761


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

