### PR TITLE
[GOBBLIN-805] Fix dag being cleaned twice

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
@@ -565,7 +565,7 @@ public class DagManager extends AbstractIdleService {
 
       //Clean up completed dags
       for (String dagId : this.dags.keySet()) {
-        if (!hasRunningJobs(dagId)) {
+        if (!hasRunningJobs(dagId) && !this.failedDagIdsFinishRunning.contains(dagId)) {
           String status = "COMPLETE";
           if (this.failedDagIdsFinishAllPossible.contains(dagId)) {
             status = "FAILED";

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagerTest.java
@@ -317,7 +317,7 @@ public class DagManagerTest {
     }
   }
 
-  @Test
+  @Test (dependsOnMethods = "testFailedDag")
   public void testSucceedAfterRetry() throws Exception {
     long flowExecutionId = System.currentTimeMillis();
     String flowGroupId = "0";
@@ -398,7 +398,7 @@ public class DagManagerTest {
     Assert.assertEquals(this._dagStateStore.getDags().size(), 0);
   }
 
-  @Test
+  @Test (dependsOnMethods = "testSucceedAfterRetry")
   public void testFailAfterRetry() throws Exception {
     long flowExecutionId = System.currentTimeMillis();
     String flowGroupId = "0";


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-805


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
- Fix bug where dag is attempted to be cleaned twice if failure option is FINISH_RUNNING
- Make unit test for dagManager use dependsOn to avoid concurrency issue in testing

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

