### PR TITLE
[GOBBLIN-785] remove wrapper isPartition function, use table.isPartitioned instead

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/source/HiveSource.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/source/HiveSource.java
@@ -169,7 +169,7 @@ public class HiveSource implements Source {
           log.debug(String.format("Processing dataset: %s", hiveDataset));
 
           // Create workunits for partitions
-          if (HiveUtils.isPartitioned(hiveDataset.getTable())
+          if (hiveDataset.getTable().isPartitioned()
               && state.getPropAsBoolean(HIVE_SOURCE_CREATE_WORKUNITS_FOR_PARTITIONS,
               DEFAULT_HIVE_SOURCE_CREATE_WORKUNITS_FOR_PARTITIONS)) {
             createWorkunitsForPartitionedTable(hiveDataset, client);

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/task/HiveConverterUtils.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/task/HiveConverterUtils.java
@@ -435,7 +435,7 @@ public class HiveConverterUtils {
         table = Optional.of(client.get().getTable(dbName, tableName));
         if (table.isPresent()) {
           org.apache.hadoop.hive.ql.metadata.Table qlTable = new org.apache.hadoop.hive.ql.metadata.Table(table.get());
-          if (HiveUtils.isPartitioned(qlTable)) {
+          if (qlTable.isPartitioned()) {
             partitions = Optional.of(HiveUtils.getPartitions(client.get(), qlTable, Optional.<String>absent()));
           }
         }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/watermarker/PartitionLevelWatermarker.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/watermarker/PartitionLevelWatermarker.java
@@ -306,8 +306,8 @@ public class PartitionLevelWatermarker implements HiveSourceWatermarker {
 
         // Watermark workunits are required only for Partitioned tables
         // tableKey is table complete name in the format db@table
-        if (!HiveUtils.isPartitioned(new org.apache.hadoop.hive.ql.metadata.Table(client.get().getTable(
-            tableKey.split("@")[0], tableKey.split("@")[1])))) {
+        if (!(new org.apache.hadoop.hive.ql.metadata.Table(client.get().getTable(
+            tableKey.split("@")[0], tableKey.split("@")[1])).isPartitioned())) {
           continue;
         }
         // We only keep watermarks for partitions that were updated after leastWatermarkToPersistInState

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HiveUtils.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HiveUtils.java
@@ -163,4 +163,11 @@ public class HiveUtils {
     return conf;
   }
 
+  /**
+   * @return true if {@link Table} is partitioned.
+   * @deprecated use {@link Table}'s isPartitioned method directly.
+   */
+  public static boolean isPartitioned(Table table) {
+    return table.isPartitioned();
+  }
 }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HiveUtils.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HiveUtils.java
@@ -60,7 +60,7 @@ public class HiveUtils {
    * @param table the {@link Table} for which we should get partitions.
    * @param filter an optional filter for partitions as would be used in Hive. Can only filter on String columns.
    *               (e.g. "part = \"part1\"" or "date > \"2015\"".
-   * @return a map of values to {@link Partition} for input {@link Table}.
+   * @return a map of values to {@link Partition} for input {@link Table} filtered and non-nullified.
    */
   public static Map<List<String>, Partition> getPartitionsMap(IMetaStoreClient client, Table table,
       Optional<String> filter, Optional<? extends HivePartitionExtendedFilter> hivePartitionExtendedFilterOptional) throws IOException {
@@ -163,10 +163,4 @@ public class HiveUtils {
     return conf;
   }
 
-  /**
-   * @return true if {@link Table} is partitioned.
-   */
-  public static boolean isPartitioned(Table table) {
-    return table.isPartitioned();
-  }
 }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/version/finder/AbstractHiveDatasetVersionFinder.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/version/finder/AbstractHiveDatasetVersionFinder.java
@@ -68,7 +68,7 @@ public abstract class AbstractHiveDatasetVersionFinder implements VersionFinder<
     }
     final HiveDataset hiveDataset = (HiveDataset) dataset;
 
-    if (!HiveUtils.isPartitioned(hiveDataset.getTable())) {
+    if (hiveDataset.getTable().isPartitioned()) {
       throw new IllegalArgumentException("HiveDatasetVersionFinder is only compatible with partitioned hive tables");
     }
 

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/version/finder/AbstractHiveDatasetVersionFinder.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/version/finder/AbstractHiveDatasetVersionFinder.java
@@ -68,7 +68,7 @@ public abstract class AbstractHiveDatasetVersionFinder implements VersionFinder<
     }
     final HiveDataset hiveDataset = (HiveDataset) dataset;
 
-    if (hiveDataset.getTable().isPartitioned()) {
+    if (!hiveDataset.getTable().isPartitioned()) {
       throw new IllegalArgumentException("HiveDatasetVersionFinder is only compatible with partitioned hive tables");
     }
 

--- a/gobblin-modules/gobblin-azkaban/src/main/java/org/apache/gobblin/data/management/conversion/hive/validation/ValidationJob.java
+++ b/gobblin-modules/gobblin-azkaban/src/main/java/org/apache/gobblin/data/management/conversion/hive/validation/ValidationJob.java
@@ -293,7 +293,7 @@ public class ValidationJob extends AbstractJob {
 
           // Validate dataset
           log.info(String.format("Validating dataset: %s", hiveDataset));
-          if (HiveUtils.isPartitioned(hiveDataset.getTable())) {
+          if (hiveDataset.getTable().isPartitioned()) {
             processPartitionedTable(hiveDataset, client);
           } else {
             processNonPartitionedTable(hiveDataset);


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-785


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
some places use HiveUtils.isPartitioned() which is un-necessary wrapper function, and some places uses direct HiveTable.isPartitioned() the later should be used consistently.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: no change or addition in functionality.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

