### PR TITLE
[GOBBLIN-825] Initialize message schema at object construction rather than creating a new instance for every message

### DIFF
--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/metrics/reporter/KeyValueEventObjectReporter.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/metrics/reporter/KeyValueEventObjectReporter.java
@@ -58,15 +58,10 @@ public class KeyValueEventObjectReporter extends EventReporter {
   protected List<String> keys;
   protected final String randomKey;
   protected KeyValuePusher pusher;
-  protected Optional<Map<String, String>> namespaceOverride;
-  protected final String topic;
   protected final Schema schema;
 
   public KeyValueEventObjectReporter(Builder builder) {
     super(builder);
-
-    this.topic = builder.topic;
-    this.namespaceOverride = builder.namespaceOverride;
 
     Config config = builder.config.get();
     Config pusherConfig = ConfigUtils.getConfigOrEmpty(config, PUSHER_CONFIG).withFallback(config);
@@ -87,7 +82,7 @@ public class KeyValueEventObjectReporter extends EventReporter {
           ConfigurationKeys.METRICS_REPORTING_EVENTS_PUSHERKEYS, randomKey);
     }
 
-    schema = AvroUtils.overrideNameAndNamespace(GobblinTrackingEvent.getClassSchema(), this.topic, this.namespaceOverride);
+    schema = AvroUtils.overrideNameAndNamespace(GobblinTrackingEvent.getClassSchema(), builder.topic, builder.namespaceOverride);
   }
 
   @Override

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/metrics/reporter/KeyValueEventObjectReporter.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/metrics/reporter/KeyValueEventObjectReporter.java
@@ -17,12 +17,14 @@
 
 package org.apache.gobblin.metrics.reporter;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Random;
 import java.util.StringJoiner;
 
+import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -58,6 +60,7 @@ public class KeyValueEventObjectReporter extends EventReporter {
   protected KeyValuePusher pusher;
   protected Optional<Map<String, String>> namespaceOverride;
   protected final String topic;
+  protected final Schema schema;
 
   public KeyValueEventObjectReporter(Builder builder) {
     super(builder);
@@ -83,17 +86,24 @@ public class KeyValueEventObjectReporter extends EventReporter {
           "Key not assigned from config. Please set it with property {} Using randomly generated number {} as key ",
           ConfigurationKeys.METRICS_REPORTING_EVENTS_PUSHERKEYS, randomKey);
     }
+
+    schema = AvroUtils.overrideNameAndNamespace(GobblinTrackingEvent.getClassSchema(), this.topic, this.namespaceOverride);
   }
 
   @Override
   public void reportEventQueue(Queue<GobblinTrackingEvent> queue) {
-    log.info("Emitting report using KeyValueEventObjectReporter");
 
     List<Pair<String, GenericRecord>> events = Lists.newArrayList();
     GobblinTrackingEvent event;
 
     while (null != (event = queue.poll())) {
-      GenericRecord record = AvroUtils.overrideNameAndNamespace(event, this.topic, this.namespaceOverride);
+
+      GenericRecord record=event;
+      try {
+        record = AvroUtils.convertRecordSchema(event, schema);
+      } catch (IOException e){
+        log.error("Unable to generate generic data record", e);
+      }
       events.add(Pair.of(buildKey(record), record));
     }
 

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/metrics/reporter/KeyValueMetricObjectReporter.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/metrics/reporter/KeyValueMetricObjectReporter.java
@@ -57,15 +57,10 @@ public class KeyValueMetricObjectReporter extends MetricReportReporter {
   private List<String> keys;
   protected final String randomKey;
   protected KeyValuePusher pusher;
-  private Optional<Map<String, String>> namespaceOverride;
-  protected final String topic;
   protected final Schema schema;
 
   public KeyValueMetricObjectReporter(Builder builder, Config config) {
     super(builder, config);
-
-    this.topic = builder.topic;
-    this.namespaceOverride = builder.namespaceOverride;
 
     Config pusherConfig = ConfigUtils.getConfigOrEmpty(config, PUSHER_CONFIG).withFallback(config);
     String pusherClassName =
@@ -85,7 +80,7 @@ public class KeyValueMetricObjectReporter extends MetricReportReporter {
           ConfigurationKeys.METRICS_REPORTING_PUSHERKEYS, randomKey);
     }
 
-    schema = AvroUtils.overrideNameAndNamespace(MetricReport.getClassSchema(), this.topic, this.namespaceOverride);
+    schema = AvroUtils.overrideNameAndNamespace(MetricReport.getClassSchema(), builder.topic, builder.namespaceOverride);
   }
 
   @Override

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/metrics/reporter/KeyValueMetricObjectReporter.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/metrics/reporter/KeyValueMetricObjectReporter.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.StringJoiner;
 
+import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -36,7 +37,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.metrics.MetricReport;
 import org.apache.gobblin.metrics.kafka.PusherUtils;
-import org.apache.gobblin.metrics.reporter.MetricReportReporter;
 import org.apache.gobblin.util.AvroUtils;
 import org.apache.gobblin.util.ConfigUtils;
 
@@ -59,6 +59,7 @@ public class KeyValueMetricObjectReporter extends MetricReportReporter {
   protected KeyValuePusher pusher;
   private Optional<Map<String, String>> namespaceOverride;
   protected final String topic;
+  protected final Schema schema;
 
   public KeyValueMetricObjectReporter(Builder builder, Config config) {
     super(builder, config);
@@ -83,11 +84,19 @@ public class KeyValueMetricObjectReporter extends MetricReportReporter {
           "Key not assigned from config. Please set it with property {} Using randomly generated number {} as key ",
           ConfigurationKeys.METRICS_REPORTING_PUSHERKEYS, randomKey);
     }
+
+    schema = AvroUtils.overrideNameAndNamespace(MetricReport.getClassSchema(), this.topic, this.namespaceOverride);
   }
 
   @Override
   protected void emitReport(MetricReport report) {
-    GenericRecord record = AvroUtils.overrideNameAndNamespace(report, this.topic, this.namespaceOverride);
+    GenericRecord record = report;
+    try {
+      record = AvroUtils.convertRecordSchema(report, schema);
+    } catch (IOException e){
+      log.error("Unable to generate generic data record", e);
+      return;
+    }
     this.pusher.pushKeyValueMessages(Lists.newArrayList(Pair.of(buildKey(record), record)));
   }
 

--- a/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/metrics/reporter/KeyValueEventObjectReporterTest.java
+++ b/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/metrics/reporter/KeyValueEventObjectReporterTest.java
@@ -106,6 +106,7 @@ public class KeyValueEventObjectReporterTest extends KeyValueEventObjectReporter
     Assert.assertEquals(retrievedEvent.getValue().get("name"), eventName);
     int partition = Integer.parseInt(retrievedEvent.getKey());
     Assert.assertTrue((0 <= partition && partition <= 99));
+    Assert.assertTrue(retrievedEvent.getValue().getSchema() == reporter.schema);
   }
 
   private static Pair<String, GenericRecord> nextKVEvent(Iterator<Pair<String, GenericRecord>> it) {

--- a/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/metrics/reporter/KeyValueMetricObjectReporterTest.java
+++ b/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/metrics/reporter/KeyValueMetricObjectReporterTest.java
@@ -23,6 +23,7 @@ import java.util.Properties;
 
 import org.apache.avro.generic.GenericRecord;
 import org.apache.commons.lang3.tuple.Pair;
+import org.codehaus.jackson.annotate.JsonTypeInfo;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -95,6 +96,7 @@ public class KeyValueMetricObjectReporterTest extends KeyValueMetricObjectReport
     Assert.assertEquals(retrievedEvent.getValue().getSchema().getName(), name);
     int partition = Integer.parseInt(retrievedEvent.getKey());
     Assert.assertTrue((0 <= partition && partition <= 99));
+    Assert.assertTrue(retrievedEvent.getValue().getSchema() == reporter.schema);
 
     reporter.close();
   }

--- a/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/metrics/reporter/KeyValueMetricObjectReporterTest.java
+++ b/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/metrics/reporter/KeyValueMetricObjectReporterTest.java
@@ -23,7 +23,6 @@ import java.util.Properties;
 
 import org.apache.avro.generic.GenericRecord;
 import org.apache.commons.lang3.tuple.Pair;
-import org.codehaus.jackson.annotate.JsonTypeInfo;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/AvroUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/AvroUtils.java
@@ -899,7 +899,7 @@ public class AvroUtils {
    * @param input input record who's name and namespace need to be overridden
    * @param nameOverride new name for the record schema
    * @param namespaceOverride Optional map containing namespace overrides
-   * @return an output record with overriden name and possibly namespace
+   * @return an output record with overridden name and possibly namespace
    */
   public static GenericRecord overrideNameAndNamespace(GenericRecord input, String nameOverride, Optional<Map<String, String>> namespaceOverride) {
 
@@ -916,6 +916,23 @@ public class AvroUtils {
     }
 
     return output;
+  }
+
+  /**
+   * Given a input schema, Override the name and namespace of the schema and return a new schema
+   * @param input
+   * @param nameOverride
+   * @param namespaceOverride
+   * @return a schema with overridden name and possibly namespace
+   */
+  public static Schema overrideNameAndNamespace(Schema input, String nameOverride, Optional<Map<String, String>> namespaceOverride) {
+
+    Schema newSchema = switchName(input, nameOverride);
+    if(namespaceOverride.isPresent()) {
+      newSchema = switchNamespace(newSchema, namespaceOverride.get());
+    }
+
+    return newSchema;
   }
 
 }

--- a/gobblin-utility/src/test/java/org/apache/gobblin/util/AvroUtilsTest.java
+++ b/gobblin-utility/src/test/java/org/apache/gobblin/util/AvroUtilsTest.java
@@ -514,4 +514,25 @@ public class AvroUtilsTest {
 
   }
 
+  @Test
+  public void overrideSchemaNameAndNamespaceTest() {
+    String inputName = "input_name";
+    String inputNamespace = "input_namespace";
+    String outputName = "output_name";
+    String outputNamespace = "output_namespace";
+
+    Schema inputSchema = SchemaBuilder.record(inputName).namespace(inputNamespace).fields()
+        .name("integer1")
+        .type().intBuilder().endInt().noDefault()
+        .endRecord();
+
+    Map<String,String> namespaceOverrideMap = new HashMap<>();
+    namespaceOverrideMap.put(inputNamespace, outputNamespace);
+
+    Schema newSchema = AvroUtils.overrideNameAndNamespace(inputSchema, outputName, Optional.of(namespaceOverrideMap));
+
+    Assert.assertEquals(newSchema.getName(), outputName);
+    Assert.assertEquals(newSchema.getNamespace(), outputNamespace);
+  }
+
 }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-825


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
An issue with a schema registry client caused this issue. This issue fixes the creation of new instances of the same schema for every message sent. Instead we now create an instance of the schema during object construction and use the same schema instance for all the messages.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
- overrideSchemaNameAndNamespaceTest in AvroUtilsTest.java
- KeyValueEventObjectReporterTest.java
- KeyValueMetricObjectReporterTest.java

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

