### PR TITLE
[GOBBLIN-769] Support string record timestamp in TimeBasedAvroWriterPartitioner

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/writer/partitioner/TimeBasedAvroWriterPartitioner.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/writer/partitioner/TimeBasedAvroWriterPartitioner.java
@@ -60,7 +60,7 @@ public class TimeBasedAvroWriterPartitioner extends TimeBasedWriterPartitioner<G
   public TimeBasedAvroWriterPartitioner(State state, int numBranches, int branchId) {
     super(state, numBranches, branchId);
     this.partitionColumns = getWriterPartitionColumns(state, numBranches, branchId);
-    this.enableParseAsString = getEnableParseString(state, numBranches, branchId);
+    this.enableParseAsString = getEnableParseAsString(state, numBranches, branchId);
     log.info("Enable parse string: {}", this.enableParseAsString);
   }
 
@@ -71,7 +71,7 @@ public class TimeBasedAvroWriterPartitioner extends TimeBasedWriterPartitioner<G
     return state.contains(propName) ? Optional.of(state.getPropAsList(propName)) : Optional.<List<String>> absent();
   }
 
-  private static boolean getEnableParseString(State state, int numBranches, int branchId) {
+  private static boolean getEnableParseAsString(State state, int numBranches, int branchId) {
     String propName = ForkOperatorUtils.getPropertyNameForBranch(WRITER_PARTITION_ENABLE_PARSE_AS_STRING,
         numBranches, branchId);
     return state.getPropAsBoolean(propName, false);

--- a/gobblin-core/src/main/java/org/apache/gobblin/writer/partitioner/TimeBasedAvroWriterPartitioner.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/writer/partitioner/TimeBasedAvroWriterPartitioner.java
@@ -61,7 +61,7 @@ public class TimeBasedAvroWriterPartitioner extends TimeBasedWriterPartitioner<G
     super(state, numBranches, branchId);
     this.partitionColumns = getWriterPartitionColumns(state, numBranches, branchId);
     this.enableParseAsString = getEnableParseAsString(state, numBranches, branchId);
-    log.info("Enable parse string: {}", this.enableParseAsString);
+    log.info("Enable parse as string: {}", this.enableParseAsString);
   }
 
   private static Optional<List<String>> getWriterPartitionColumns(State state, int numBranches, int branchId) {

--- a/gobblin-core/src/main/java/org/apache/gobblin/writer/partitioner/TimeBasedWriterPartitioner.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/writer/partitioner/TimeBasedWriterPartitioner.java
@@ -74,7 +74,7 @@ public abstract class TimeBasedWriterPartitioner<D> implements WriterPartitioner
   private final String writerPartitionSuffix;
   private final DatePartitionType granularity;
   private final DateTimeZone timeZone;
-  private final TimeUnit timeUnit;
+  protected final TimeUnit timeUnit;
   private final Optional<DateTimeFormatter> timestampToPathFormatter;
   private final Schema schema;
 

--- a/gobblin-core/src/test/java/org/apache/gobblin/writer/partitioner/TimeBasedAvroWriterPartitionerTest.java
+++ b/gobblin-core/src/test/java/org/apache/gobblin/writer/partitioner/TimeBasedAvroWriterPartitionerTest.java
@@ -142,17 +142,17 @@ public class TimeBasedAvroWriterPartitionerTest {
     State state = getBasicState();
     TimeBasedAvroWriterPartitioner partitioner = new TimeBasedAvroWriterPartitioner(state);
     GenericRecordBuilder genericRecordBuilder = new GenericRecordBuilder(getRecordSchema("string"));
-
-    // Test for string type
     genericRecordBuilder.set("timestamp", "1557786583000");
+    // Test without parsing as string
+    Assert.assertTrue(partitioner.getRecordTimestamp(genericRecordBuilder.build()) > 1557786583000L);
+
+    // Test with parsing as string
+    state.setProp(TimeBasedAvroWriterPartitioner.WRITER_PARTITION_ENABLE_PARSE_AS_STRING, true);
+    partitioner = new TimeBasedAvroWriterPartitioner(state);
     Assert.assertEquals(partitioner.getRecordTimestamp(genericRecordBuilder.build()), 1557786583000L);
     // Test for Utf8
     genericRecordBuilder.set("timestamp", new Utf8("1557786583000"));
     Assert.assertEquals(partitioner.getRecordTimestamp(genericRecordBuilder.build()), 1557786583000L);
-    // Test for random string
-    genericRecordBuilder.set("timestamp", "blah");
-    Assert.assertTrue(
-        partitioner.getRecordTimestamp(genericRecordBuilder.build()) <= System.currentTimeMillis());
     // Test for null value
     genericRecordBuilder.set("timestamp", null);
     Assert.assertTrue(
@@ -163,10 +163,6 @@ public class TimeBasedAvroWriterPartitionerTest {
     partitioner = new TimeBasedAvroWriterPartitioner(state);
     genericRecordBuilder.set("timestamp", "1557786583");
     Assert.assertEquals(partitioner.getRecordTimestamp(genericRecordBuilder.build()), 1557786583L);
-    // Test for random string
-    genericRecordBuilder.set("timestamp", "blah");
-    Assert.assertTrue(
-        partitioner.getRecordTimestamp(genericRecordBuilder.build()) <= System.currentTimeMillis() / 1000);
   }
 
   @AfterClass


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/GOBBLIN-769


### Description
- [x] Here are some details about my PR:
- Currently, if a record timestamp is a string, `TimeBasedAvroWriterPartitioner` will not be able to recognize it and will use current time. This change will try to convert a string to Long before using current time

### Tests
- [x] My PR adds the following unit tests:
- `TimeBasedAvroWriterPartitioner.testGetRecordTimestamp` covers various cases for reading string record timestamp

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

