### PR TITLE
GOBBLIN-778 - Moving config creation to a separate method

### DIFF
--- a/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/source/jdbc/JdbcExtractor.java
+++ b/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/source/jdbc/JdbcExtractor.java
@@ -655,7 +655,9 @@ public abstract class JdbcExtractor extends QueryBasedExtractor<JsonArray, JsonE
     ResultSet resultSet = null;
     try {
       this.jdbcSource = createJdbcSource();
-      this.dataConnection = this.jdbcSource.getConnection();
+      if(this.dataConnection == null) {
+        this.dataConnection = this.jdbcSource.getConnection();
+      }
       Statement statement = this.dataConnection.createStatement();
 
       if (fetchSize != 0 && this.getExpectedRecordCount() > 2000) {
@@ -712,7 +714,9 @@ public abstract class JdbcExtractor extends QueryBasedExtractor<JsonArray, JsonE
     ResultSet resultSet = null;
     try {
       this.jdbcSource = createJdbcSource();
-      this.dataConnection = this.jdbcSource.getConnection();
+      if(this.dataConnection == null) {
+        this.dataConnection = this.jdbcSource.getConnection();
+      }
 
       PreparedStatement statement =
           this.dataConnection.prepareStatement(query, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);

--- a/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/source/jdbc/JdbcExtractor.java
+++ b/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/source/jdbc/JdbcExtractor.java
@@ -655,7 +655,7 @@ public abstract class JdbcExtractor extends QueryBasedExtractor<JsonArray, JsonE
     ResultSet resultSet = null;
     try {
       this.jdbcSource = createJdbcSource();
-      if(this.dataConnection == null) {
+      if (this.dataConnection == null) {
         this.dataConnection = this.jdbcSource.getConnection();
       }
       Statement statement = this.dataConnection.createStatement();
@@ -714,7 +714,7 @@ public abstract class JdbcExtractor extends QueryBasedExtractor<JsonArray, JsonE
     ResultSet resultSet = null;
     try {
       this.jdbcSource = createJdbcSource();
-      if(this.dataConnection == null) {
+      if (this.dataConnection == null) {
         this.dataConnection = this.jdbcSource.getConnection();
       }
 

--- a/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/SalesforceExtractor.java
+++ b/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/SalesforceExtractor.java
@@ -690,19 +690,10 @@ public class SalesforceExtractor extends RestApiExtractor {
       String soapEndpoint = partnerConfig.getServiceEndpoint();
       String restEndpoint = soapEndpoint.substring(0, soapEndpoint.indexOf("Soap/")) + "async/" + apiVersion;
 
-      ConnectorConfig config = new ConnectorConfig();
+      ConnectorConfig config = createConfig();
       config.setSessionId(partnerConfig.getSessionId());
       config.setRestEndpoint(restEndpoint);
-      config.setCompression(true);
-      config.setTraceFile("traceLogs.txt");
-      config.setTraceMessage(false);
-      config.setPrettyPrintXml(true);
 
-      if (super.workUnitState.contains(ConfigurationKeys.SOURCE_CONN_USE_PROXY_URL)
-          && !super.workUnitState.getProp(ConfigurationKeys.SOURCE_CONN_USE_PROXY_URL).isEmpty()) {
-        config.setProxy(super.workUnitState.getProp(ConfigurationKeys.SOURCE_CONN_USE_PROXY_URL),
-            super.workUnitState.getPropAsInt(ConfigurationKeys.SOURCE_CONN_USE_PROXY_PORT));
-      }
 
       this.bulkConnection = new BulkConnection(config);
       success = true;
@@ -1034,6 +1025,26 @@ public class SalesforceExtractor extends RestApiExtractor {
     }
 
     return batchInfo;
+  }
+
+  //Moving config creation in a separate method for custom config parameters like setting up transport factory.
+  public ConnectorConfig createConfig() {
+    ConnectorConfig config = new ConnectorConfig();
+    config.setCompression(true);
+    try {
+      config.setTraceFile("traceLogs.txt");
+    } catch (FileNotFoundException e) {
+      e.printStackTrace();
+    }
+    config.setTraceMessage(false);
+    config.setPrettyPrintXml(true);
+
+    if (super.workUnitState.contains(ConfigurationKeys.SOURCE_CONN_USE_PROXY_URL)
+        && !super.workUnitState.getProp(ConfigurationKeys.SOURCE_CONN_USE_PROXY_URL).isEmpty()) {
+      config.setProxy(super.workUnitState.getProp(ConfigurationKeys.SOURCE_CONN_USE_PROXY_URL),
+          super.workUnitState.getPropAsInt(ConfigurationKeys.SOURCE_CONN_USE_PROXY_PORT));
+    }
+    return config;
   }
 
   @Data

--- a/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/SalesforceExtractor.java
+++ b/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/SalesforceExtractor.java
@@ -20,6 +20,7 @@ package org.apache.gobblin.salesforce;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.FileNotFoundException;
 import java.io.InputStreamReader;
 import java.net.URI;
 import java.text.ParseException;


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/GOBBLIN-778


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
SalesforceExtractor uses bulk connection to connect to Salesforce using bulk API. Since bulkConnection is private variable it cannot be modified to pass custom transportFactory via config.
This task is to separate the config creation from bulkApiLogin method so as it can be overridden for passing custom params like setTransport.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
No new code added, this change only refactors the code into a separate method.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

