### PR TITLE
return the message instead of the value part of the message

### DIFF
--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaExtractor.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaExtractor.java
@@ -341,9 +341,9 @@ public abstract class KafkaExtractor<S, D> extends EventBasedExtractor<S, D> {
    * @return the converted record
    * @throws IOException
    */
-  protected D convertRecord(D record) throws IOException {
+  protected D convertRecord(DecodeableKafkaRecord record) throws IOException {
     // default implementation does no conversion
-    return record;
+    return record.getValue();
   }
 
   @Override

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaExtractor.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaExtractor.java
@@ -207,13 +207,8 @@ public abstract class KafkaExtractor<S, D> extends EventBasedExtractor<S, D> {
           if (nextValidMessage instanceof ByteArrayBasedKafkaRecord) {
             record = decodeRecord((ByteArrayBasedKafkaRecord)nextValidMessage);
           } else if (nextValidMessage instanceof DecodeableKafkaRecord){
-            // if value is null then this is a bad record that is returned for further error handling, so raise an error
-            if (((DecodeableKafkaRecord) nextValidMessage).getValue() == null) {
-              throw new DataRecordException("Could not decode Kafka record");
-            }
-
             // get value from decodeable record and convert to the output schema if necessary
-            record = convertRecord(((DecodeableKafkaRecord<?, D>) nextValidMessage).getValue());
+            record = convertRecord(((DecodeableKafkaRecord<?, D>) nextValidMessage));
           } else {
             throw new IllegalStateException(
                 "Unsupported KafkaConsumerRecord type. The returned record can either be ByteArrayBasedKafkaRecord"

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaExtractor.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaExtractor.java
@@ -208,7 +208,7 @@ public abstract class KafkaExtractor<S, D> extends EventBasedExtractor<S, D> {
             record = decodeRecord((ByteArrayBasedKafkaRecord)nextValidMessage);
           } else if (nextValidMessage instanceof DecodeableKafkaRecord){
             // get value from decodeable record and convert to the output schema if necessary
-            record = convertRecord(((DecodeableKafkaRecord<?, D>) nextValidMessage));
+            record = convertRecord((DecodeableKafkaRecord<?, D>) nextValidMessage);
           } else {
             throw new IllegalStateException(
                 "Unsupported KafkaConsumerRecord type. The returned record can either be ByteArrayBasedKafkaRecord"
@@ -341,7 +341,7 @@ public abstract class KafkaExtractor<S, D> extends EventBasedExtractor<S, D> {
    * @return the converted record
    * @throws IOException
    */
-  protected D convertRecord(DecodeableKafkaRecord record) throws IOException {
+  protected D convertRecord(DecodeableKafkaRecord<?,D> record) throws IOException {
     // default implementation does no conversion
     return record.getValue();
   }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

for the flexibility to manipulate the kafka message in the later stage, it would be nice to just return the entire message than the partial one