### PR TITLE
[GOBBLIN-770] Add JVM configuration to avoid exhausting YARN containe…

### DIFF
--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnConfigurationKeys.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnConfigurationKeys.java
@@ -45,6 +45,13 @@ public class GobblinYarnConfigurationKeys {
   public static final String APP_MASTER_WORK_DIR_NAME = "appmaster";
   public static final String APP_MASTER_JVM_ARGS_KEY = GOBBLIN_YARN_PREFIX + "app.master.jvm.args";
   public static final String APP_MASTER_SERVICE_CLASSES = GOBBLIN_YARN_PREFIX + "app.master.serviceClasses";
+  // Amount of overhead to subtract when computing the Xmx value. This is to account for non-heap memory, like metaspace
+  // and stack memory
+  public static final String APP_MASTER_JVM_MEMORY_OVERHEAD_MBS_KEY = GOBBLIN_YARN_PREFIX + "app.master.jvmMemoryOverheadMbs";
+  public static final int DEFAULT_APP_MASTER_JVM_MEMORY_OVERHEAD_MBS = 0;
+  // The ratio of the amount of Xmx to carve out of the container memory before adjusting for jvm memory overhead
+  public static final String APP_MASTER_JVM_MEMORY_XMX_RATIO_KEY = GOBBLIN_YARN_PREFIX + "app.master.jvmMemoryXmxRatio";
+  public static final double DEFAULT_APP_MASTER_JVM_MEMORY_XMX_RATIO = 1.0;
 
   // Gobblin Yarn container configuration properties.
   public static final String INITIAL_CONTAINERS_KEY = GOBBLIN_YARN_PREFIX + "initial.containers";
@@ -56,6 +63,13 @@ public class GobblinYarnConfigurationKeys {
   public static final String CONTAINER_WORK_DIR_NAME = "container";
   public static final String CONTAINER_JVM_ARGS_KEY = GOBBLIN_YARN_PREFIX + "container.jvm.args";
   public static final String CONTAINER_HOST_AFFINITY_ENABLED = GOBBLIN_YARN_PREFIX + "container.affinity.enabled";
+  // Amount of overhead to subtract when computing the Xmx value. This is to account for non-heap memory, like metaspace
+  // and stack memory
+  public static final String CONTAINER_JVM_MEMORY_OVERHEAD_MBS_KEY = GOBBLIN_YARN_PREFIX + "container.jvmMemoryOverheadMbs";
+  public static final int DEFAULT_CONTAINER_JVM_MEMORY_OVERHEAD_MBS = 0;
+  // The ratio of the amount of Xmx to carve out of the container memory before adjusting for jvm memory overhead
+  public static final String CONTAINER_JVM_MEMORY_XMX_RATIO_KEY = GOBBLIN_YARN_PREFIX + "container.jvmMemoryXmxRatio";
+  public static final double DEFAULT_CONTAINER_JVM_MEMORY_XMX_RATIO = 1.0;
 
   // Helix configuration properties.
   public static final String HELIX_INSTANCE_MAX_RETRIES = GOBBLIN_YARN_PREFIX + "helix.instance.max.retries";

--- a/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/GobblinYarnAppLauncherTest.java
+++ b/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/GobblinYarnAppLauncherTest.java
@@ -182,6 +182,14 @@ public class GobblinYarnAppLauncherTest implements HelixMessageTestBase {
   }
 
   @Test
+  public void testBuildApplicationMasterCommand() {
+    String command = this.gobblinYarnAppLauncher.buildApplicationMasterCommand(64);
+
+    // 41 is from 64 * 0.8 - 10
+    Assert.assertTrue(command.contains("-Xmx41"));
+  }
+
+  @Test
   public void testCreateHelixCluster() throws Exception {
     // This is tested here instead of in HelixUtilsTest to avoid setting up yet another testing ZooKeeper server.
     HelixUtils.createGobblinHelixCluster(

--- a/gobblin-yarn/src/test/resources/GobblinYarnAppLauncherTest.conf
+++ b/gobblin-yarn/src/test/resources/GobblinYarnAppLauncherTest.conf
@@ -21,3 +21,6 @@ include "reference"
 gobblin.cluster.helix.cluster.name=GobblinYarnAppLauncherTest
 gobblin.yarn.app.name=GobblinYarnAppLauncherTest
 gobblin.yarn.work.dir=GobblinYarnAppLauncherTest
+
+gobblin.yarn.app.master.jvmMemoryOverheadMbs=10
+gobblin.yarn.app.master.jvmMemoryXmxRatio=0.8


### PR DESCRIPTION
…r memory

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-770


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
The current code sets Xmx to the value of the YARN container memory limit. The JVM is highly likely to hit the container memory limit with this configuration due to overhead costs that are not in the JVM heap.

Configuration should be added to set JVM memory as a percentage of the container memory minus a configurable overhead.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

