### PR TITLE
[GOBBLIN-873] Add offset look-back option in Kafka consumer

### DIFF
--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSource.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSource.java
@@ -461,8 +461,9 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
         offsets.startAtEarliestOffset();
       } else if (offsetOption.equals(OFFSET_LOOKBACK)) {
         long lookbackOffsetRange = state.getPropAsLong(KAFKA_OFFSET_LOOKBACK , 0L);
-        long offset = offsets.getLatestOffset() - lookbackOffsetRange;
-        LOG.warn(offsetNotFoundMsg + "This partition will start from latest-lookback [ " + offsets.getLatestOffset() + " - " + lookbackOffsetRange + " ]  start offset: " + offset);
+        long latestOffset = offsets.getLatestOffset();
+        long offset = latestOffset - lookbackOffsetRange;
+        LOG.warn(offsetNotFoundMsg + "This partition will start from latest-lookback [ " + latestOffset + " - " + lookbackOffsetRange + " ]  start offset: " + offset);
         try {
           offsets.startAt(offset);
         } catch (StartOffsetOutOfRangeException e) {

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSource.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSource.java
@@ -90,6 +90,8 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
   public static final String LATEST_OFFSET = "latest";
   public static final String EARLIEST_OFFSET = "earliest";
   public static final String NEAREST_OFFSET = "nearest";
+  public static final String OFFSET_LOOKBACK = "offset_lookback";
+  public static final String TIMESTAMP_LOOKBACK = "timestamp_lookback";
   public static final String BOOTSTRAP_WITH_OFFSET = "bootstrap.with.offset";
   public static final String DEFAULT_BOOTSTRAP_WITH_OFFSET = LATEST_OFFSET;
   public static final String TOPICS_MOVE_TO_LATEST_OFFSET = "topics.move.to.latest.offset";
@@ -440,8 +442,14 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
       offsets.startAtLatestOffset();
     } else if (previousOffsetNotFound) {
 
-      // When previous offset cannot be found, either start at earliest offset or latest offset, or skip the partition
-      // (no need to create an empty workunit in this case since there's no offset to persist).
+      /**
+       * When previous offset cannot be found, either start at earliest offset, latest offset, go back with (latest - lookback)
+       * (long value to be deducted from latest offset in order to avoid data loss) or skip the partition
+       * (no need to create an empty workunit in this case since there's no offset to persist).
+       * In case of no previous state OFFSET_LOOKBACK will make sure to avoid consuming huge amount of data (earlist) and data loss (latest offset)
+       * lookback can be set to any long value where (latest-lookback) is nearest offset for each partition. If computed offset is out of range then
+       * partition will be consumed from latest offset
+       **/
       String offsetNotFoundMsg = String.format("Previous offset for partition %s does not exist. ", partition);
       String offsetOption = state.getProp(BOOTSTRAP_WITH_OFFSET, DEFAULT_BOOTSTRAP_WITH_OFFSET).toLowerCase();
       if (offsetOption.equals(LATEST_OFFSET)) {
@@ -451,7 +459,21 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
         LOG.warn(
             offsetNotFoundMsg + "This partition will start from the earliest offset: " + offsets.getEarliestOffset());
         offsets.startAtEarliestOffset();
-      } else {
+      } else if (offsetOption.equals(OFFSET_LOOKBACK)) {
+        long lookbackOffsetRange = state.getPropAsLong("kafka.offset.lookback", 0L);
+        long offset = offsets.getLatestOffset() - lookbackOffsetRange;
+        LOG.warn(offsetNotFoundMsg + "This partition will start from latest-lookback [ " + offsets.getLatestOffset() + " - " + lookbackOffsetRange + " ]  start offset: " + offset);
+        try {
+          offsets.startAt(offset);
+        } catch (StartOffsetOutOfRangeException e) {
+          String offsetOutOfRangeMsg = String.format(
+                  "Start offset for partition %s is out of range. Start offset = %d, earliest offset = %d, latest offset = %d.",
+                  partition, offsets.getStartOffset(), offsets.getEarliestOffset(), offsets.getLatestOffset());
+          LOG.warn(offsetOutOfRangeMsg + "This partition will start from the latest offset: " + offsets.getLatestOffset());
+          offsets.startAtLatestOffset();
+        }
+      }
+      else {
         LOG.warn(offsetNotFoundMsg + "This partition will be skipped.");
         return null;
       }

--- a/gobblin-runtime/src/main/resources/templates/kafka-hdfs.template
+++ b/gobblin-runtime/src/main/resources/templates/kafka-hdfs.template
@@ -45,8 +45,6 @@ topic.whitelist=${kafka.topics}
 org.apache.gobblin.kafka.consumerClient.class="org.apache.gobblin.kafka.client.Kafka09ConsumerClient$Factory"
 # Accepted values - latest, earliest and with offset lookback (latest offset - lookback)
 bootstrap.with.offset=earliest
-#bootstrap.with.offset=earliest
-#kafka.offset.lookback=100
 kafka.workunit.packer.type=SINGLE_LEVEL
 mr.job.max.mappers=10
 

--- a/gobblin-runtime/src/main/resources/templates/kafka-hdfs.template
+++ b/gobblin-runtime/src/main/resources/templates/kafka-hdfs.template
@@ -43,7 +43,10 @@ source.kafka.json.schema=${kafka.schema.json}
 
 topic.whitelist=${kafka.topics}
 org.apache.gobblin.kafka.consumerClient.class="org.apache.gobblin.kafka.client.Kafka09ConsumerClient$Factory"
+# Accepted values - latest, earliest and with offset lookback (latest offset - lookback)
 bootstrap.with.offset=earliest
+#bootstrap.with.offset=earliest
+#kafka.offset.lookback=100
 kafka.workunit.packer.type=SINGLE_LEVEL
 mr.job.max.mappers=10
 


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-873


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
   Current kafka consumer supports only latest and easiest offset reset options if previous state is not available. This PR is to add a new option , offset look-back , through which offset can be reset to specific amount from the latest offset for each topic partition.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

