### PR TITLE
GOBBLIN-865: Add feature that enables PK-chunking in partition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .classpath*
 .project*
 .settings
+.DS_Store
+*.tar.gz
 
 # Intellij related
 **/.idea
@@ -62,5 +64,11 @@ package-lock.json
 
 # generated config files by tests
 **/generated-gobblin-cluster.conf
+ligradle/findbugs/findbugsInclude.xml
+ligradle/checkstyle/linkedin-checkstyle.xml
+ligradle/checkstyle/suppressions.xml
+gobblin-core/src/test/resources/serde/output-staging/
+gobblin-integration-test-log-dir/
+gobblin-modules/gobblin-elasticsearch/test-elasticsearch/
 
 temp/

--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ gobblin-integration-test-log-dir/
 gobblin-modules/gobblin-elasticsearch/test-elasticsearch/
 
 temp/
+ligradle/*

--- a/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiExtractor.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/extract/restapi/RestApiExtractor.java
@@ -158,7 +158,7 @@ public abstract class RestApiExtractor extends QueryBasedExtractor<JsonArray, Js
       this.updatedQuery = buildDataQuery(inputQuery, entity);
       log.info("Schema:" + columnArray);
       this.setOutputSchema(columnArray);
-    } catch (RuntimeException | RestApiConnectionException | RestApiProcessingException | IOException
+    } catch (RuntimeException | RestApiProcessingException | RestApiConnectionException | IOException
         | SchemaException e) {
       throw new SchemaException("Failed to get schema using rest api; error - " + e.getMessage(), e);
     }

--- a/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/ResultIterator.java
+++ b/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/ResultIterator.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gobblin.salesforce;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.sforce.async.BulkConnection;
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.source.extractor.utils.InputStreamCSVReader;
+import org.apache.gobblin.source.extractor.utils.Utils;
+
+
+/**
+ * Result Iterator.
+ * Take jobId and 'batchId:resultId,batchId2:resultId2' as input build a result record iterator.
+ */
+@Slf4j
+public class ResultIterator implements Iterator {
+  private Iterator<ResultStruct> batchIdResultIdIterator;
+  private BulkConnection bulkConnection;
+  private InputStreamCSVReader csvReader;
+  private List<String> csvHeader;
+  private int columnSize;
+  private int urlLoadRetryLimit;
+  private ResultStruct resultStruct;
+  private List<String> currentRecord = null;
+  private Boolean isLoadedCurrentRecord = false;
+  private int currentFileRowCount = 0;
+  private int totalRowCount = 0;
+
+  /**
+   *  constructor
+   *  need to initiate the reader and currentRecord
+   */
+  public ResultIterator(BulkConnection bulkConnection, String jobId, String batchIdResultIdString, int urlLoadRetryLimit) {
+    this.urlLoadRetryLimit = urlLoadRetryLimit;
+    this.bulkConnection = bulkConnection;
+    this.batchIdResultIdIterator = this.parsebatchIdResultIdString(jobId, batchIdResultIdString);
+    if (this.batchIdResultIdIterator.hasNext()) {
+      this.resultStruct = this.batchIdResultIdIterator.next();
+      this.csvReader = this.fetchResultsetAsCsvReader(this.resultStruct); // first file reader
+    } else {
+      throw new RuntimeException("No batch-result id found.");
+    }
+    this.fulfilCurrentRecord();
+    this.csvHeader = this.currentRecord;
+    this.columnSize = this.csvHeader.size();
+    // after fetching cvs header, clean up status
+    this.resetCurrentRecordStatus();
+  }
+
+  /**
+   * call reader.next and set up currentRecord
+   */
+  private void fulfilCurrentRecord() {
+    if (this.isLoadedCurrentRecord) {
+      return; // skip, since CurrentRecord was loaded.
+    }
+    try {
+      this.currentRecord = this.csvReader.nextRecord();
+      if (this.currentRecord == null) { // according InputStreamCSVReader, it returns null at the end of the reader.
+        log.info("Fetched {} - rows: {}", this.resultStruct, this.currentFileRowCount); // print out log before switch result file
+        this.currentFileRowCount = 0; // clean up
+        if (this.batchIdResultIdIterator.hasNext()) { // if there is next file, load next file.
+          this.resultStruct = this.batchIdResultIdIterator.next();
+          this.csvReader = this.fetchResultsetAsCsvReader(resultStruct);
+          this.csvReader.nextRecord(); // read and ignore the csv header.
+          this.currentRecord = this.csvReader.nextRecord();
+        } else {
+          log.info("---- Fetched {} rows -----", this.totalRowCount); // print out log when all records were fetched.
+        }
+      }
+      this.isLoadedCurrentRecord = true;
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private void resetCurrentRecordStatus() {
+    this.currentRecord = null;
+    this.isLoadedCurrentRecord = false;
+  }
+
+  @Override
+  public boolean hasNext() {
+    this.fulfilCurrentRecord();
+    return this.currentRecord != null;
+  }
+
+  @Override
+  public JsonElement next() {
+    this.fulfilCurrentRecord();
+    List<String> csvRecord = this.currentRecord;
+    this.resetCurrentRecordStatus();
+    if (csvRecord == null) {
+      throw new NoSuchElementException();
+    }
+    this.currentFileRowCount++;
+    this.totalRowCount++;
+    JsonObject jsonObject = Utils.csvToJsonObject(this.csvHeader, csvRecord, this.columnSize);
+    return jsonObject;
+  }
+
+  /**
+   * resultStruct has all data which identify a result set file
+   * fetch it and convert to a csvReader
+   */
+  private InputStreamCSVReader fetchResultsetAsCsvReader(ResultStruct resultStruct) {
+    String jobId = resultStruct.jobId;
+    String batchId = resultStruct.batchId;
+    String resultId = resultStruct.resultId;
+    log.info("PK-Chunking workunit: fetching [jobId={}, batchId={}, resultId={}]", jobId, batchId, resultId);
+    for (int i = 0; i < this.urlLoadRetryLimit; i++) { // retries
+      try {
+        InputStream is = this.bulkConnection.getQueryResultStream(jobId, batchId, resultId);
+        BufferedReader br = new BufferedReader(new InputStreamReader(is, ConfigurationKeys.DEFAULT_CHARSET_ENCODING));
+        return new InputStreamCSVReader(br);
+      } catch (Exception e) { // skip, for retry
+      }
+    }
+    // tried fetchRetryLimit times, always getting exception
+    throw new RuntimeException("Tried " + this.urlLoadRetryLimit + " times, but couldn't fetch data.");
+  }
+
+  /**
+   * input string format is "batchId:resultId,batchId2:resultId2"
+   * parse it to iterator
+   */
+  private Iterator<ResultStruct> parsebatchIdResultIdString(String jobId, String batchIdResultIdString) {
+    return Arrays.stream(batchIdResultIdString.split(",")).map(x -> x.split(":")).map(x -> new ResultStruct(jobId, x[0], x[1])).iterator();
+  }
+
+  @Data
+  class ResultStruct {
+    private final String jobId;
+    private final String batchId;
+    private final String resultId;
+    public String toString() {
+      return String.format("[jobId=%s, batchId=%s, resultId=%s]", jobId, batchId, resultId);
+    }
+  }
+
+}

--- a/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/ResultIterator.java
+++ b/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/ResultIterator.java
@@ -65,7 +65,7 @@ public class ResultIterator implements Iterator {
     } else {
       throw new RuntimeException("No batch-result id found.");
     }
-    this.fulfilCurrentRecord();
+    this.fulfillCurrentRecord();
     this.csvHeader = this.currentRecord;
     this.columnSize = this.csvHeader.size();
     // after fetching cvs header, clean up status
@@ -75,7 +75,7 @@ public class ResultIterator implements Iterator {
   /**
    * call reader.next and set up currentRecord
    */
-  private void fulfilCurrentRecord() {
+  private void fulfillCurrentRecord() {
     if (this.isLoadedCurrentRecord) {
       return; // skip, since CurrentRecord was loaded.
     }
@@ -106,13 +106,13 @@ public class ResultIterator implements Iterator {
 
   @Override
   public boolean hasNext() {
-    this.fulfilCurrentRecord();
+    this.fulfillCurrentRecord();
     return this.currentRecord != null;
   }
 
   @Override
   public JsonElement next() {
-    this.fulfilCurrentRecord();
+    this.fulfillCurrentRecord();
     List<String> csvRecord = this.currentRecord;
     this.resetCurrentRecordStatus();
     if (csvRecord == null) {
@@ -154,7 +154,7 @@ public class ResultIterator implements Iterator {
   }
 
   @Data
-  class ResultStruct {
+  static class ResultStruct {
     private final String jobId;
     private final String batchId;
     private final String resultId;

--- a/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/SalesforceConfigurationKeys.java
+++ b/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/SalesforceConfigurationKeys.java
@@ -17,14 +17,24 @@
 
 package org.apache.gobblin.salesforce;
 
-public class SalesforceConfigurationKeys {
+public final class SalesforceConfigurationKeys {
+  private SalesforceConfigurationKeys() {
+  }
   public static final String SOURCE_QUERYBASED_SALESFORCE_IS_SOFT_DELETES_PULL_DISABLED =
       "source.querybased.salesforce.is.soft.deletes.pull.disabled";
-  public static final int DEFAULT_SALESFORCE_MAX_CHARS_IN_FILE = 200000000;
-  public static final int DEFAULT_SALESFORCE_MAX_ROWS_IN_FILE = 1000000;
+  public static final int DEFAULT_FETCH_RETRY_LIMIT = 5;
+  public static final String BULK_API_USE_QUERY_ALL = "salesforce.bulkApiUseQueryAll";
 
   // pk-chunking
+  public static final String PK_CHUNKING_TEST_BATCH_ID_LIST = "salesforce.pkchunking.test.batch.id.list";
+  public static final String PK_CHUNKING_TEST_JOB_ID = "salesforce.pkchunking.test.job.id";
+  public static final String SALESFORCE_PARTITION_TYPE = "salesforce.partitionType";
   public static final String PARTITION_PK_CHUNKING_SIZE = "salesforce.partition.PkChunkingSize";
   public static final String PK_CHUNKING_JOB_ID = "_salesforce.job.id";
   public static final String PK_CHUNKING_BATCH_RESULT_IDS = "_salesforce.result.ids";
+  public static final int MAX_PK_CHUNKING_SIZE = 250_000; // this number is from SFDC's doc - https://tinyurl.com/ycjvgwv2
+  public static final int MIN_PK_CHUNKING_SIZE = 20_000;
+  public static final int DEFAULT_PK_CHUNKING_SIZE = 250_000; // default to max for saving request quota
 }
+
+

--- a/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/SalesforceConfigurationKeys.java
+++ b/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/SalesforceConfigurationKeys.java
@@ -22,4 +22,9 @@ public class SalesforceConfigurationKeys {
       "source.querybased.salesforce.is.soft.deletes.pull.disabled";
   public static final int DEFAULT_SALESFORCE_MAX_CHARS_IN_FILE = 200000000;
   public static final int DEFAULT_SALESFORCE_MAX_ROWS_IN_FILE = 1000000;
+
+  // pk-chunking
+  public static final String PARTITION_PK_CHUNKING_SIZE = "salesforce.partition.PkChunkingSize";
+  public static final String PK_CHUNKING_JOB_ID = "_salesforce.job.id";
+  public static final String PK_CHUNKING_BATCH_RESULT_IDS = "_salesforce.result.ids";
 }

--- a/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/SalesforceConfigurationKeys.java
+++ b/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/SalesforceConfigurationKeys.java
@@ -26,10 +26,10 @@ public final class SalesforceConfigurationKeys {
   public static final String BULK_API_USE_QUERY_ALL = "salesforce.bulkApiUseQueryAll";
 
   // pk-chunking
-  public static final String PK_CHUNKING_TEST_BATCH_ID_LIST = "salesforce.pkchunking.test.batch.id.list";
-  public static final String PK_CHUNKING_TEST_JOB_ID = "salesforce.pkchunking.test.job.id";
+  public static final String PK_CHUNKING_TEST_BATCH_ID_LIST = "salesforce.pkChunking.testBatchIdList";
+  public static final String PK_CHUNKING_TEST_JOB_ID = "salesforce.pkChunking.testJobId";
   public static final String SALESFORCE_PARTITION_TYPE = "salesforce.partitionType";
-  public static final String PARTITION_PK_CHUNKING_SIZE = "salesforce.partition.PkChunkingSize";
+  public static final String PARTITION_PK_CHUNKING_SIZE = "salesforce.partition.pkChunkingSize";
   public static final String PK_CHUNKING_JOB_ID = "_salesforce.job.id";
   public static final String PK_CHUNKING_BATCH_RESULT_IDS = "_salesforce.result.ids";
   public static final int MAX_PK_CHUNKING_SIZE = 250_000; // this number is from SFDC's doc - https://tinyurl.com/ycjvgwv2

--- a/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/SalesforceSource.java
+++ b/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/SalesforceSource.java
@@ -17,6 +17,7 @@
 
 package org.apache.gobblin.salesforce;
 
+import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.math.RoundingMode;
 import java.util.ArrayList;
@@ -28,8 +29,10 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.Set;
 
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.text.StrSubstitutor;
 import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
 
@@ -65,7 +68,9 @@ import org.apache.gobblin.source.extractor.extract.restapi.RestApiConnector;
 import org.apache.gobblin.source.extractor.partition.Partition;
 import org.apache.gobblin.source.extractor.partition.Partitioner;
 import org.apache.gobblin.source.extractor.utils.Utils;
+import org.apache.gobblin.source.extractor.watermark.Predicate;
 import org.apache.gobblin.source.extractor.watermark.WatermarkType;
+import org.apache.gobblin.source.workunit.Extract;
 import org.apache.gobblin.source.workunit.WorkUnit;
 
 import lombok.AllArgsConstructor;
@@ -73,13 +78,18 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import static org.apache.gobblin.configuration.ConfigurationKeys.*;
+import static org.apache.gobblin.salesforce.SalesforceConfigurationKeys.*;
 
+import org.apache.gobblin.salesforce.SalesforceExtractor.SalesforceBulkJobId;
+import org.apache.gobblin.salesforce.SalesforceExtractor.BatchIdAndResultId;
 /**
  * An implementation of {@link QueryBasedSource} for salesforce data sources.
  */
 @Slf4j
 public class SalesforceSource extends QueryBasedSource<JsonArray, JsonElement> {
-
+  // partition pk-chunking
+  private static final String PARTITION_TYPE = "salesforce.partitionType";
   public static final String USE_ALL_OBJECTS = "use.all.objects";
   public static final boolean DEFAULT_USE_ALL_OBJECTS = false;
 
@@ -146,12 +156,101 @@ public class SalesforceSource extends QueryBasedSource<JsonArray, JsonElement> {
 
   @Override
   protected List<WorkUnit> generateWorkUnits(SourceEntity sourceEntity, SourceState state, long previousWatermark) {
+    String partitionType = state.getProp(PARTITION_TYPE, "");
+    if (partitionType.equals("PK_CHUNKING")) {
+      // pk-chunking only supports start-time by source.querybased.start.value, and does not support end-time.
+      // always ingest data later than or equal source.querybased.start.value.
+      // we should only pk chunking based work units only in case of snapshot/full ingestion
+      return generateWorkUnitsPkChunking(sourceEntity, state, previousWatermark);
+    } else {
+      return generateWorkUnitsStrategy(sourceEntity, state, previousWatermark);
+    }
+  }
+
+  /**
+   * generate workUnit with noQuery=true
+   */
+  private List<WorkUnit> generateWorkUnitsPkChunking(SourceEntity sourceEntity, SourceState state, long previousWatermark) {
+      SalesforceBulkJobId salesforceBulkJobId = executeQueryWithPkChunking(state, previousWatermark);
+      List<WorkUnit> ret = createWorkUnits(sourceEntity, state, salesforceBulkJobId);
+      return ret;
+  }
+
+  private SalesforceBulkJobId executeQueryWithPkChunking(
+      SourceState sourceState,
+      long previousWatermark
+  ) throws RuntimeException {
+    State state = new State(sourceState);
+    WorkUnit workUnit = WorkUnit.createEmpty();
+    try {
+      WorkUnitState workUnitState = new WorkUnitState(workUnit, state);
+      workUnitState.setId("Execute pk-chunking");
+      SalesforceExtractor salesforceExtractor = (SalesforceExtractor) this.getExtractor(workUnitState);
+      Partitioner partitioner = new Partitioner(sourceState);
+      if (isEarlyStopEnabled(state) && partitioner.isFullDump()) {
+        throw new UnsupportedOperationException("Early stop mode cannot work with full dump mode.");
+      }
+      Partition partition = partitioner.getGlobalPartition(previousWatermark);
+      String condition = "";
+      Date startDate = Utils.toDate(partition.getLowWatermark(), Partitioner.WATERMARKTIMEFORMAT);
+      String field = sourceState.getProp(ConfigurationKeys.EXTRACT_DELTA_FIELDS_KEY);
+      // pk-chunking only supports start-time by source.querybased.start.value, and does not support end-time.
+      // always ingest data later than or equal source.querybased.start.value.
+      // we should only pk chunking based work units only in case of snapshot/full ingestion
+      if (startDate != null && field != null) {
+        String lowWatermarkDate = Utils.dateToString(startDate, SalesforceExtractor.SALESFORCE_TIMESTAMP_FORMAT);
+        condition = field + " >= " + lowWatermarkDate;
+      }
+      Predicate predicate = new Predicate(null, 0, condition, "", null);
+      List<Predicate> predicateList = Arrays.asList(predicate);
+      String entity = sourceState.getProp(ConfigurationKeys.SOURCE_ENTITY);
+      SalesforceBulkJobId salesforceBulkJobId = salesforceExtractor.getQueryResultIdsPkChunking(entity, predicateList);
+      return salesforceBulkJobId;
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private List<WorkUnit> createWorkUnits(
+      SourceEntity sourceEntity,
+      SourceState state,
+      SalesforceBulkJobId salesforceBulkJobId
+  ) {
+    String nameSpaceName = state.getProp(ConfigurationKeys.EXTRACT_NAMESPACE_NAME_KEY);
+    Extract.TableType tableType = Extract.TableType.valueOf(state.getProp(ConfigurationKeys.EXTRACT_TABLE_TYPE_KEY).toUpperCase());
+    String outputTableName = sourceEntity.getDestTableName();
+    Extract extract = createExtract(tableType, nameSpaceName, outputTableName);
+
+    List<WorkUnit> workUnits = Lists.newArrayList();
+    int partitionNumber = state.getPropAsInt(SOURCE_MAX_NUMBER_OF_PARTITIONS, 1);
+    List<BatchIdAndResultId> batchResultIds = salesforceBulkJobId.getBatchIdAndResultIdList();
+    int maxPartition = (batchResultIds.size() + partitionNumber - 1)/partitionNumber;
+    List<List<BatchIdAndResultId>> partitionedResultIds = Lists.partition(batchResultIds, maxPartition);
+    for (List<BatchIdAndResultId> resultIds : partitionedResultIds){
+      WorkUnit workunit = new WorkUnit(extract);
+      String bulkJobId = salesforceBulkJobId.getJobId();
+      workunit.setProp(PK_CHUNKING_JOB_ID, bulkJobId);
+      String resultIdStr = resultIds.stream().map(x -> x.getBatchId() + ":" + x.getResultId()).collect(Collectors.joining(","));
+      workunit.setProp(PK_CHUNKING_BATCH_RESULT_IDS, resultIdStr);
+      workunit.setProp(ConfigurationKeys.SOURCE_ENTITY, sourceEntity.getSourceEntityName());
+      workunit.setProp(ConfigurationKeys.EXTRACT_TABLE_NAME_KEY, sourceEntity.getDestTableName());
+      workunit.setProp(WORK_UNIT_STATE_VERSION_KEY, CURRENT_WORK_UNIT_STATE_VERSION);
+      addLineageSourceInfo(state, sourceEntity, workunit);
+      workUnits.add(workunit);
+    }
+    return workUnits;
+  }
+
+  /**
+   * the 2 pre-partition algorithms
+   */
+  private List<WorkUnit> generateWorkUnitsStrategy(SourceEntity sourceEntity, SourceState state, long previousWatermark) {
     WatermarkType watermarkType = WatermarkType.valueOf(
         state.getProp(ConfigurationKeys.SOURCE_QUERYBASED_WATERMARK_TYPE, ConfigurationKeys.DEFAULT_WATERMARK_TYPE)
             .toUpperCase());
     String watermarkColumn = state.getProp(ConfigurationKeys.EXTRACT_DELTA_FIELDS_KEY);
 
-    int maxPartitions = state.getPropAsInt(ConfigurationKeys.SOURCE_MAX_NUMBER_OF_PARTITIONS,
+    int maxPartitions = state.getPropAsInt(SOURCE_MAX_NUMBER_OF_PARTITIONS,
         ConfigurationKeys.DEFAULT_MAX_NUMBER_OF_PARTITIONS);
     int minTargetPartitionSize = state.getPropAsInt(MIN_TARGET_PARTITION_SIZE, DEFAULT_MIN_TARGET_PARTITION_SIZE);
 
@@ -387,7 +486,7 @@ public class SalesforceSource extends QueryBasedSource<JsonArray, JsonElement> {
    */
   private Histogram getRefinedHistogram(SalesforceConnector connector, String entity, String watermarkColumn,
       SourceState state, Partition partition, Histogram histogram) {
-    final int maxPartitions = state.getPropAsInt(ConfigurationKeys.SOURCE_MAX_NUMBER_OF_PARTITIONS,
+    final int maxPartitions = state.getPropAsInt(SOURCE_MAX_NUMBER_OF_PARTITIONS,
         ConfigurationKeys.DEFAULT_MAX_NUMBER_OF_PARTITIONS);
     final int probeLimit = state.getPropAsInt(DYNAMIC_PROBING_LIMIT, DEFAULT_DYNAMIC_PROBING_LIMIT);
     final int minTargetPartitionSize = state.getPropAsInt(MIN_TARGET_PARTITION_SIZE, DEFAULT_MIN_TARGET_PARTITION_SIZE);

--- a/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/SalesforceSource.java
+++ b/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/SalesforceSource.java
@@ -153,7 +153,6 @@ public class SalesforceSource extends QueryBasedSource<JsonArray, JsonElement> {
 
   @Override
   protected List<WorkUnit> generateWorkUnits(SourceEntity sourceEntity, SourceState state, long previousWatermark) {
-    log.info("====sfdc connector with pkchk===="); // TODO: remove this after merge back to OS.
     List<WorkUnit> workUnits = null;
     String partitionType = state.getProp(SALESFORCE_PARTITION_TYPE, "");
     if (partitionType.equals("PK_CHUNKING")) {
@@ -238,10 +237,12 @@ public class SalesforceSource extends QueryBasedSource<JsonArray, JsonElement> {
     int partitionNumber = state.getPropAsInt(SOURCE_MAX_NUMBER_OF_PARTITIONS, 1);
     List<BatchIdAndResultId> batchResultIds = jobIdAndBatchIdResultIdList.getBatchIdAndResultIdList();
     int total = batchResultIds.size();
+
     // size of every partition should be: math.ceil(total/partitionNumber), use simpler way: (total+partitionNumber-1)/partitionNumber
     int sizeOfPartition = (total + partitionNumber - 1) / partitionNumber;
     List<List<BatchIdAndResultId>> partitionedResultIds = Lists.partition(batchResultIds, sizeOfPartition);
     log.info("----partition strategy: max-parti={}, size={}, actual-parti={}, total={}", partitionNumber, sizeOfPartition, partitionedResultIds.size(), total);
+
     for (List<BatchIdAndResultId> resultIds : partitionedResultIds) {
       WorkUnit workunit = new WorkUnit(extract);
       String bulkJobId = jobIdAndBatchIdResultIdList.getJobId();


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### JIRA
  - https://issues.apache.org/jira/browse/GOBBLIN-865

### Description
In SFDC(salesforce) connector, we have partitioning mechanisms to split a giant query to multiple sub queries. There are 3 mechanisms:

simple partition (equally split by time)
dynamic pre-partition (generate histogram and split by row numbers)
user specified partition (set up time range in job file)
However there are tables like Task and Contract are failing time to time to fetch full data.

We may want to utilize PK-chunking to partition the query.

The pk-chunking doc from SFDC - https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/async_api_headers_enable_pk_chunking.htm

### Solution

- In Source, execute the giant query with PK-Chunking and partition to workUnits
  - Create a state with all PK-chunking arguments 
  - Instantiate an extractor with the state
  - Call extractor function to execute the giant query
  - we would get a list of result IDs.
  - generate a list of workUnit( one workUnit contains a slice of the result ID list)
- In extractor, execute the workUnit to fetch resultset
  - identify the workUnit whether it is for pk chunking
  - if not, keep run as before (using the existing 3 partition)
  - if yes, just fetch resultset files by the result id list.

