### PR TITLE
[GOBBLIN-852]Reorganize the code for hive registration to isolate function

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/publisher/HiveRegistrationPublisher.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/publisher/HiveRegistrationPublisher.java
@@ -143,11 +143,12 @@ public class HiveRegistrationPublisher extends DataPublisher {
 
         final HiveRegistrationPolicy policy = HiveRegistrationPolicyBase.getPolicy(taskSpecificState);
         for ( final String path : state.getPropAsList(ConfigurationKeys.PUBLISHER_DIRS) ) {
-          if (isPathDedupeEnabled && pathsToRegisterFromSingleState.contains(path)){
-            continue;
-          }
-          if(isPathDedupeEnabled) {
-            pathsToRegisterFromSingleState.add(path);
+          if (isPathDedupeEnabled){
+            if (pathsToRegisterFromSingleState.contains(path)) {
+              continue;
+            } else {
+              pathsToRegisterFromSingleState.add(path);
+            }
           }
           toRegisterPathCount += 1;
           completionService.submit(new Callable<Collection<HiveSpec>>() {

--- a/gobblin-core/src/main/java/org/apache/gobblin/publisher/HiveRegistrationPublisher.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/publisher/HiveRegistrationPublisher.java
@@ -76,9 +76,9 @@ public class HiveRegistrationPublisher extends DataPublisher {
   private static final boolean DEFAULT_PATH_DEDUPE_ENABLED = true;
 
   private final Closer closer = Closer.create();
-  private final HiveRegister hiveRegister;
-  private final ExecutorService hivePolicyExecutor;
-  private final MetricContext metricContext;
+  protected final HiveRegister hiveRegister;
+  protected final ExecutorService hivePolicyExecutor;
+  protected final MetricContext metricContext;
 
   /**
    * The configuration to determine if path deduplication should be enabled during Hive Registration process.
@@ -88,7 +88,7 @@ public class HiveRegistrationPublisher extends DataPublisher {
    *
    * e.g. In streaming mode, there could be cases that files(e.g. avro) under single topic folder carry different schema.
    */
-  private boolean isPathDedupeEnabled;
+  protected boolean isPathDedupeEnabled;
 
   /**
    * Make the deduplication of path to be registered in the Publisher level,
@@ -118,6 +118,51 @@ public class HiveRegistrationPublisher extends DataPublisher {
     }
   }
 
+  protected int computeSpecs(Collection<? extends WorkUnitState> states, CompletionService<Collection<HiveSpec>> completionService) {
+    // Each state in states is task-level State, while superState is the Job-level State.
+    // Using both State objects to distinguish each HiveRegistrationPolicy so that
+    // they can carry task-level information to pass into Hive Partition and its corresponding Hive Table.
+
+    // Here all runtime task-level props are injected into superstate which installed in each Policy Object.
+    // runtime.props are comma-separated props collected in runtime.
+    int toRegisterPathCount = 0;
+    for (State state:states) {
+      State taskSpecificState = state;
+      if (state.contains(ConfigurationKeys.PUBLISHER_DIRS)) {
+
+        // Upstream data attribute is specified, need to inject these info into superState as runtimeTableProps.
+        if (this.hiveRegister.getProps().getUpstreamDataAttrName().isPresent()) {
+          for (String attrName:
+              LIST_SPLITTER_COMMA.splitToList(this.hiveRegister.getProps().getUpstreamDataAttrName().get())){
+            if (state.contains(attrName)) {
+              taskSpecificState.appendToListProp(HiveMetaStoreUtils.RUNTIME_PROPS,
+                  attrName + ":" + state.getProp(attrName));
+            }
+          }
+        }
+
+        final HiveRegistrationPolicy policy = HiveRegistrationPolicyBase.getPolicy(taskSpecificState);
+        for ( final String path : state.getPropAsList(ConfigurationKeys.PUBLISHER_DIRS) ) {
+          if (isPathDedupeEnabled && pathsToRegisterFromSingleState.contains(path)){
+            continue;
+          }
+          if(isPathDedupeEnabled) {
+            pathsToRegisterFromSingleState.add(path);
+          }
+          toRegisterPathCount += 1;
+          completionService.submit(new Callable<Collection<HiveSpec>>() {
+            @Override
+            public Collection<HiveSpec> call() throws Exception {
+              try (Timer.Context context = metricContext.timer(HIVE_SPEC_COMPUTATION_TIMER).time()) {
+                return policy.getHiveSpecs(new Path(path));
+              }
+            }
+          });
+        }
+      }
+    }
+    return toRegisterPathCount;
+  }
   @Deprecated
   @Override
   public void initialize() throws IOException {}
@@ -130,47 +175,7 @@ public class HiveRegistrationPublisher extends DataPublisher {
     CompletionService<Collection<HiveSpec>> completionService =
         new ExecutorCompletionService<>(this.hivePolicyExecutor);
 
-    // Each state in states is task-level State, while superState is the Job-level State.
-    // Using both State objects to distinguish each HiveRegistrationPolicy so that
-    // they can carry task-level information to pass into Hive Partition and its corresponding Hive Table.
-
-    // Here all runtime task-level props are injected into superstate which installed in each Policy Object.
-    // runtime.props are comma-separated props collected in runtime.
-    int toRegisterPathCount = 0 ;
-    for (State state:states) {
-      State taskSpecificState = state;
-      if (state.contains(ConfigurationKeys.PUBLISHER_DIRS)) {
-
-        // Upstream data attribute is specified, need to inject these info into superState as runtimeTableProps.
-        if (this.hiveRegister.getProps().getUpstreamDataAttrName().isPresent()) {
-          for (String attrName:
-              LIST_SPLITTER_COMMA.splitToList(this.hiveRegister.getProps().getUpstreamDataAttrName().get())){
-            if (state.contains(attrName)) {
-              taskSpecificState.appendToListProp(HiveMetaStoreUtils.RUNTIME_PROPS,
-                    attrName + ":" + state.getProp(attrName));
-            }
-          }
-        }
-
-        final HiveRegistrationPolicy policy = HiveRegistrationPolicyBase.getPolicy(taskSpecificState);
-        for ( final String path : state.getPropAsList(ConfigurationKeys.PUBLISHER_DIRS) ) {
-          if (isPathDedupeEnabled && pathsToRegisterFromSingleState.contains(path)){
-            continue;
-          }
-          pathsToRegisterFromSingleState.add(path);
-          toRegisterPathCount += 1;
-          completionService.submit(new Callable<Collection<HiveSpec>>() {
-            @Override
-            public Collection<HiveSpec> call() throws Exception {
-              try (Timer.Context context = metricContext.timer(HIVE_SPEC_COMPUTATION_TIMER).time()) {
-                return policy.getHiveSpecs(new Path(path));
-              }
-            }
-          });
-        }
-      }
-      else continue;
-    }
+    int toRegisterPathCount = computeSpecs(states, completionService);
     for (int i = 0; i < toRegisterPathCount; i++) {
       try {
         for (HiveSpec spec : completionService.take().get()) {


### PR DESCRIPTION

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [GOBBLIN-852](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-852


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Reorganize HiveRegistrationPublisher to isolate function. And make some filed protected to be reused in the subclass. 

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Run streaming job on azkaban.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

