### PR TITLE
[GOBBLIN-863]Handle race condition issue for hive registration

### DIFF
--- a/gobblin-docs/user-guide/Configuration-Properties-Glossary.md
+++ b/gobblin-docs/user-guide/Configuration-Properties-Glossary.md
@@ -98,7 +98,7 @@ These properties are common to both the Job Launcher and the Command Line.
 | `job.group` | A way to group logically similar jobs together. | No | None |
 | `job.description` | A description of what the jobs does. | No | None |
 | `job.lock.enabled` | If set to true job locks are enabled, if set to false they are disabled | No | True |
-| `job.lock.type` | The fully qualified name of the JobLock class to run. The JobLock is responsible for ensuring that only a single instance of a job runs at a time. <br><br> Allowed values: [gobblin.runtime.locks.FfiFileBasedJobLock](#FileBasedJobLock-Properties), [gobblin.runtime.locks.ZookeeperBasedJobLock](#ZookeeperBasedJobLock-Properties) | No | `gobblin.runtime.locks.FileBasedJobLock` |
+| `job.lock.type` | The fully qualified name of the JobLock class to run. The JobLock is responsible for ensuring that only a single instance of a job runs at a time. <br><br> Allowed values: [gobblin.runtime.locks.FileBasedJobLock](#FileBasedJobLock-Properties), [gobblin.runtime.locks.ZookeeperBasedJobLock](#ZookeeperBasedJobLock-Properties) | No | `gobblin.runtime.locks.FileBasedJobLock` |
 | `job.runonce` | A boolean specifying whether the job will be only once, or multiple times. If set to true the job will only be run once even if a job.schedule is specified. If set to false and a job.schedule is specified then it will run according to the schedule. If set false and a job.schedule is not specified, it will run only once. | No | False |
 | `job.disabled` | Whether the job is disabled or not. If set to true, then Gobblin will not run this job. | No | False |
 

--- a/gobblin-docs/user-guide/Configuration-Properties-Glossary.md
+++ b/gobblin-docs/user-guide/Configuration-Properties-Glossary.md
@@ -98,7 +98,7 @@ These properties are common to both the Job Launcher and the Command Line.
 | `job.group` | A way to group logically similar jobs together. | No | None |
 | `job.description` | A description of what the jobs does. | No | None |
 | `job.lock.enabled` | If set to true job locks are enabled, if set to false they are disabled | No | True |
-| `job.lock.type` | The fully qualified name of the JobLock class to run. The JobLock is responsible for ensuring that only a single instance of a job runs at a time. <br><br> Allowed values: [gobblin.runtime.locks.FileBasedJobLock](#FileBasedJobLock-Properties), [gobblin.runtime.locks.ZookeeperBasedJobLock](#ZookeeperBasedJobLock-Properties) | No | `gobblin.runtime.locks.FileBasedJobLock` |
+| `job.lock.type` | The fully qualified name of the JobLock class to run. The JobLock is responsible for ensuring that only a single instance of a job runs at a time. <br><br> Allowed values: [gobblin.runtime.locks.FfiFileBasedJobLock](#FileBasedJobLock-Properties), [gobblin.runtime.locks.ZookeeperBasedJobLock](#ZookeeperBasedJobLock-Properties) | No | `gobblin.runtime.locks.FileBasedJobLock` |
 | `job.runonce` | A boolean specifying whether the job will be only once, or multiple times. If set to true the job will only be run once even if a job.schedule is specified. If set to false and a job.schedule is specified then it will run according to the schedule. If set false and a job.schedule is not specified, it will run only once. | No | False |
 | `job.disabled` | Whether the job is disabled or not. If set to true, then Gobblin will not run this job. | No | False |
 

--- a/gobblin-docs/user-guide/Gobblin-on-Yarn.md
+++ b/gobblin-docs/user-guide/Gobblin-on-Yarn.md
@@ -225,7 +225,7 @@ qualitychecker.row.err.file=${gobblin.yarn.work.dir}/err
 
 # Use zookeeper for maintaining the job lock
 job.lock.enabled=true
-job.lock.type=org.apache.gobblin.runtime.locks.ZookeeperBasedJobLock
+job.lock.type=ZookeeperBasedJobLock
 
 # Directory where job locks are stored
 job.lock.dir=${gobblin.yarn.work.dir}/locks

--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/AutoCloseableHiveLock.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/AutoCloseableHiveLock.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.hive;
+
+import java.io.IOException;
+
+
+/**
+ * An autoCloseable hive lock. Use a {@link HiveLockImpl} as real lock, but will unlock automatically when close
+ */
+public class AutoCloseableHiveLock implements AutoCloseable {
+
+  private final HiveLockImpl lock;
+
+  public AutoCloseableHiveLock(HiveLockImpl lock) throws IOException {
+    this.lock = lock;
+    this.lock.lock();
+  }
+
+  @Override
+  public void close() throws IOException{
+    this.lock.unlock();
+  }
+}

--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/HiveLockFactory.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/HiveLockFactory.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.hive;
+
+import com.google.common.util.concurrent.Striped;
+import java.io.IOException;
+import java.util.Properties;
+import java.util.concurrent.locks.Lock;
+
+
+/**
+ * A lock factory that provide a get method for a HiveLockImpl for a specific object
+ */
+public class HiveLockFactory {
+  protected Properties properties;
+  private final Striped<Lock> locks = Striped.lazyWeakLock(Integer.MAX_VALUE);
+  public HiveLockFactory(Properties _properties) {
+    this.properties = _properties;
+
+  }
+  public HiveLockImpl get(String name) {
+
+    return new HiveLockImpl<Lock>(locks.get(name)) {
+      @Override
+      public void lock() throws IOException {
+        this.lock.lock();
+      }
+
+      @Override
+      public void unlock() throws IOException {
+        this.lock.unlock();
+      }
+    };
+  }
+}

--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/HiveLockImpl.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/HiveLockImpl.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.hive;
+
+import java.io.IOException;
+
+
+/**
+ * A wrapper lock to be used by hive.
+ * @param <T> The class of the real lock
+ */
+public abstract class HiveLockImpl<T> {
+  public T lock;
+  public HiveLockImpl(T _lock){
+    this.lock = _lock;
+  }
+  public abstract void lock() throws IOException;
+  public abstract void unlock() throws IOException;
+}

--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/HiveLockImpl.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/HiveLockImpl.java
@@ -25,7 +25,7 @@ import java.io.IOException;
  * @param <T> The class of the real lock
  */
 public abstract class HiveLockImpl<T> {
-  public T lock;
+  protected T lock;
   public HiveLockImpl(T _lock){
     this.lock = _lock;
   }

--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/metastore/HiveMetaStoreBasedRegister.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/metastore/HiveMetaStoreBasedRegister.java
@@ -29,6 +29,7 @@ import java.util.concurrent.ExecutionException;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+import org.apache.gobblin.hive.AutoCloseableHiveLock;
 import org.apache.gobblin.kafka.schemareg.KafkaSchemaRegistry;
 import org.apache.gobblin.kafka.schemareg.KafkaSchemaRegistryFactory;
 import org.apache.gobblin.kafka.schemareg.SchemaRegistryException;
@@ -64,7 +65,6 @@ import org.apache.gobblin.metrics.GobblinMetrics;
 import org.apache.gobblin.metrics.GobblinMetricsRegistry;
 import org.apache.gobblin.metrics.MetricContext;
 import org.apache.gobblin.metrics.event.EventSubmitter;
-import org.apache.gobblin.util.AutoCloseableLock;
 import org.apache.gobblin.util.AutoReturnableObject;
 
 
@@ -102,7 +102,7 @@ public class HiveMetaStoreBasedRegister extends HiveRegister {
   public static final String DROP_TABLE = HIVE_REGISTER_METRICS_PREFIX + "dropTableTimer";
   public static final String PATH_REGISTER_TIMER = HIVE_REGISTER_METRICS_PREFIX + "pathRegisterTimer";
   public static final String SKIP_PARTITION_DIFF_COMPUTATION = HIVE_REGISTER_METRICS_PREFIX + "skip.partition.diff.computation";
-  public static final String FETCH_LATEST_SCHEMA = HIVE_REGISTER_METRICS_PREFIX + "fetch.latest.schema";
+  public static final String FETCH_LATEST_SCHEMA = HIVE_REGISTER_METRICS_PREFIX + "fetchLatestSchemaFromSchemaRegistry";
   /**
    * To reduce lock aquisition and RPC to metaStoreClient, we cache the result of query regarding to
    * the existence of databases and tables in {@link #tableAndDbExistenceCache},
@@ -113,7 +113,7 @@ public class HiveMetaStoreBasedRegister extends HiveRegister {
   public static final String OPTIMIZED_CHECK_ENABLED = "hiveRegister.cacheDbTableExistence";
 
   private final HiveMetastoreClientPool clientPool;
-  private final HiveLock locks = new HiveLock();
+  private final HiveLock locks;
   private final EventSubmitter eventSubmitter;
   private final MetricContext metricContext;
 
@@ -145,6 +145,7 @@ public class HiveMetaStoreBasedRegister extends HiveRegister {
   private String topicName = "";
   public HiveMetaStoreBasedRegister(State state, Optional<String> metastoreURI) throws IOException {
     super(state);
+    this.locks = new HiveLock(state.getProperties());
 
     this.optimizedChecks = state.getPropAsBoolean(this.OPTIMIZED_CHECK_ENABLED, true);
     this.skipDiffComputation = state.getPropAsBoolean(this.SKIP_PARTITION_DIFF_COMPUTATION, false);
@@ -190,7 +191,7 @@ public class HiveMetaStoreBasedRegister extends HiveRegister {
    */
   private boolean ensureHiveTableExistenceBeforeAlternation(String tableName, String dbName, IMetaStoreClient client,
       Table table, HiveSpec spec) throws TException, IOException{
-    try (AutoCloseableLock lock = this.locks.getTableLock(dbName, tableName)) {
+    try (AutoCloseableHiveLock lock = this.locks.getTableLock(dbName, tableName)) {
       try {
         try (Timer.Context context = this.metricContext.timer(CREATE_HIVE_TABLE).time()) {
           client.createTable(getTableWithCreateTimeNow(table));
@@ -210,13 +211,15 @@ public class HiveMetaStoreBasedRegister extends HiveRegister {
         try (Timer.Context context = this.metricContext.timer(GET_HIVE_TABLE).time()) {
           existingTable = HiveMetaStoreUtils.getHiveTable(client.getTable(dbName, tableName));
         }
+        //TODO: Determine whether we still use inline hive registration,
+        // if so, instead of fetching schema from schema registry, we need to enable schema version
         if (this.schemaRegistry.isPresent()) {
           try (Timer.Context context = this.metricContext.timer(GET_AND_SET_LATEST_SCHEMA).time()) {
             String latestSchema = this.schemaRegistry.get().getLatestSchema(topicName).toString();
             spec.getTable().getSerDeProps().setProp(AvroSerdeUtils.AvroTableProperties.SCHEMA_LITERAL.getPropName(), latestSchema);
             table.getSd().setSerdeInfo(HiveMetaStoreUtils.getSerDeInfo(spec.getTable()));
           } catch (SchemaRegistryException | IOException e) {
-            log.error(String.format("Error when fetch latest for topic %s", topicName), e);
+            log.error(String.format("Error when fetch latest schema for topic %s", topicName), e);
             throw new IOException(e);
           }
         }
@@ -244,7 +247,7 @@ public class HiveMetaStoreBasedRegister extends HiveRegister {
    * @param hiveDbName is the hive databases to be checked for existence
    */
   private boolean ensureHiveDbExistence(String hiveDbName, IMetaStoreClient client) throws IOException{
-    try (AutoCloseableLock lock = this.locks.getDbLock(hiveDbName)) {
+    try (AutoCloseableHiveLock lock = this.locks.getDbLock(hiveDbName)) {
       Database db = new Database();
       db.setName(hiveDbName);
 
@@ -320,7 +323,7 @@ public class HiveMetaStoreBasedRegister extends HiveRegister {
   @Override
   public boolean createTableIfNotExists(HiveTable table) throws IOException {
     try (AutoReturnableObject<IMetaStoreClient> client = this.clientPool.getClient();
-        AutoCloseableLock lock = this.locks.getTableLock(table.getDbName(), table.getTableName())) {
+        AutoCloseableHiveLock lock = this.locks.getTableLock(table.getDbName(), table.getTableName())) {
       return createTableIfNotExists(client.get(), HiveMetaStoreUtils.getTable(table), table);
     }
   }
@@ -332,7 +335,7 @@ public class HiveMetaStoreBasedRegister extends HiveRegister {
   @Override
   public boolean addPartitionIfNotExists(HiveTable table, HivePartition partition) throws IOException {
     try (AutoReturnableObject<IMetaStoreClient> client = this.clientPool.getClient();
-        AutoCloseableLock lock = this.locks.getTableLock(table.getDbName(), table.getTableName())) {
+        AutoCloseableHiveLock lock = this.locks.getTableLock(table.getDbName(), table.getTableName())) {
       try {
         try (Timer.Context context = this.metricContext.timer(GET_HIVE_PARTITION).time()) {
           client.get().getPartition(table.getDbName(), table.getTableName(), partition.getValues());
@@ -360,7 +363,7 @@ public class HiveMetaStoreBasedRegister extends HiveRegister {
     String dbName = table.getDbName();
     String tableName = table.getTableName();
 
-    try (AutoCloseableLock lock = this.locks.getTableLock(dbName, tableName)) {
+    try (AutoCloseableHiveLock lock = this.locks.getTableLock(dbName, tableName)) {
       boolean tableExists;
       try (Timer.Context context = this.metricContext.timer(TABLE_EXISTS).time()) {
         tableExists = client.tableExists(table.getDbName(), table.getTableName());
@@ -483,14 +486,14 @@ public class HiveMetaStoreBasedRegister extends HiveRegister {
   }
 
   private void addOrAlterPartition(IMetaStoreClient client, Table table, HivePartition partition)
-      throws TException {
+      throws TException, IOException {
     Partition nativePartition = HiveMetaStoreUtils.getPartition(partition);
 
     Preconditions.checkArgument(table.getPartitionKeysSize() == nativePartition.getValues().size(),
         String.format("Partition key size is %s but partition value size is %s", table.getPartitionKeys().size(),
             nativePartition.getValues().size()));
 
-    try (AutoCloseableLock lock =
+    try (AutoCloseableHiveLock lock =
         this.locks.getPartitionLock(table.getDbName(), table.getTableName(), nativePartition.getValues())) {
 
       try {

--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/metastore/HiveMetaStoreUtils.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/metastore/HiveMetaStoreUtils.java
@@ -239,7 +239,7 @@ public class HiveMetaStoreUtils {
     return sd;
   }
 
-  private static SerDeInfo getSerDeInfo(HiveRegistrationUnit unit) {
+  public static SerDeInfo getSerDeInfo(HiveRegistrationUnit unit) {
     State props = unit.getSerDeProps();
     SerDeInfo si = new SerDeInfo();
     si.setParameters(getParameters(props));

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/locks/DistributedHiveLockFactory.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/locks/DistributedHiveLockFactory.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.runtime.locks;
+
+import java.io.IOException;
+import java.util.Properties;
+import org.apache.gobblin.hive.HiveLockFactory;
+import org.apache.gobblin.hive.HiveLockImpl;
+
+/**
+ * A lock factory that extends {@link HiveLockFactory} provide a get method for a distributed lock for a specific object
+ */
+public class DistributedHiveLockFactory extends HiveLockFactory {
+  public DistributedHiveLockFactory(Properties properties) {
+    super(properties);
+  }
+  public HiveLockImpl get(String name) {
+    return new HiveLockImpl<ZookeeperBasedJobLock>(new ZookeeperBasedJobLock(properties, name)) {
+      @Override
+      public void lock() throws IOException {
+        try {
+          this.lock.lock();
+        } catch (Exception e) {
+          throw new IOException(e);
+        }
+      }
+
+      @Override
+      public void unlock() throws IOException {
+        try {
+          this.lock.unlock();
+        } catch (Exception e) {
+          throw new IOException(e);
+        }
+      }
+    };
+  }
+}

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/locks/DistributedHiveLockFactory.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/locks/DistributedHiveLockFactory.java
@@ -35,7 +35,7 @@ public class DistributedHiveLockFactory extends HiveLockFactory {
       public void lock() throws IOException {
         try {
           this.lock.lock();
-        } catch (Exception e) {
+        } catch (JobLockException e) {
           throw new IOException(e);
         }
       }
@@ -44,7 +44,7 @@ public class DistributedHiveLockFactory extends HiveLockFactory {
       public void unlock() throws IOException {
         try {
           this.lock.unlock();
-        } catch (Exception e) {
+        } catch (JobLockException e) {
           throw new IOException(e);
         }
       }

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/locks/ZookeeperBasedJobLock.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/locks/ZookeeperBasedJobLock.java
@@ -69,8 +69,11 @@ public class ZookeeperBasedJobLock implements ListenableJobLock {
   private long lockAcquireTimeoutMilliseconds;
   private InterProcessLock lock;
 
-  public ZookeeperBasedJobLock(Properties properties) throws JobLockException {
-    String jobName = properties.getProperty(ConfigurationKeys.JOB_NAME_KEY);
+  public ZookeeperBasedJobLock(Properties properties) {
+    this(properties, properties.getProperty(ConfigurationKeys.JOB_NAME_KEY));
+  }
+
+  public ZookeeperBasedJobLock(Properties properties, String jobName)  {
     this.lockAcquireTimeoutMilliseconds =
         getLong(properties, LOCKS_ACQUIRE_TIMEOUT_MILLISECONDS, LOCKS_ACQUIRE_TIMEOUT_MILLISECONDS_DEFAULT);
     this.lockPath = Paths.get(LOCKS_ROOT_PATH, jobName).toString();


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-863


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
When updating the hive table, lock the table and fetch the latest schema from schema registry and use the latest schema to update table to make sure the table always has the latest schema

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Test streaming job to see hive registration work as expected. And fetching latest latest schema may cost 0.05~0.15 second. But this should not happen frequently, only happen when there if new partition or schema change.

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

