### PR TITLE
[GOBBLIN-833] Make SFTP connection timeout-table

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/sftp/SftpFsHelper.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/sftp/SftpFsHelper.java
@@ -64,6 +64,9 @@ public class SftpFsHelper implements TimestampAwareFileBasedHelper {
   private Session session;
   private State state;
 
+  private static final String SFTP_CONNECTION_TIMEOUT_KEY = "sftpConn.timeout";
+  private static final int DEFAULT_SFTP_CONNECTION_TIMEOUT = 3000;
+
   public SftpFsHelper(State state) {
 
     this.state = state;
@@ -99,7 +102,10 @@ public class SftpFsHelper implements TimestampAwareFileBasedHelper {
 
     try {
       ChannelSftp channelSftp = (ChannelSftp) this.session.openChannel("sftp");
-      channelSftp.connect();
+
+      // In millsec
+      int connTimeout = state.getPropAsInt(SFTP_CONNECTION_TIMEOUT_KEY, DEFAULT_SFTP_CONNECTION_TIMEOUT);
+      channelSftp.connect(connTimeout);
       return channelSftp;
     } catch (JSchException e) {
       throw new SftpException(0, "Cannot open a channel to SFTP server", e);


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA]
    - https://issues.apache.org/jira/browse/GOBBLIN-833


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Simple change to make `connect()` method subject to a timeout passed in as a parameter.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

