### PR TITLE
[GOBBLIN-807] Added TimingEventBuilder and deprecated TimingEvent

### DIFF
--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/TimingEventBuilder.java
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/TimingEventBuilder.java
@@ -18,11 +18,13 @@
 package org.apache.gobblin.metrics.event;
 
 import org.apache.gobblin.metrics.GobblinTrackingEvent;
+import org.apache.gobblin.metrics.MetricContext;
 
 
 /**
  * A Builder that builds and can submit a {@link GobblinTrackingEvent }
- *
+ * It can be manually stopped by calling {@link #stop()}
+ * or will be automatically stopped when {@link #submit(MetricContext)} is called
  */
 public class TimingEventBuilder extends GobblinEventBuilder {
 
@@ -110,12 +112,12 @@ public class TimingEventBuilder extends GobblinEventBuilder {
   }
 
   /**
-   * stops the timer and returns a {@link GobblinTrackingEvent}
-   * @return {@link GobblinTrackingEvent}
+   * Stop the timer if not stopped already
+   * and submit the event
    */
   @Override
-  public GobblinTrackingEvent build() {
+  public void submit(MetricContext context) {
     stop();
-    return super.build();
+    super.submit(context);
   }
 }

--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/TimingEventBuilder.java
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/TimingEventBuilder.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.gobblin.metrics.event;
 
 import org.apache.gobblin.metrics.GobblinTrackingEvent;


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-807


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
1) Added TimingEventBuilder that extends the GobblinEventBuilder to standardize creating and submitting GobblinTrackingEvents
2) Deprecated TimingEvent 

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tested locally in FARO by creating timing events for Nuage API calls

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

