### PR TITLE
[GOBBLIN-800] Remove the metric context cache from GobblinMetricsRegistry

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SingleTask.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SingleTask.java
@@ -87,6 +87,8 @@ public class SingleTask {
 
       _taskattempt = _taskAttemptBuilder.build(workUnits.iterator(), _jobId, jobState, jobBroker);
       _taskattempt.runAndOptionallyCommitTaskAttempt(GobblinMultiTaskAttempt.CommitPolicy.IMMEDIATE);
+    } finally {
+      _taskattempt.cleanMetrics();
     }
   }
 

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/suite/IntegrationBasicSuite.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/suite/IntegrationBasicSuite.java
@@ -34,14 +34,13 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Scanner;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.curator.test.TestingServer;
+import org.testng.Assert;
 
 import com.google.common.base.Charsets;
 import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.io.Resources;
@@ -51,7 +50,6 @@ import com.typesafe.config.ConfigParseOptions;
 import com.typesafe.config.ConfigRenderOptions;
 import com.typesafe.config.ConfigSyntax;
 
-import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.gobblin.cluster.ClusterIntegrationTest;
@@ -60,6 +58,8 @@ import org.apache.gobblin.cluster.GobblinClusterManager;
 import org.apache.gobblin.cluster.GobblinTaskRunner;
 import org.apache.gobblin.cluster.HelixUtils;
 import org.apache.gobblin.cluster.TestHelper;
+import org.apache.gobblin.metrics.GobblinMetrics;
+import org.apache.gobblin.metrics.GobblinMetricsRegistry;
 import org.apache.gobblin.testing.AssertWithBackoff;
 
 /**
@@ -71,6 +71,7 @@ import org.apache.gobblin.testing.AssertWithBackoff;
  */
 @Slf4j
 public class IntegrationBasicSuite {
+  public static final String JOB_NAME = "HelloWorldTestJob";
   public static final String JOB_CONF_NAME = "HelloWorldJob.conf";
   public static final String WORKER_INSTANCE_0 = "WorkerInstance_0";
   public static final String TEST_INSTANCE_NAME_KEY = "worker.instance.name";
@@ -162,7 +163,7 @@ public class IntegrationBasicSuite {
   }
 
   protected Map<String, Config> overrideJobConfigs(Config rawJobConfig) {
-    return ImmutableMap.of("HelloWorldJob", rawJobConfig);
+    return ImmutableMap.of(JOB_NAME, rawJobConfig);
   }
 
   private void writeJobConf(String jobName, Config jobConfig) throws IOException {
@@ -300,6 +301,11 @@ public class IntegrationBasicSuite {
         workerThread.start();
       }
     }
+  }
+
+  public void verifyMetricsCleaned() {
+    Collection<GobblinMetrics> all = GobblinMetricsRegistry.getInstance().getMetricsByPattern(".*" + JOB_NAME + ".*");
+    Assert.assertEquals(all.size(), 0);
   }
 
   public void shutdownCluster() throws InterruptedException, IOException {

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/suite/IntegrationDedicatedTaskDriverClusterSuite.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/suite/IntegrationDedicatedTaskDriverClusterSuite.java
@@ -72,7 +72,7 @@ public class IntegrationDedicatedTaskDriverClusterSuite extends IntegrationBasic
     Config newConfig = ConfigFactory.parseMap(ImmutableMap.of(
         GobblinClusterConfigurationKeys.DISTRIBUTED_JOB_LAUNCHER_ENABLED, true))
         .withFallback(rawJobConfig);
-    return ImmutableMap.of("HelloWorldJob", newConfig);
+    return ImmutableMap.of(JOB_NAME, newConfig);
   }
 
   @Override

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/suite/IntegrationJobCancelSuite.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/suite/IntegrationJobCancelSuite.java
@@ -42,7 +42,7 @@ public class IntegrationJobCancelSuite extends IntegrationBasicSuite {
         GobblinClusterConfigurationKeys.HELIX_JOB_TIMEOUT_ENABLED_KEY, Boolean.TRUE,
         GobblinClusterConfigurationKeys.HELIX_JOB_TIMEOUT_SECONDS, 10L, SleepingTask.TASK_STATE_FILE_KEY, TASK_STATE_FILE))
         .withFallback(rawJobConfig);
-    return ImmutableMap.of("HelloWorldJob", newConfig);
+    return ImmutableMap.of(JOB_NAME, newConfig);
   }
 
   @Override

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/suite/IntegrationJobFactorySuite.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/suite/IntegrationJobFactorySuite.java
@@ -45,7 +45,7 @@ public class IntegrationJobFactorySuite extends IntegrationBasicSuite {
         GobblinClusterConfigurationKeys.DISTRIBUTED_JOB_LAUNCHER_ENABLED, true,
         GobblinClusterConfigurationKeys.DISTRIBUTED_JOB_LAUNCHER_BUILDER, "TestDistributedExecutionLauncherBuilder"))
         .withFallback(rawJobConfig);
-    return ImmutableMap.of("HelloWorldJob", newConfig);
+    return ImmutableMap.of(JOB_NAME, newConfig);
   }
 
   @Override

--- a/gobblin-metrics-libs/gobblin-metrics/src/main/java/org/apache/gobblin/metrics/GobblinMetrics.java
+++ b/gobblin-metrics-libs/gobblin-metrics/src/main/java/org/apache/gobblin/metrics/GobblinMetrics.java
@@ -70,6 +70,7 @@ import org.apache.gobblin.util.PropertiesUtils;
  */
 public class GobblinMetrics {
 
+  public static final String METRICS_ID_PREFIX = "gobblin.metrics.";
   public static final String METRICS_STATE_CUSTOM_TAGS = "metrics.state.custom.tags";
 
   protected static final GobblinMetricsRegistry GOBBLIN_METRICS_REGISTRY = GobblinMetricsRegistry.getInstance();

--- a/gobblin-metrics-libs/gobblin-metrics/src/main/java/org/apache/gobblin/metrics/GobblinMetricsRegistry.java
+++ b/gobblin-metrics-libs/gobblin-metrics/src/main/java/org/apache/gobblin/metrics/GobblinMetricsRegistry.java
@@ -17,11 +17,15 @@
 
 package org.apache.gobblin.metrics;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 import com.google.common.cache.Cache;
@@ -113,6 +117,21 @@ public class GobblinMetricsRegistry {
    */
   public static GobblinMetricsRegistry getInstance() {
     return GLOBAL_INSTANCE;
+  }
+
+  /**
+   * Retrieve the {@link GobblinMetrics} by check if the key in cache matches a given regex.
+   */
+  @VisibleForTesting
+  public Collection<GobblinMetrics> getMetricsByPattern(String regex) {
+    Map<String, GobblinMetrics> entries = this.metricsCache.asMap();
+    List<GobblinMetrics> rst = new ArrayList<>();
+    for (Map.Entry<String, GobblinMetrics> entry: entries.entrySet()) {
+      if (entry.getKey().matches(regex)) {
+        rst.add(entry.getValue());
+      }
+    }
+    return rst;
   }
 
   /**

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/TaskState.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/TaskState.java
@@ -311,6 +311,7 @@ public class TaskState extends WorkUnitState implements TaskProgress {
     this.jobId = text.toString().intern();
     text.readFields(in);
     this.taskId = text.toString().intern();
+    this.taskAttemptId = Optional.absent();
     this.setId(this.taskId);
     this.startTime = in.readLong();
     this.endTime = in.readLong();

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/util/ForkMetrics.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/util/ForkMetrics.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.gobblin.runtime.util;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+
+import com.google.common.collect.ImmutableList;
+
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.configuration.State;
+import org.apache.gobblin.metrics.GobblinMetrics;
+import org.apache.gobblin.metrics.MetricContext;
+import org.apache.gobblin.metrics.Tag;
+import org.apache.gobblin.runtime.TaskState;
+import org.apache.gobblin.runtime.fork.Fork;
+
+/**
+ * An extension to {@link GobblinMetrics} specifically for {@link Fork}.
+ */
+public class ForkMetrics extends GobblinMetrics {
+  private static final String FORK_METRICS_BRANCH_NAME_KEY = "forkBranchName";
+
+  protected ForkMetrics(TaskState taskState, int index) {
+    super(name(taskState, index), parentContextForFork(taskState), getForkMetricsTags(taskState, index));
+  }
+
+  private static MetricContext parentContextForFork(TaskState taskState) {
+    return TaskMetrics.get(METRICS_ID_PREFIX + taskState.getJobId() + "." + taskState.getTaskId()).getMetricContext();
+  }
+
+  public static ForkMetrics get(final TaskState taskState, int index) {
+    return (ForkMetrics) GOBBLIN_METRICS_REGISTRY.getOrDefault(name(taskState, index), new Callable<GobblinMetrics>() {
+      @Override
+      public GobblinMetrics call() throws Exception {
+        return new ForkMetrics(taskState, index);
+      }
+    });
+  }
+
+  /**
+   * Creates a unique {@link String} representing this branch.
+   */
+  private static String getForkMetricsId(State state, int index) {
+    return state.getProp(ConfigurationKeys.FORK_BRANCH_NAME_KEY + "." + index,
+        ConfigurationKeys.DEFAULT_FORK_BRANCH_NAME + index);
+  }
+
+  /**
+   * Creates a {@link List} of {@link Tag}s for a {@link Fork} instance. The {@link Tag}s are purely based on the
+   * index and the branch name.
+   */
+  private static List<Tag<?>> getForkMetricsTags(State state, int index) {
+    return ImmutableList.<Tag<?>>of(new Tag<>(FORK_METRICS_BRANCH_NAME_KEY, getForkMetricsId(state, index)));
+  }
+
+  /**
+   * Creates a {@link String} that is a concatenation of the {@link TaskMetrics#getName()} and
+   * {@link #getForkMetricsId(State, int)}.
+   */
+  protected static String name(TaskState taskState, int index) {
+    return METRICS_ID_PREFIX + taskState.getJobId() + "." + taskState.getTaskId() + "." + getForkMetricsId(taskState, index);
+  }
+}

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/util/JobMetrics.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/util/JobMetrics.java
@@ -65,7 +65,7 @@ public class JobMetrics extends GobblinMetrics {
 
   /**
    * Get a new {@link GobblinMetrics} instance for a given job.
-   * This method has been deprecated. Please consider to use {@link JobMetrics#get(String, String, CreatorTag)}
+   * @deprecated  use {@link JobMetrics#get(String, String, CreatorTag)} instead.
    *
    * @param jobName job name
    * @param jobId job ID
@@ -119,7 +119,7 @@ public class JobMetrics extends GobblinMetrics {
 
   /**
    * Get a {@link JobMetrics} instance for the job with the given {@link JobState} instance.
-   * This method has been deprecated. Please consider to use {@link JobMetrics#get(JobState, CreatorTag)}.
+   * @deprecated  use {@link JobMetrics#get(JobState, CreatorTag)} instead.
    *
    * @param jobState the given {@link JobState} instance
    * @return a {@link JobMetrics} instance

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/util/JobMetrics.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/util/JobMetrics.java
@@ -118,7 +118,7 @@ public class JobMetrics extends GobblinMetrics {
   }
 
   private static String name(JobState jobState) {
-    return "gobblin.metrics." + jobState.getJobId();
+    return METRICS_ID_PREFIX + jobState.getJobId();
   }
 
   private static List<Tag<?>> tagsForJob(JobState jobState) {

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/util/JobMetrics.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/util/JobMetrics.java
@@ -20,7 +20,11 @@ package org.apache.gobblin.runtime.util;
 import java.util.List;
 import java.util.concurrent.Callable;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 
 import org.apache.gobblin.metrics.GobblinMetrics;
 import org.apache.gobblin.metrics.MetricContext;
@@ -36,67 +40,112 @@ import org.apache.gobblin.util.ClustersNames;
  *
  * @author Yinan Li
  */
+@Slf4j
 public class JobMetrics extends GobblinMetrics {
 
+  public static final CreatorTag DEFAULT_CREATOR_TAG = new CreatorTag( "driver");
   protected final String jobName;
-
-  protected JobMetrics(JobState job) {
-    this(job, null);
+  @Getter
+  protected final CreatorTag creatorTag;
+  protected JobMetrics(JobState job, CreatorTag tag) {
+    this(job, null, tag);
   }
 
-  protected JobMetrics(JobState job, MetricContext parentContext) {
+  protected JobMetrics(JobState job, MetricContext parentContext, CreatorTag creatorTag) {
     super(name(job), parentContext, tagsForJob(job));
     this.jobName = job.getJobName();
+    this.creatorTag = creatorTag;
+  }
+
+  public static class CreatorTag extends Tag<String> {
+    public CreatorTag(String value) {
+      super("creator", value);
+    }
   }
 
   /**
    * Get a new {@link GobblinMetrics} instance for a given job.
+   * This method has been deprecated. Please consider to use {@link JobMetrics#get(String, String, CreatorTag)}
    *
    * @param jobName job name
    * @param jobId job ID
    * @return a new {@link GobblinMetrics} instance for the given job
    */
+  @Deprecated
   public static JobMetrics get(String jobName, String jobId) {
-    return get(new JobState(jobName, jobId));
+    return get(new JobState(jobName, jobId), DEFAULT_CREATOR_TAG);
   }
 
   /**
    * Get a new {@link GobblinMetrics} instance for a given job.
    *
+   * @param creatorTag the unique id which can tell who initiates this get operation
+   * @param jobName job name
+   * @param jobId job ID
+   * @param creatorTag who creates this job metrics
+   * @return a new {@link GobblinMetrics} instance for the given job
+   */
+  public static JobMetrics get(String jobName, String jobId, CreatorTag creatorTag) {
+    return get(new JobState(jobName, jobId), creatorTag);
+  }
+
+  /**
+   * Get a new {@link GobblinMetrics} instance for a given job.
+   *
+   * @param creatorTag the unique id which can tell who initiates this get operation
    * @param jobId job ID
    * @return a new {@link GobblinMetrics} instance for the given job
    */
-  public static JobMetrics get(String jobId) {
-    return get(null, jobId);
+  public static JobMetrics get(String jobId, CreatorTag creatorTag) {
+    return get(null, jobId, creatorTag);
   }
 
   /**
    * Get a new {@link GobblinMetrics} instance for a given job.
    *
+   * @param creatorTag the unique id which can tell who initiates this get operation
    * @param jobState the given {@link JobState} instance
    * @param parentContext is the parent {@link MetricContext}
    * @return a {@link JobMetrics} instance
    */
-  public static JobMetrics get(final JobState jobState, final MetricContext parentContext) {
+  public static JobMetrics get(final JobState jobState, final MetricContext parentContext, CreatorTag creatorTag) {
     return (JobMetrics) GOBBLIN_METRICS_REGISTRY.getOrDefault(name(jobState), new Callable<GobblinMetrics>() {
       @Override
       public GobblinMetrics call() throws Exception {
-        return new JobMetrics(jobState, parentContext);
+        return new JobMetrics(jobState, parentContext, creatorTag);
       }
     });
   }
 
   /**
    * Get a {@link JobMetrics} instance for the job with the given {@link JobState} instance.
+   * This method has been deprecated. Please consider to use {@link JobMetrics#get(JobState, CreatorTag)}.
    *
    * @param jobState the given {@link JobState} instance
    * @return a {@link JobMetrics} instance
    */
+  @Deprecated
   public static JobMetrics get(final JobState jobState) {
     return (JobMetrics) GOBBLIN_METRICS_REGISTRY.getOrDefault(name(jobState), new Callable<GobblinMetrics>() {
       @Override
       public GobblinMetrics call() throws Exception {
-        return new JobMetrics(jobState);
+        return new JobMetrics(jobState, DEFAULT_CREATOR_TAG);
+      }
+    });
+  }
+
+  /**
+   * Get a {@link JobMetrics} instance for the job with the given {@link JobState} instance and a creator tag.
+   *
+   * @param creatorTag the unique id which can tell who initiates this get operation
+   * @param jobState the given {@link JobState} instance
+   * @return a {@link JobMetrics} instance
+   */
+  public static JobMetrics get(final JobState jobState, CreatorTag creatorTag) {
+    return (JobMetrics) GOBBLIN_METRICS_REGISTRY.getOrDefault(name(jobState), new Callable<GobblinMetrics>() {
+      @Override
+      public GobblinMetrics call() throws Exception {
+        return new JobMetrics(jobState, creatorTag);
       }
     });
   }
@@ -106,7 +155,7 @@ public class JobMetrics extends GobblinMetrics {
    *
    * <p>
    *   Removing a {@link JobMetrics} instance for a job will also remove the {@link TaskMetrics}s
-   *   of every tasks of the job.
+   *   of every tasks of the job. This is only used by job driver where there is no {@link ForkMetrics}.
    * </p>
    * @param jobState the given {@link JobState} instance
    */
@@ -114,6 +163,23 @@ public class JobMetrics extends GobblinMetrics {
     remove(name(jobState));
     for (TaskState taskState : jobState.getTaskStates()) {
       TaskMetrics.remove(taskState);
+    }
+  }
+
+  /**
+   * Attempt to remove the {@link JobMetrics} instance for the job with the given jobId.
+   * It also checks the creator tag of this {@link JobMetrics}. If the given tag doesn't
+   * match the creator tag, this {@link JobMetrics} won't be removed.
+   */
+  public static void attemptRemove(String jobId, Tag matchTag) {
+    Optional<GobblinMetrics> gobblinMetricsOptional = GOBBLIN_METRICS_REGISTRY.get(
+        GobblinMetrics.METRICS_ID_PREFIX + jobId);
+    JobMetrics jobMetrics = gobblinMetricsOptional.isPresent()? (JobMetrics) (gobblinMetricsOptional.get()): null;
+
+    // only remove if the tag matches
+    if (jobMetrics != null && jobMetrics.getCreatorTag().equals(matchTag)) {
+      log.info("Removing job metrics because creator matches : " + matchTag.getValue());
+      GOBBLIN_METRICS_REGISTRY.remove(GobblinMetrics.METRICS_ID_PREFIX + jobId);
     }
   }
 

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/util/TaskMetrics.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/util/TaskMetrics.java
@@ -27,6 +27,7 @@ import org.apache.gobblin.metrics.GobblinMetrics;
 import org.apache.gobblin.metrics.MetricContext;
 import org.apache.gobblin.metrics.Tag;
 import org.apache.gobblin.metrics.event.TaskEvent;
+import org.apache.gobblin.runtime.Task;
 import org.apache.gobblin.runtime.TaskState;
 
 
@@ -61,6 +62,8 @@ public class TaskMetrics extends GobblinMetrics {
 
   /**
    * Remove the {@link TaskMetrics} instance for the task with the given {@link TaskMetrics} instance.
+   * Please note this method is invoked by job driver so it won't delete any underlying {@link ForkMetrics}
+   * because the {@link org.apache.gobblin.runtime.fork.Fork} can be created on different nodes.
    *
    * @param taskState the given {@link TaskState} instance
    */
@@ -68,8 +71,26 @@ public class TaskMetrics extends GobblinMetrics {
     remove(name(taskState));
   }
 
+  /**
+   * Remove the {@link TaskMetrics} instance for the task with the given {@link TaskMetrics} instance.
+   * Please note that this will also delete the underlying {@link ForkMetrics} related to this specific task.
+   *
+   * @param task the given task instance
+   */
+  public static void remove(Task task) {
+    task.getForks().forEach(forkOpt -> {
+      remove(ForkMetrics.name(task.getTaskState(), forkOpt.get().getIndex()));
+    });
+
+    remove(name(task));
+  }
+
   private static String name(TaskState taskState) {
-    return "gobblin.metrics." + taskState.getJobId() + "." + taskState.getTaskId();
+    return METRICS_ID_PREFIX + taskState.getJobId() + "." + taskState.getTaskId();
+  }
+
+  private static String name(Task task) {
+    return METRICS_ID_PREFIX + task.getJobId() + "." + task.getTaskId();
   }
 
   protected static List<Tag<?>> tagsForTask(TaskState taskState) {

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/util/TaskMetrics.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/util/TaskMetrics.java
@@ -90,7 +90,7 @@ public class TaskMetrics extends GobblinMetrics {
   }
 
   private static String name(Task task) {
-    return METRICS_ID_PREFIX + task.getJobId() + "." + task.getTaskId();
+    return name(task.getTaskState());
   }
 
   protected static List<Tag<?>> tagsForTask(TaskState taskState) {
@@ -104,7 +104,11 @@ public class TaskMetrics extends GobblinMetrics {
   }
 
   private static MetricContext parentContextForTask(TaskState taskState) {
-    return JobMetrics.get(taskState.getProp(ConfigurationKeys.JOB_NAME_KEY), taskState.getJobId()).getMetricContext();
+    return JobMetrics.get(
+        taskState.getProp(ConfigurationKeys.JOB_NAME_KEY),
+        taskState.getJobId(),
+        new JobMetrics.CreatorTag(taskState.getTaskId()))
+        .getMetricContext();
   }
 
   public static String taskInstanceRemoved(String metricName) {


### PR DESCRIPTION
Remove the metric context cache from GobblinMetricsRegistry

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-800


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
   1) Create the ForkMetrics that can be used by Fork constrct when creating the metric context.
   2) Add the clean up logic in the GobblinMultiTaskAttempt to remove the metrics context hold by GobblinMetricsRegistry.
   3) Fix the Nullpointer exception due to an uninitialized taskAttemptId field inside of the TaskState deserialization.
   4) Some string replacement (refactoring) for GobblinMetrics.
   5) Add the metrics cleanup validation in ClusterIntegrationTest
   6) Add the creatorTag inside JobMetrics. The removal can first check if the JobMetircs was created by the real creator; otherwise it just ignore the removal operation.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
   Rerun ClusterIntegrationTest
   Rerun MRJobLauncher test

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

