### PR TITLE
[GOBBLIN-868] Check flow status instead of job status to determine if flow is running

### DIFF
--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowStatusResource.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowStatusResource.java
@@ -117,7 +117,7 @@ public class FlowStatusResource extends ComplexKeyResourceTemplate<FlowStatusId,
       org.apache.gobblin.service.monitoring.JobStatus queriedJobStatus = jobStatusIter.next();
 
       // Check if this is the flow status instead of a single job status
-      if (isFlowStatus(queriedJobStatus)) {
+      if (JobStatusRetriever.isFlowStatus(queriedJobStatus)) {
         flowEndTime = queriedJobStatus.getEndTime();
         flowExecutionStatus = ExecutionStatus.valueOf(queriedJobStatus.getEventName());
         continue;
@@ -157,14 +157,6 @@ public class FlowStatusResource extends ComplexKeyResourceTemplate<FlowStatusId,
         .setMessage(flowMessages)
         .setExecutionStatus(flowExecutionStatus)
         .setJobStatuses(jobStatusArray);
-  }
-
-  /**
-   * Check if a {@link org.apache.gobblin.service.monitoring.JobStatus} is the special job status that represents the
-   * entire flow's status
-   */
-  private static boolean isFlowStatus(org.apache.gobblin.service.monitoring.JobStatus jobStatus) {
-    return jobStatus.getJobName().equals(JobStatusRetriever.NA_KEY) && jobStatus.getJobGroup().equals(JobStatusRetriever.NA_KEY);
   }
 
   /**

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/FlowStatusGenerator.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/FlowStatusGenerator.java
@@ -34,7 +34,7 @@ import org.apache.gobblin.annotation.Alpha;
 @Alpha
 @Builder
 public class FlowStatusGenerator {
-  public static final List<String> FINISHED_JOB_STATUSES = Lists.newArrayList("FAILED", "COMPLETE", "CANCELLED");
+  public static final List<String> FINISHED_STATUSES = Lists.newArrayList("FAILED", "COMPLETE", "CANCELLED");
 
   private final JobStatusRetriever jobStatusRetriever;
 
@@ -94,8 +94,8 @@ public class FlowStatusGenerator {
 
       while (jobStatusIterator.hasNext()) {
         JobStatus jobStatus = jobStatusIterator.next();
-        if (isJobRunning(jobStatus)) {
-          return true;
+        if (JobStatusRetriever.isFlowStatus(jobStatus)) {
+          return isJobRunning(jobStatus);
         }
       }
       return false;
@@ -108,6 +108,6 @@ public class FlowStatusGenerator {
    */
   private boolean isJobRunning(JobStatus jobStatus) {
     String status = jobStatus.getEventName().toUpperCase();
-    return !FINISHED_JOB_STATUSES.contains(status);
+    return !FINISHED_STATUSES.contains(status);
   }
 }

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/JobStatusRetriever.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/JobStatusRetriever.java
@@ -91,4 +91,12 @@ public abstract class JobStatusRetriever implements LatestFlowExecutionIdTracker
   }
 
   public abstract StateStore<State> getStateStore();
+
+  /**
+   * Check if a {@link org.apache.gobblin.service.monitoring.JobStatus} is the special job status that represents the
+   * entire flow's status
+   */
+  public static boolean isFlowStatus(org.apache.gobblin.service.monitoring.JobStatus jobStatus) {
+    return jobStatus.getJobName().equals(JobStatusRetriever.NA_KEY) && jobStatus.getJobGroup().equals(JobStatusRetriever.NA_KEY);
+  }
 }

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/JobStatusRetriever.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/JobStatusRetriever.java
@@ -97,6 +97,7 @@ public abstract class JobStatusRetriever implements LatestFlowExecutionIdTracker
    * entire flow's status
    */
   public static boolean isFlowStatus(org.apache.gobblin.service.monitoring.JobStatus jobStatus) {
-    return jobStatus.getJobName().equals(JobStatusRetriever.NA_KEY) && jobStatus.getJobGroup().equals(JobStatusRetriever.NA_KEY);
+    return jobStatus.getJobName() != null && jobStatus.getJobGroup() != null
+        && jobStatus.getJobName().equals(JobStatusRetriever.NA_KEY) && jobStatus.getJobGroup().equals(JobStatusRetriever.NA_KEY);
   }
 }

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/service/monitoring/FlowStatusGeneratorTest.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/service/monitoring/FlowStatusGeneratorTest.java
@@ -42,12 +42,12 @@ public class FlowStatusGeneratorTest {
     Mockito.when(jobStatusRetriever.getLatestExecutionIdsForFlow(flowName, flowGroup, 1)).thenReturn(
         Lists.newArrayList(flowExecutionId));
     JobStatus jobStatus = JobStatus.builder().flowGroup(flowGroup).flowName(flowName).flowExecutionId(flowExecutionId)
-        .jobName(JobStatusRetriever.NA_KEY).eventName("COMPILED").build();
+        .jobName(JobStatusRetriever.NA_KEY).jobGroup(JobStatusRetriever.NA_KEY).eventName("COMPILED").build();
     Iterator<JobStatus> jobStatusIterator = Lists.newArrayList(jobStatus).iterator();
     Mockito.when(jobStatusRetriever.getJobStatusesForFlowExecution(flowName, flowGroup, flowExecutionId)).thenReturn(jobStatusIterator);
     Assert.assertTrue(flowStatusGenerator.isFlowRunning(flowName, flowGroup));
 
-    //A flow with 3 JobStatus-es with status COMPLETE, FAILED and CANCELLED => isFlowRunning() should return false.
+    //JobStatuses should be ignored, only the flow level status matters.
     String job1 = "job1";
     String job2 = "job2";
     String job3 = "job3";
@@ -57,13 +57,15 @@ public class FlowStatusGeneratorTest {
         .jobName(job2).eventName("FAILED").build();
     JobStatus jobStatus3 = JobStatus.builder().flowGroup(flowGroup).flowName(flowName).flowExecutionId(flowExecutionId)
         .jobName(job3).eventName("CANCELLED").build();
-    jobStatusIterator = Lists.newArrayList(jobStatus1, jobStatus2, jobStatus3).iterator();
+    JobStatus flowStatus = JobStatus.builder().flowGroup(flowGroup).flowName(flowName).flowExecutionId(flowExecutionId)
+        .jobName(JobStatusRetriever.NA_KEY).jobGroup(JobStatusRetriever.NA_KEY).eventName("CANCELLED").build();
+    jobStatusIterator = Lists.newArrayList(jobStatus1, jobStatus2, jobStatus3, flowStatus).iterator();
     Mockito.when(jobStatusRetriever.getJobStatusesForFlowExecution(flowName, flowGroup, flowExecutionId)).thenReturn(jobStatusIterator);
     Assert.assertFalse(flowStatusGenerator.isFlowRunning(flowName, flowGroup));
 
-    jobStatus2 = JobStatus.builder().flowGroup(flowGroup).flowName(flowName).flowExecutionId(flowExecutionId)
-        .jobName(job2).eventName("RUNNING").build();
-    jobStatusIterator = Lists.newArrayList(jobStatus1, jobStatus2, jobStatus3).iterator();
+    flowStatus = JobStatus.builder().flowGroup(flowGroup).flowName(flowName).flowExecutionId(flowExecutionId)
+        .jobName(JobStatusRetriever.NA_KEY).jobGroup(JobStatusRetriever.NA_KEY).eventName("RUNNING").build();
+    jobStatusIterator = Lists.newArrayList(jobStatus1, jobStatus2, jobStatus3, flowStatus).iterator();
     Mockito.when(jobStatusRetriever.getJobStatusesForFlowExecution(flowName, flowGroup, flowExecutionId)).thenReturn(jobStatusIterator);
     Assert.assertTrue(flowStatusGenerator.isFlowRunning(flowName, flowGroup));
   }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-868


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):

After updating to use flow level events for job status, this code should be using the flow level status instead of using jobs.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

