### PR TITLE
[GOBBLIN-851] Provide capability to disable Hive partition schema registration.

### DIFF
--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/HiveRegistrationUnit.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/HiveRegistrationUnit.java
@@ -50,6 +50,7 @@ public class HiveRegistrationUnit {
 
   protected final String dbName;
   protected final String tableName;
+  protected final boolean registerSchema;
   protected final List<Column> columns = Lists.newArrayList();
   protected final State props = new State();
   protected final State storageProps = new State();
@@ -85,6 +86,7 @@ public class HiveRegistrationUnit {
 
     this.dbName = builder.dbName;
     this.tableName = builder.tableName;
+    this.registerSchema = builder.registerSchema;
     this.columns.addAll(builder.columns);
     this.props.addAll(builder.props);
     this.storageProps.addAll(builder.storageProps);
@@ -400,6 +402,7 @@ public class HiveRegistrationUnit {
   static abstract class Builder<T extends Builder<?>> {
     private String dbName;
     private String tableName;
+    private boolean registerSchema = true;
     private List<Column> columns = Lists.newArrayList();
     private State props = new State();
     private State storageProps = new State();
@@ -415,6 +418,11 @@ public class HiveRegistrationUnit {
     @SuppressWarnings("unchecked")
     public T withTableName(String tableName) {
       this.tableName = tableName;
+      return (T) this;
+    }
+
+    public T withRegisterSchema(boolean registerSchema) {
+      this.registerSchema = registerSchema;
       return (T) this;
     }
 

--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/avro/HiveAvroSerDeManager.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/avro/HiveAvroSerDeManager.java
@@ -122,8 +122,7 @@ public class HiveAvroSerDeManager extends HiveSerDeManager {
     hiveUnit.setSerDeType(this.serDeWrapper.getSerDe().getClass().getName());
     hiveUnit.setInputFormat(this.serDeWrapper.getInputFormatClassName());
     hiveUnit.setOutputFormat(this.serDeWrapper.getOutputFormatClassName());
-
-    addSchemaProperties(path, hiveUnit, schema);
+    addSchemaPropertiesIfRequired(path, hiveUnit, schema);
   }
 
   @Override
@@ -145,13 +144,15 @@ public class HiveAvroSerDeManager extends HiveSerDeManager {
     }
   }
 
-  private void addSchemaProperties(Path path, HiveRegistrationUnit hiveUnit, Schema schema) throws IOException {
-    Path schemaFile = new Path(path, this.schemaFileName);
-    if (this.useSchemaFile) {
-      hiveUnit.setSerDeProp(SCHEMA_URL, schemaFile.toString());
-    } else {
-      try (Timer.Context context = metricContext.timer(HIVE_SPEC_SCHEMA_WRITING_TIMER).time()) {
-        addSchemaFromAvroFile(schema, schemaFile, hiveUnit);
+  private void addSchemaPropertiesIfRequired(Path path, HiveRegistrationUnit hiveUnit, Schema schema) throws IOException {
+    if (hiveUnit.isRegisterSchema()) {
+      Path schemaFile = new Path(path, this.schemaFileName);
+      if (this.useSchemaFile) {
+        hiveUnit.setSerDeProp(SCHEMA_URL, schemaFile.toString());
+      } else {
+        try (Timer.Context context = metricContext.timer(HIVE_SPEC_SCHEMA_WRITING_TIMER).time()) {
+          addSchemaFromAvroFile(schema, schemaFile, hiveUnit);
+        }
       }
     }
   }

--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/metastore/HiveMetaStoreUtils.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/metastore/HiveMetaStoreUtils.java
@@ -211,7 +211,7 @@ public class HiveMetaStoreUtils {
     State props = unit.getStorageProps();
     StorageDescriptor sd = new StorageDescriptor();
     sd.setParameters(getParameters(props));
-    if (unit instanceof HiveTable) {
+    if (unit.isRegisterSchema()) {
       sd.setCols(getFieldSchemas(unit));
     }
     if (unit.getLocation().isPresent()) {

--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/metastore/HiveMetaStoreUtils.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/metastore/HiveMetaStoreUtils.java
@@ -211,7 +211,9 @@ public class HiveMetaStoreUtils {
     State props = unit.getStorageProps();
     StorageDescriptor sd = new StorageDescriptor();
     sd.setParameters(getParameters(props));
-    sd.setCols(getFieldSchemas(unit));
+    if (unit instanceof HiveTable) {
+      sd.setCols(getFieldSchemas(unit));
+    }
     if (unit.getLocation().isPresent()) {
       sd.setLocation(unit.getLocation().get());
     }

--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/EventSubmitter.java
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/EventSubmitter.java
@@ -87,7 +87,9 @@ public class EventSubmitter {
     if(eventBuilder.namespace == null) {
       eventBuilder.setNamespace(this.namespace);
     }
-    this.metricContext.get().submitEvent(eventBuilder.build());
+    if (metricContext.isPresent()) {
+      this.metricContext.get().submitEvent(eventBuilder.build());
+    }
   }
 
   /**


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-851


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
We had problems when table level schema and partition level schema diverges. Think about the case when user register two partitions : 2019/08/10, 2019/08/11, but schema changes in between(S1->S2). Now the table level has schema S2, but 2019/08/10 will have schema S1. 

Query on the latest schema will cause the old partition failure.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
   Unit tests in gobblin-hive-registration module.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

