### PR TITLE
[GOBBLIN-798] Clean up workflows from Helix when the Gobblin applicat…

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
@@ -161,8 +161,4 @@ public class GobblinClusterConfigurationKeys {
 
   public static final String CANCEL_RUNNING_JOB_ON_DELETE = GOBBLIN_CLUSTER_PREFIX + "job.cancelRunningJobOnDelete";
   public static final String DEFAULT_CANCEL_RUNNING_JOB_ON_DELETE = "false";
-
-  // for cleaning up jobs on cluster manager startup
-  public static final String CLEAN_UP_JOBS_ON_MANAGER_START = GOBBLIN_CLUSTER_PREFIX + "cleanUpJobsOnManagerStart";
-  public static final boolean DEFAULT_CLEAN_UP_JOBS_ON_MANAGER_START = false;
 }

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
@@ -161,4 +161,8 @@ public class GobblinClusterConfigurationKeys {
 
   public static final String CANCEL_RUNNING_JOB_ON_DELETE = GOBBLIN_CLUSTER_PREFIX + "job.cancelRunningJobOnDelete";
   public static final String DEFAULT_CANCEL_RUNNING_JOB_ON_DELETE = "false";
+
+  // for cleaning up jobs on cluster manager startup
+  public static final String CLEAN_UP_JOBS_ON_MANAGER_START = GOBBLIN_CLUSTER_PREFIX + "cleanUpJobsOnManagerStart";
+  public static final boolean DEFAULT_CLEAN_UP_JOBS_ON_MANAGER_START = false;
 }

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterManager.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterManager.java
@@ -126,8 +126,6 @@ public class GobblinClusterManager implements ApplicationLauncher, StandardMetri
 
   private final boolean isStandaloneMode;
 
-  private final boolean cleanUpJobsOnStartup;
-
   @Getter
   protected GobblinHelixMultiManager multiManager;
   @Getter
@@ -147,8 +145,6 @@ public class GobblinClusterManager implements ApplicationLauncher, StandardMetri
     this.config = config;
     this.isStandaloneMode = ConfigUtils.getBoolean(config, GobblinClusterConfigurationKeys.STANDALONE_CLUSTER_MODE_KEY,
         GobblinClusterConfigurationKeys.DEFAULT_STANDALONE_CLUSTER_MODE);
-    this.cleanUpJobsOnStartup = ConfigUtils.getBoolean(config, GobblinClusterConfigurationKeys.CLEAN_UP_JOBS_ON_MANAGER_START,
-        GobblinClusterConfigurationKeys.DEFAULT_CLEAN_UP_JOBS_ON_MANAGER_START);
 
     this.applicationId = applicationId;
 
@@ -268,9 +264,9 @@ public class GobblinClusterManager implements ApplicationLauncher, StandardMetri
     this.eventBus.register(this);
     this.multiManager.connect();
 
-    // Standalone mode registers a handler to clean up on leadership change, so don't do the cleanup
-    // now even if the option to clean up on startup is set.
-    if (this.cleanUpJobsOnStartup && !this.isStandaloneMode) {
+    // Standalone mode registers a handler to clean up on manager leadership change, so only clean up for non-standalone
+    // mode, such as YARN mode
+    if (!this.isStandaloneMode) {
       this.multiManager.cleanUpJobs();
     }
 

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixMultiManager.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixMultiManager.java
@@ -377,7 +377,7 @@ public class GobblinHelixMultiManager implements StandardMetricsBridge {
 
     Map<String, WorkflowConfig> workflows = taskDriver.getWorkflows();
 
-    log.debug("cleanUpJobs workflow count {} workflows {}", workflows.size(), workflows);
+    log.debug("cleanUpJobs workflow count {} workflows {}", workflows.size(), workflows.keySet());
 
     boolean cleanupDistJobs = ConfigUtils.getBoolean(this.config,
         GobblinClusterConfigurationKeys.CLEAN_ALL_DIST_JOBS,

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixMultiManager.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixMultiManager.java
@@ -339,11 +339,7 @@ public class GobblinHelixMultiManager implements StandardMetricsBridge {
       if (!isLeader) {
         log.info("New Helix Controller leader {}", this.managerClusterHelixManager.getInstanceName());
 
-        cleanUpJobs(this.jobClusterHelixManager);
-
-        if (this.taskDriverHelixManager.isPresent()) {
-          cleanUpJobs(this.taskDriverHelixManager.get());
-        }
+        cleanUpJobs();
 
         for (LeadershipChangeAwareComponent c: this.leadershipChangeAwareComponents) {
           c.becomeActive();
@@ -363,11 +359,25 @@ public class GobblinHelixMultiManager implements StandardMetricsBridge {
     }
   }
 
+  /**
+   * Delete jobs from the helix cluster
+   */
+  @VisibleForTesting
+  public void cleanUpJobs() {
+    cleanUpJobs(this.jobClusterHelixManager);
+
+    if (this.taskDriverHelixManager.isPresent()) {
+      cleanUpJobs(this.taskDriverHelixManager.get());
+    }
+  }
+
   private void cleanUpJobs(HelixManager helixManager) {
     // Clean up existing jobs
     TaskDriver taskDriver = new TaskDriver(helixManager);
 
     Map<String, WorkflowConfig> workflows = taskDriver.getWorkflows();
+
+    log.debug("cleanUpJobs workflow count {} workflows {}", workflows.size(), workflows);
 
     boolean cleanupDistJobs = ConfigUtils.getBoolean(this.config,
         GobblinClusterConfigurationKeys.CLEAN_ALL_DIST_JOBS,

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinApplicationMaster.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinApplicationMaster.java
@@ -44,11 +44,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.Service;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
-import com.typesafe.config.ConfigValueFactory;
 
 import lombok.Getter;
 
@@ -83,10 +81,7 @@ public class GobblinApplicationMaster extends GobblinClusterManager {
   public GobblinApplicationMaster(String applicationName, ContainerId containerId, Config config,
       YarnConfiguration yarnConfiguration) throws Exception {
     super(applicationName, containerId.getApplicationAttemptId().getApplicationId().toString(),
-        GobblinClusterUtils.addDynamicConfig(config)
-        .withFallback(ConfigFactory.parseMap(
-            ImmutableMap.of(GobblinClusterConfigurationKeys.CLEAN_UP_JOBS_ON_MANAGER_START, "true"))),
-        Optional.<Path>absent());
+        GobblinClusterUtils.addDynamicConfig(config), Optional.<Path>absent());
 
     GobblinYarnLogSource gobblinYarnLogSource = new GobblinYarnLogSource();
     if (gobblinYarnLogSource.isLogSourcePresent()) {

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinApplicationMaster.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinApplicationMaster.java
@@ -44,9 +44,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.Service;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigValueFactory;
 
 import lombok.Getter;
 
@@ -81,7 +83,10 @@ public class GobblinApplicationMaster extends GobblinClusterManager {
   public GobblinApplicationMaster(String applicationName, ContainerId containerId, Config config,
       YarnConfiguration yarnConfiguration) throws Exception {
     super(applicationName, containerId.getApplicationAttemptId().getApplicationId().toString(),
-        GobblinClusterUtils.addDynamicConfig(config), Optional.<Path>absent());
+        GobblinClusterUtils.addDynamicConfig(config)
+        .withFallback(ConfigFactory.parseMap(
+            ImmutableMap.of(GobblinClusterConfigurationKeys.CLEAN_UP_JOBS_ON_MANAGER_START, "true"))),
+        Optional.<Path>absent());
 
     GobblinYarnLogSource gobblinYarnLogSource = new GobblinYarnLogSource();
     if (gobblinYarnLogSource.isLogSourcePresent()) {
@@ -110,7 +115,7 @@ public class GobblinApplicationMaster extends GobblinClusterManager {
   /**
    * Build the {@link YarnService} for the Application Master.
    */
-  private YarnService buildYarnService(Config config, String applicationName, String applicationId,
+  protected YarnService buildYarnService(Config config, String applicationName, String applicationId,
       YarnConfiguration yarnConfiguration, FileSystem fs)
       throws Exception {
     return new YarnService(config, applicationName, applicationId, yarnConfiguration, fs, this.eventBus);

--- a/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/GobblinYarnAppLauncherTest.java
+++ b/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/GobblinYarnAppLauncherTest.java
@@ -20,6 +20,7 @@ package org.apache.gobblin.yarn;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.eventbus.EventBus;
 import com.google.common.io.Closer;
 import com.google.common.util.concurrent.Service;
 import com.typesafe.config.Config;
@@ -43,6 +44,7 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.test.TestingServer;
 import org.apache.gobblin.cluster.GobblinClusterConfigurationKeys;
 import org.apache.gobblin.cluster.GobblinHelixConstants;
+import org.apache.gobblin.cluster.GobblinHelixMultiManager;
 import org.apache.gobblin.cluster.HelixMessageTestBase;
 import org.apache.gobblin.cluster.HelixUtils;
 import org.apache.gobblin.cluster.TestHelper;
@@ -52,6 +54,7 @@ import org.apache.gobblin.configuration.DynamicConfigGenerator;
 import org.apache.gobblin.runtime.app.ServiceBasedAppLauncher;
 import org.apache.gobblin.testing.AssertWithBackoff;
 
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.ContainerId;
@@ -63,12 +66,15 @@ import org.apache.helix.HelixManager;
 import org.apache.helix.HelixManagerFactory;
 import org.apache.helix.InstanceType;
 import org.apache.helix.model.Message;
+import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.times;
 
 
 /**
@@ -341,6 +347,28 @@ public class GobblinYarnAppLauncherTest implements HelixMessageTestBase {
   }
 
   /**
+   * Test that the job cleanup call is called
+   */
+  @Test
+  public void testJobCleanup() throws Exception {
+    ContainerId containerId = ContainerId.newInstance(
+        ApplicationAttemptId.newInstance(ApplicationId.newInstance(0, 0), 0), 0);
+    TestApplicationMaster
+        appMaster = Mockito.spy(new TestApplicationMaster("testApp", containerId, config,
+        new YarnConfiguration()));
+
+    Assert.assertEquals(appMaster.getConfig().getString(GobblinClusterConfigurationKeys.CLEAN_UP_JOBS_ON_MANAGER_START),
+        "true");
+
+    GobblinHelixMultiManager mockMultiManager = Mockito.mock(GobblinHelixMultiManager.class);
+
+    appMaster.setMultiManager(mockMultiManager);
+    appMaster.start();
+
+    Mockito.verify(mockMultiManager, times(1)).cleanUpJobs();
+  }
+
+  /**
    * An application master for accessing protected fields in {@link GobblinApplicationMaster}
    * for testing.
    */
@@ -351,12 +379,26 @@ public class GobblinYarnAppLauncherTest implements HelixMessageTestBase {
       super(applicationName, containerId, config, yarnConfiguration);
     }
 
+    @Override
+    protected YarnService buildYarnService(Config config, String applicationName, String applicationId,
+        YarnConfiguration yarnConfiguration, FileSystem fs) throws Exception {
+
+      YarnService testYarnService = new TestYarnService(config, applicationName, applicationId, yarnConfiguration, fs,
+          new EventBus("GobblinYarnAppLauncherTest"));
+
+      return testYarnService;
+    }
+
     public Config getConfig() {
       return this.config;
     }
 
     public ServiceBasedAppLauncher getAppLauncher() {
       return this.applicationLauncher;
+    }
+
+    public void setMultiManager(GobblinHelixMultiManager multiManager) {
+      this.multiManager = multiManager;
     }
   }
 
@@ -371,6 +413,22 @@ public class GobblinYarnAppLauncherTest implements HelixMessageTestBase {
     @Override
     public Config generateDynamicConfig(Config config) {
       return ConfigFactory.parseMap(ImmutableMap.of("dynamicKey1", "dynamicValue1"));
+    }
+  }
+
+  /**
+   * Test class for mocking out YarnService. Need to use this instead of Mockito because of final methods.
+   */
+  private static class TestYarnService extends YarnService {
+    public TestYarnService(Config config, String applicationName, String applicationId, YarnConfiguration yarnConfiguration,
+        FileSystem fs, EventBus eventBus) throws Exception {
+      super(config, applicationName, applicationId, yarnConfiguration, fs, eventBus);
+    }
+
+    @Override
+    protected void startUp()
+        throws Exception {
+      // do nothing
     }
   }
 }

--- a/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/GobblinYarnAppLauncherTest.java
+++ b/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/GobblinYarnAppLauncherTest.java
@@ -357,9 +357,6 @@ public class GobblinYarnAppLauncherTest implements HelixMessageTestBase {
         appMaster = Mockito.spy(new TestApplicationMaster("testApp", containerId, config,
         new YarnConfiguration()));
 
-    Assert.assertEquals(appMaster.getConfig().getString(GobblinClusterConfigurationKeys.CLEAN_UP_JOBS_ON_MANAGER_START),
-        "true");
-
     GobblinHelixMultiManager mockMultiManager = Mockito.mock(GobblinHelixMultiManager.class);
 
     appMaster.setMultiManager(mockMultiManager);


### PR DESCRIPTION
…ion master starts

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-798


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
If the application master aborts a new one may be spawned by YARN. The second application master will resubmit the jobs. This results in duplicate jobs in Helix and multiple instances of the job may run, resulting in duplicate data.

The Gobblin application master should clean up all workflows on startup to avoid executing multiple instances of a job.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
GobblinYarnAppLauncherTest.testJobCleanup()

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

