### PR TITLE
[GOBBLIN-786]Separate SerDe library in DagStateStore out for GaaS-wide sharing

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/service/ServiceConfigKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/service/ServiceConfigKeys.java
@@ -22,7 +22,7 @@ import org.apache.gobblin.annotation.Alpha;
 @Alpha
 public class ServiceConfigKeys {
 
-  private static final String GOBBLIN_SERVICE_PREFIX = "gobblin.service.";
+  public static final String GOBBLIN_SERVICE_PREFIX = "gobblin.service.";
 
   // Gobblin Service Manager Keys
   public static final String GOBBLIN_SERVICE_TOPOLOGY_CATALOG_ENABLED_KEY = GOBBLIN_SERVICE_PREFIX + "topologyCatalog.enabled";

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/FSDagStateStore.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/FSDagStateStore.java
@@ -19,6 +19,7 @@ package org.apache.gobblin.service.modules.orchestration;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Type;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
@@ -30,6 +31,7 @@ import com.google.common.collect.Lists;
 import com.google.common.io.Files;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonSerializer;
+import com.google.gson.reflect.TypeToken;
 import com.typesafe.config.Config;
 
 import lombok.extern.slf4j.Slf4j;
@@ -63,7 +65,13 @@ public class FSDagStateStore implements DagStateStore {
 
     JsonSerializer<List<JobExecutionPlan>> serializer = new JobExecutionPlanListSerializer();
     JsonDeserializer<List<JobExecutionPlan>> deserializer = new JobExecutionPlanListDeserializer(topologySpecMap);
-    this.serDe = new GsonSerDe<>(serializer, deserializer);
+
+    /** {@link Type} object will need to strictly match with the generic arguments being used
+     * to define {@link GsonSerDe}
+     * Due to type erasure, the {@link Type} needs to initialized here instead of inside {@link GsonSerDe}.
+     * */
+    Type typeToken = new TypeToken<List<JobExecutionPlan>>(){}.getType();
+    this.serDe = new GsonSerDe<>(typeToken, serializer, deserializer);
   }
 
   /**

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/spec/GsonSerDe.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/spec/GsonSerDe.java
@@ -23,7 +23,6 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonSerializer;
-import com.google.gson.reflect.TypeToken;
 
 
 /**
@@ -37,24 +36,23 @@ public class GsonSerDe<T> {
   private final Gson gson;
   private final JsonSerializer<T> serializer;
   private final JsonDeserializer<T> deserializer;
-  private final Type typeToken;
+  private final Type type;
 
-  public GsonSerDe(JsonSerializer<T> serializer, JsonDeserializer<T> deserializer) {
+  public GsonSerDe(Type type, JsonSerializer<T> serializer, JsonDeserializer<T> deserializer) {
     this.serializer = serializer;
     this.deserializer = deserializer;
+    this.type = type;
 
-    typeToken = new TypeToken<T>() {
-    }.getType();
-    this.gson = new GsonBuilder().registerTypeAdapter(typeToken, serializer)
-        .registerTypeAdapter(typeToken, deserializer)
+    this.gson = new GsonBuilder().registerTypeAdapter(type, serializer)
+        .registerTypeAdapter(type, deserializer)
         .create();
   }
 
   public String serialize(T object) {
-    return gson.toJson(object, typeToken);
+    return gson.toJson(object, type);
   }
 
   public T deserialize(String serializedObject) {
-    return gson.fromJson(serializedObject, typeToken);
+    return gson.fromJson(serializedObject, type);
   }
 }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/spec/GsonSerDe.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/spec/GsonSerDe.java
@@ -1,11 +1,12 @@
 package org.apache.gobblin.service.modules.spec;
 
+import java.lang.reflect.Type;
+
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonSerializer;
 import com.google.gson.reflect.TypeToken;
-import java.lang.reflect.Type;
 
 
 /**

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/spec/GsonSerDe.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/spec/GsonSerDe.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.gobblin.service.modules.spec;
 
 import java.lang.reflect.Type;

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/spec/GsonSerDe.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/spec/GsonSerDe.java
@@ -1,0 +1,42 @@
+package org.apache.gobblin.service.modules.spec;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonSerializer;
+import com.google.gson.reflect.TypeToken;
+import java.lang.reflect.Type;
+
+
+/**
+ * SerDe library used in GaaS for {@link org.apache.gobblin.runtime.api.SpecStore} and
+ * {@link org.apache.gobblin.service.modules.orchestration.DagStateStore}.
+ *
+ * The solution is built on top of {@link Gson} library.
+ * @param <T> The type of object to be serialized.
+ */
+public class GsonSerDe<T> {
+  private final Gson gson;
+  private final JsonSerializer<T> serializer;
+  private final JsonDeserializer<T> deserializer;
+  private final Type typeToken;
+
+  public GsonSerDe(JsonSerializer<T> serializer, JsonDeserializer<T> deserializer) {
+    this.serializer = serializer;
+    this.deserializer = deserializer;
+
+    typeToken = new TypeToken<T>() {
+    }.getType();
+    this.gson = new GsonBuilder().registerTypeAdapter(typeToken, serializer)
+        .registerTypeAdapter(typeToken, deserializer)
+        .create();
+  }
+
+  public String serialize(T object) {
+    return gson.toJson(object, typeToken);
+  }
+
+  public T deserialize(String serializedObject) {
+    return gson.fromJson(serializedObject, typeToken);
+  }
+}


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA]
    - https://issues.apache.org/jira/browse/GOBBLIN-786


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

This PR separate the SerDe library (Gson) used in `DataStateStore` out to make it sharable for other components in Gobblin as a Service. 

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

