### PR TITLE
[GOBBLIN-774] Send nack when a control message handler fails in Fork

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/records/FlushControlMessageHandler.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/records/FlushControlMessageHandler.java
@@ -27,7 +27,7 @@ import org.apache.gobblin.stream.FlushControlMessage;
  * Flush control message handler that will flush a {@link Flushable} when handling a {@link FlushControlMessage}
  */
 public class FlushControlMessageHandler implements ControlMessageHandler {
-  Flushable flushable;
+  protected Flushable flushable;
 
   /**
    * Create a flush control message that will flush the given {@link Flushable}

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/TestRecordStream.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/TestRecordStream.java
@@ -17,6 +17,7 @@
 
 package org.apache.gobblin.runtime;
 
+import java.io.Flushable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -33,6 +34,7 @@ import org.testng.annotations.Test;
 import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
 
+import org.apache.gobblin.ack.Ackable;
 import org.apache.gobblin.ack.BasicAckableForTesting;
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.WorkUnitState;
@@ -115,6 +117,40 @@ public class TestRecordStream {
 
     Assert.assertEquals(writer.records, Lists.newArrayList("a", "b"));
     Assert.assertEquals(writer.flush_messages, Lists.newArrayList("flush called", "flush called"));
+  }
+
+  @Test
+  public void testFlushFailure() throws Exception {
+    FlushAckable flushAckable1 = new FlushAckable();
+    FlushAckable flushAckable2 = new FlushAckable();
+
+    MyExtractor extractor = new MyExtractor(new StreamEntity[]{new RecordEnvelope<>("a"),
+        FlushControlMessage.builder().flushReason("flush1").build().addCallBack(flushAckable1), new RecordEnvelope<>("b"),
+        FlushControlMessage.builder().flushReason("flushFail1").build().addCallBack(flushAckable2)});
+    MyConverter converter = new MyConverter();
+    MyFlushDataWriter writer = new MyFlushDataWriter();
+
+    Task task = setupTask(extractor, writer, converter);
+
+    task.run();
+
+    // first flush should succeed, but second one should fail
+    Throwable error = flushAckable1.waitForAck();
+    Assert.assertNull(error);
+
+    error = flushAckable2.waitForAck();
+    Assert.assertNotNull(error);
+
+    task.commit();
+    Assert.assertEquals(task.getTaskState().getWorkingState(), WorkUnitState.WorkingState.SUCCESSFUL);
+
+    Assert.assertEquals(converter.records, Lists.newArrayList("a", "b"));
+    Assert.assertEquals(converter.messages, Lists.newArrayList(
+        FlushControlMessage.builder().flushReason("flush1").build(),
+        FlushControlMessage.builder().flushReason("flushFail1").build()));
+
+    Assert.assertEquals(writer.records, Lists.newArrayList("a", "b"));
+    Assert.assertEquals(writer.flush_messages, Lists.newArrayList("flush called"));
   }
 
   /**
@@ -489,12 +525,69 @@ public class TestRecordStream {
     }
   }
 
+  static class MyFlushControlMessageHandler extends FlushControlMessageHandler {
+    public MyFlushControlMessageHandler(Flushable flushable) {
+      super(flushable);
+    }
+
+    @Override
+    public void handleMessage(ControlMessage message) {
+      if (message instanceof FlushControlMessage) {
+        if (((FlushControlMessage) message).getFlushReason().contains("Fail")) {
+          throw new RuntimeException("Flush failed: " + ((FlushControlMessage) message).getFlushReason());
+        }
+
+        try {
+          flushable.flush();
+        } catch (IOException e) {
+          throw new RuntimeException("Could not flush when handling FlushControlMessage", e);
+        }
+      }
+    }
+  }
+
+  /**
+   * {@link Ackable} for waiting for the flush control message to be processed
+   */
+  private static class FlushAckable implements Ackable {
+    private Throwable error;
+    private final CountDownLatch processed;
+
+    public FlushAckable() {
+      this.processed = new CountDownLatch(1);
+    }
+
+    @Override
+    public void ack() {
+      this.processed.countDown();
+    }
+
+    @Override
+    public void nack(Throwable error) {
+      this.error = error;
+      this.processed.countDown();
+    }
+
+    /**
+     * Wait for ack
+     * @return any error encountered
+     */
+    public Throwable waitForAck() {
+      try {
+        this.processed.await();
+        return this.error;
+      } catch (InterruptedException e) {
+        throw new RuntimeException("interrupted while waiting for ack");
+      }
+    }
+  }
+
   static class MyFlushDataWriter extends MyDataWriter {
     private List<String> flush_messages = new ArrayList<>();
 
     @Override
     public ControlMessageHandler getMessageHandler() {
-      return new FlushControlMessageHandler(this);
+      return new MyFlushControlMessageHandler(this);
     }
 
     @Override


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-774

### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
Fork will raise an error without ack/nacking if the control message handler raises an error. This can result in another thread waiting indefinitely for a control message ack. Fork.

consumeRecordStream() should handle control message exceptions by calling nack() with the exception before reraising the error.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

