### PR TITLE
[GOBBLIN-806]Enable metrics reporter during dataset discovery for retention job

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/retention/profile/MultiCleanableDatasetFinder.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/retention/profile/MultiCleanableDatasetFinder.java
@@ -16,6 +16,7 @@
  */
 package org.apache.gobblin.data.management.retention.profile;
 
+import com.google.common.base.Optional;
 import org.apache.gobblin.data.management.retention.DatasetCleaner;
 
 import java.net.URI;
@@ -50,7 +51,7 @@ public class MultiCleanableDatasetFinder extends MultiDatasetFinder {
 
 
   public MultiCleanableDatasetFinder(FileSystem fs, Properties jobProps) {
-    super(fs, jobProps);
+    this(fs,jobProps,new EventSubmitter.Builder(Optional.absent(),"noMessage").build());
   }
 
   public MultiCleanableDatasetFinder(FileSystem fs, Properties jobProps, EventSubmitter eventSubmitter) {

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/retention/profile/MultiCleanableDatasetFinder.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/retention/profile/MultiCleanableDatasetFinder.java
@@ -21,6 +21,7 @@ import org.apache.gobblin.data.management.retention.DatasetCleaner;
 import java.net.URI;
 import java.util.Properties;
 
+import org.apache.gobblin.metrics.event.EventSubmitter;
 import org.apache.hadoop.fs.FileSystem;
 
 import com.typesafe.config.Config;
@@ -50,6 +51,10 @@ public class MultiCleanableDatasetFinder extends MultiDatasetFinder {
 
   public MultiCleanableDatasetFinder(FileSystem fs, Properties jobProps) {
     super(fs, jobProps);
+  }
+
+  public MultiCleanableDatasetFinder(FileSystem fs, Properties jobProps, EventSubmitter eventSubmitter) {
+    super(fs, jobProps, eventSubmitter);
   }
 
   @Override

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/retention/profile/MultiDatasetFinder.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/retention/profile/MultiDatasetFinder.java
@@ -16,6 +16,7 @@
  */
 package org.apache.gobblin.data.management.retention.profile;
 
+import com.google.common.base.Optional;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
@@ -26,7 +27,7 @@ import java.util.Properties;
 
 import lombok.extern.slf4j.Slf4j;
 
-import org.apache.commons.lang3.reflect.ConstructorUtils;
+import org.apache.gobblin.metrics.event.EventSubmitter;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
@@ -70,8 +71,11 @@ public abstract class MultiDatasetFinder implements DatasetsFinder<Dataset> {
 
   protected final Properties jobProps;
 
-  @SuppressWarnings({ "rawtypes", "unchecked" })
   public MultiDatasetFinder(FileSystem fs, Properties jobProps) {
+    this(fs,jobProps,new EventSubmitter.Builder(Optional.absent(),"noMessage").build());
+  }
+  @SuppressWarnings({ "rawtypes", "unchecked" })
+  public MultiDatasetFinder(FileSystem fs, Properties jobProps, EventSubmitter eventSubmitter) {
     this.jobProps = jobProps;
     try {
       this.datasetFinders = Lists.newArrayList();
@@ -79,10 +83,9 @@ public abstract class MultiDatasetFinder implements DatasetsFinder<Dataset> {
       if (jobProps.containsKey(datasetFinderClassKey())) {
         try {
           log.info(String.format("Instantiating datasetfinder %s ", jobProps.getProperty(datasetFinderClassKey())));
-          this.datasetFinders.add((DatasetsFinder) ConstructorUtils.invokeConstructor(
-              Class.forName(jobProps.getProperty(datasetFinderClassKey())), fs, jobProps));
-        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException | InstantiationException
-            | ClassNotFoundException e) {
+          this.datasetFinders.add((DatasetsFinder) GobblinConstructorUtils.invokeLongestConstructor(
+              Class.forName(jobProps.getProperty(datasetFinderClassKey())), fs, jobProps, eventSubmitter));
+        } catch ( ReflectiveOperationException e) {
           log.error(
               String.format("Retention ignored could not instantiate datasetfinder %s.",
                   jobProps.getProperty(datasetFinderClassKey())), e);

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/retention/profile/MultiDatasetFinder.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/retention/profile/MultiDatasetFinder.java
@@ -85,7 +85,7 @@ public abstract class MultiDatasetFinder implements DatasetsFinder<Dataset> {
           log.info(String.format("Instantiating datasetfinder %s ", jobProps.getProperty(datasetFinderClassKey())));
           this.datasetFinders.add((DatasetsFinder) GobblinConstructorUtils.invokeLongestConstructor(
               Class.forName(jobProps.getProperty(datasetFinderClassKey())), fs, jobProps, eventSubmitter));
-        } catch ( ReflectiveOperationException e) {
+        } catch (ReflectiveOperationException e) {
           log.error(
               String.format("Retention ignored could not instantiate datasetfinder %s.",
                   jobProps.getProperty(datasetFinderClassKey())), e);
@@ -109,7 +109,8 @@ public abstract class MultiDatasetFinder implements DatasetsFinder<Dataset> {
           try {
             this.datasetFinders.add((DatasetsFinder) GobblinConstructorUtils.invokeFirstConstructor(
                 Class.forName(datasetClassConfig.getString(datasetFinderClassKey())), ImmutableList.of(fs, jobProps,
-                    datasetClassConfig), ImmutableList.of(fs, jobProps)));
+                    datasetClassConfig), ImmutableList.of(fs, jobProps, eventSubmitter),
+                    ImmutableList.of(fs, jobProps)));
             log.info(String.format("Instantiated datasetfinder %s for %s.",
                 datasetClassConfig.getString(datasetFinderClassKey()), importedBy));
           } catch (InstantiationException | IllegalAccessException | IllegalArgumentException

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/retention/profile/MultiDatasetFinder.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/retention/profile/MultiDatasetFinder.java
@@ -71,6 +71,7 @@ public abstract class MultiDatasetFinder implements DatasetsFinder<Dataset> {
 
   protected final Properties jobProps;
 
+  @SuppressWarnings({ "rawtypes", "unchecked" })
   public MultiDatasetFinder(FileSystem fs, Properties jobProps) {
     this(fs,jobProps,new EventSubmitter.Builder(Optional.absent(),"noMessage").build());
   }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-806


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
 1. Change datasetCleaner to pass the eventSubmitter to dataset finder
 2. Change MultiDatasetFinder to enable datasetFinder with/without EventSubmitter

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Test on faro for both ConfigBasedCleanabledDatasetFinder and TMSBasedCleanableDatasetsFinder for retention job.

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

