### PR TITLE
[GOBBLIN-809] Fix RateBasedLimitter factory to get double rate from config

### DIFF
--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/limiter/RateBasedLimiter.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/limiter/RateBasedLimiter.java
@@ -53,7 +53,7 @@ public class RateBasedLimiter extends NonRefillableLimiter {
       if (!config.hasPath(QPS_KEY)) {
         throw new RuntimeException("Missing key " + QPS_KEY);
       }
-      return new RateBasedLimiter(config.getLong(QPS_KEY));
+      return new RateBasedLimiter(config.getDouble(QPS_KEY));
     }
   }
 


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-XXX


### Description
- [x] Here are some details about my PR, including screenshots (if applicable): Fix RateBasedLimitter factory to get double instead of long rate for initialization


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: changed factory init method, UTs not required


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

