### PR TITLE
[GOBBLIN-814] Remove redundant dummy class in package-info

### DIFF
--- a/gobblin-config-management/gobblin-config-client/src/main/java/org/apache/gobblin/config/client/package-info.java
+++ b/gobblin-config-management/gobblin-config-client/src/main/java/org/apache/gobblin/config/client/package-info.java
@@ -19,7 +19,3 @@
  * This package contains the config config client implementation for Gobblin config management.
  */
 package org.apache.gobblin.config.client;
-
-//TODO: Remove once we commit any other classes
-class DummyClassForJavadoc {
-}


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-814


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
  
  In
  gobblin-config-management/gobblin-config-client/src/main/java/org/apache/gobblin/config/client/package-info.java,
  the class DummyClassForJavadoc is not needed anymore because other
  classes have been committed into the package, as specified by the todo
  comment.  The dummy class (and the comment) should be removed.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  
  My PR does not need testing because the dummy class is not used anywhere, and the Javadoc of that package can be generated without the dummy class normally as there are other classes in the package.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

