### PR TITLE
[GOBBLIN-768] Add MySQL implementation of SpecStore

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_store/MysqlSpecStore.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_store/MysqlSpecStore.java
@@ -58,6 +58,7 @@ import org.apache.gobblin.util.ConfigUtils;
 public class MysqlSpecStore implements SpecStore {
   public static final String CONFIG_PREFIX = "mysqlSpecStore";
   public static final String SPEC_STORE_SOURCE = "source";
+  public static final String DEFAULT_SPEC_STORE_SOURCE = "default_source";
 
   private static final String CREATE_TABLE_STATEMENT =
       "CREATE TABLE IF NOT EXISTS %s (spec_uri VARCHAR(128) NOT NULL, spec_source VARCHAR(128) NOT NULL, spec LONGBLOB, PRIMARY KEY (spec_uri, spec_source))";
@@ -82,7 +83,7 @@ public class MysqlSpecStore implements SpecStore {
     this.tableName = config.getString(ConfigurationKeys.STATE_STORE_DB_TABLE_KEY);
     this.specStoreURI = URI.create(config.getString(ConfigurationKeys.STATE_STORE_DB_URL_KEY));
     this.specSerDe = specSerDe;
-    this.specStoreSource = ConfigUtils.getString(config, SPEC_STORE_SOURCE, "default_source");
+    this.specStoreSource = ConfigUtils.getString(config, SPEC_STORE_SOURCE, DEFAULT_SPEC_STORE_SOURCE);
 
     try (Connection connection = this.dataSource.getConnection();
         PreparedStatement statement = connection.prepareStatement(String.format(CREATE_TABLE_STATEMENT, this.tableName))) {

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_store/MysqlSpecStore.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_store/MysqlSpecStore.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.runtime.spec_store;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.net.URI;
+import java.sql.Blob;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
+import com.typesafe.config.Config;
+
+import javax.sql.DataSource;
+
+import org.apache.gobblin.broker.SharedResourcesBrokerFactory;
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.metastore.MysqlDataSourceFactory;
+import org.apache.gobblin.runtime.api.Spec;
+import org.apache.gobblin.runtime.api.SpecNotFoundException;
+import org.apache.gobblin.runtime.api.SpecStore;
+
+
+/**
+ * Implementation of {@link SpecStore} that stores specs as serialized java objects in MySQL. Note that versions are not
+ * supported, so the version parameter will be ignored in methods that have it.
+ */
+public class MysqlSpecStore implements SpecStore {
+  private static final String CREATE_TABLE_STATEMENT =
+      "CREATE TABLE IF NOT EXISTS %s (spec_uri VARCHAR(128) NOT NULL, spec LONGBLOB, PRIMARY KEY (spec_uri))";
+  private static final String EXISTS_STATEMENT = "SELECT EXISTS(SELECT * FROM %s WHERE spec_uri = ?)";
+  private static final String INSERT_STATEMENT = "INSERT INTO %s (spec_uri, spec) VALUES (?, ?) ON DUPLICATE KEY UPDATE spec = VALUES(spec)";
+  private static final String DELETE_STATEMENT = "DELETE FROM %s WHERE spec_uri = ?";
+  private static final String GET_STATEMENT = "SELECT spec FROM %s WHERE spec_uri = ?";
+  private static final String GET_ALL_STATEMENT = "SELECT spec_uri, spec FROM %s";
+
+  private DataSource dataSource;
+  private String tableName;
+  private URI specStoreURI;
+
+  public MysqlSpecStore(Config config) throws IOException {
+    this.dataSource = MysqlDataSourceFactory.get(config, SharedResourcesBrokerFactory.getImplicitBroker());
+    this.tableName = config.getString(ConfigurationKeys.STATE_STORE_DB_TABLE_KEY);
+    this.specStoreURI = URI.create(config.getString(ConfigurationKeys.STATE_STORE_DB_URL_KEY));
+    try (Connection connection = this.dataSource.getConnection();
+        PreparedStatement statement = connection.prepareStatement(String.format(CREATE_TABLE_STATEMENT, this.tableName))) {
+      statement.executeUpdate();
+    } catch (SQLException e) {
+      throw new IOException(e);
+    }
+  }
+
+  @Override
+  public boolean exists(URI specUri) throws IOException {
+    try (Connection connection = this.dataSource.getConnection();
+        PreparedStatement statement = connection.prepareStatement(String.format(EXISTS_STATEMENT, this.tableName))) {
+      statement.setString(1, specUri.toString());
+      ResultSet rs = statement.executeQuery();
+      rs.next();
+      return rs.getBoolean(1);
+    } catch (SQLException e) {
+      throw new IOException(e);
+    }
+  }
+
+  @Override
+  public void addSpec(Spec spec) throws IOException {
+    try (Connection connection = this.dataSource.getConnection();
+        PreparedStatement statement = connection.prepareStatement(String.format(INSERT_STATEMENT, this.tableName));
+        ByteArrayOutputStream aos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(aos)) {
+
+      oos.writeObject(spec);
+      statement.setString(1, spec.getUri().toString());
+      statement.setBlob(2, new ByteArrayInputStream(aos.toByteArray()));
+      statement.executeUpdate();
+
+      connection.commit();
+    } catch (SQLException e) {
+      throw new IOException(e);
+    }
+  }
+
+  @Override
+  public boolean deleteSpec(Spec spec) throws IOException {
+    return deleteSpec(spec.getUri());
+  }
+
+  @Override
+  public boolean deleteSpec(URI specUri) throws IOException {
+    try (Connection connection = this.dataSource.getConnection();
+        PreparedStatement statement = connection.prepareStatement(String.format(DELETE_STATEMENT, this.tableName))) {
+      statement.setString(1, specUri.toString());
+      int result = statement.executeUpdate();
+      connection.commit();
+      return result != 0;
+    } catch (SQLException e) {
+      throw new IOException(e);
+    }
+  }
+
+  @Override
+  public boolean deleteSpec(URI specUri, String version) throws IOException {
+    return deleteSpec(specUri);
+  }
+
+  @Override
+  public Spec updateSpec(Spec spec) throws IOException, SpecNotFoundException {
+    addSpec(spec);
+    return spec;
+  }
+
+  @Override
+  public Spec getSpec(URI specUri) throws IOException, SpecNotFoundException {
+    try (Connection connection = this.dataSource.getConnection();
+        PreparedStatement statement = connection.prepareStatement(String.format(GET_STATEMENT, this.tableName))) {
+
+      statement.setString(1, specUri.toString());
+      ResultSet rs = statement.executeQuery();
+      if (!rs.next()) {
+        throw new SpecNotFoundException(specUri);
+      }
+
+      Blob blob = rs.getBlob(1);
+
+      try (ObjectInputStream ois = new ObjectInputStream(blob.getBinaryStream())) {
+        return (Spec) ois.readObject();
+      }
+
+    } catch (SQLException | ClassNotFoundException e) {
+      throw new IOException(e);
+    }
+  }
+
+  @Override
+  public Spec getSpec(URI specUri, String version) throws IOException, SpecNotFoundException {
+    return getSpec(specUri);
+  }
+
+  @Override
+  public Collection<Spec> getAllVersionsOfSpec(URI specUri) throws IOException, SpecNotFoundException {
+    return Lists.newArrayList(getSpec(specUri));
+  }
+
+  @Override
+  public Collection<Spec> getSpecs() throws IOException {
+    try (Connection connection = this.dataSource.getConnection();
+        PreparedStatement statement = connection.prepareStatement(String.format(GET_ALL_STATEMENT, this.tableName))) {
+
+      List<Spec> specs = new ArrayList<>();
+      ResultSet rs = statement.executeQuery();
+
+      while (rs.next()) {
+        Blob blob = rs.getBlob(2);
+        try (ObjectInputStream ois = new ObjectInputStream(blob.getBinaryStream())) {
+          specs.add((Spec) ois.readObject());
+        }
+      }
+
+      return specs;
+    } catch (SQLException | ClassNotFoundException e) {
+      throw new IOException(e);
+    }
+  }
+
+  @Override
+  public Iterator<URI> getSpecURIs() throws IOException {
+    try (Connection connection = this.dataSource.getConnection();
+        PreparedStatement statement = connection.prepareStatement(String.format(GET_ALL_STATEMENT, this.tableName))) {
+
+      List<URI> specs = new ArrayList<>();
+      ResultSet rs = statement.executeQuery();
+
+      while (rs.next()) {
+        URI specURI = URI.create(rs.getString(1));
+        specs.add(specURI);
+      }
+
+      return specs.iterator();
+    } catch (SQLException e) {
+      throw new IOException(e);
+    }
+  }
+
+  @Override
+  public Optional<URI> getSpecStoreURI() {
+    return Optional.of(this.specStoreURI);
+  }
+}

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/spec_store/MysqlSpecStoreTest.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/spec_store/MysqlSpecStoreTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.runtime.spec_store;
+
+import java.net.URI;
+import java.util.Collection;
+import java.util.Iterator;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.Iterators;
+import com.typesafe.config.Config;
+
+import org.apache.gobblin.config.ConfigBuilder;
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.metastore.testing.ITestMetastoreDatabase;
+import org.apache.gobblin.metastore.testing.TestMetastoreDatabaseFactory;
+import org.apache.gobblin.runtime.api.FlowSpec;
+import org.apache.gobblin.runtime.api.Spec;
+
+
+public class MysqlSpecStoreTest {
+  private static final String USER = "testUser";
+  private static final String PASSWORD = "testPassword";
+  private static final String TABLE = "spec_store";
+
+  private MysqlSpecStore specStore;
+  private URI uri1 = URI.create("flowspec1");
+  private URI uri2 = URI.create("flowspec2");
+  private FlowSpec flowSpec1 = FlowSpec.builder(this.uri1)
+      .withConfig(ConfigBuilder.create().addPrimitive("key", "value").build())
+      .withDescription("Test flow spec")
+      .withVersion("Test version")
+      .build();
+  private FlowSpec flowSpec2 = FlowSpec.builder(this.uri2)
+      .withConfig(ConfigBuilder.create().addPrimitive("key2", "value2").build())
+      .withDescription("Test flow spec 2")
+      .withVersion("Test version 2")
+      .build();
+
+  @BeforeClass
+  public void setUp() throws Exception {
+    ITestMetastoreDatabase testDb = TestMetastoreDatabaseFactory.get();
+
+    Config config = ConfigBuilder.create()
+        .addPrimitive(ConfigurationKeys.STATE_STORE_DB_URL_KEY, testDb.getJdbcUrl())
+        .addPrimitive(ConfigurationKeys.STATE_STORE_DB_USER_KEY, USER)
+        .addPrimitive(ConfigurationKeys.STATE_STORE_DB_PASSWORD_KEY, PASSWORD)
+        .addPrimitive(ConfigurationKeys.STATE_STORE_DB_TABLE_KEY, TABLE)
+        .build();
+
+    this.specStore = new MysqlSpecStore(config);
+  }
+
+  @Test
+  public void testAddGetSpec() throws Exception {
+    this.specStore.addSpec(this.flowSpec1);
+    this.specStore.addSpec(this.flowSpec2);
+
+    Assert.assertTrue(this.specStore.exists(this.uri1));
+    Assert.assertFalse(this.specStore.exists(URI.create("dummy")));
+
+    FlowSpec result = (FlowSpec) this.specStore.getSpec(this.uri1);
+    Assert.assertEquals(result, this.flowSpec1);
+
+    Collection<Spec> specs = this.specStore.getSpecs();
+    Assert.assertTrue(specs.contains(this.flowSpec1));
+    Assert.assertTrue(specs.contains(this.flowSpec2));
+
+    Iterator<URI> uris = this.specStore.getSpecURIs();
+    Assert.assertTrue(Iterators.contains(uris, this.uri1));
+    Assert.assertTrue(Iterators.contains(uris, this.uri2));
+  }
+
+  @Test
+  public void testDeleteSpec() throws Exception {
+    this.specStore.addSpec(this.flowSpec1);
+    Assert.assertTrue(this.specStore.exists(this.uri1));
+
+    this.specStore.deleteSpec(this.uri1);
+    Assert.assertFalse(this.specStore.exists(this.uri1));
+  }
+}


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-768


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Add MySQL implementation of SpecStore (currently only implementation is FS based).

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Added `MysqlSpecStoreTest`

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

