### PR TITLE
[GOBBLIN-874] Make WorkUnitPacker and SizeEstimator pluggable

### DIFF
--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaAvgRecordSizeBasedWorkUnitSizeEstimator.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaAvgRecordSizeBasedWorkUnitSizeEstimator.java
@@ -53,7 +53,7 @@ public class KafkaAvgRecordSizeBasedWorkUnitSizeEstimator implements KafkaWorkUn
 
   private final Map<KafkaPartition, Long> estAvgSizes = Maps.newHashMap();
 
-  KafkaAvgRecordSizeBasedWorkUnitSizeEstimator(SourceState state) {
+  public KafkaAvgRecordSizeBasedWorkUnitSizeEstimator(SourceState state) {
     readPreAvgRecordSizes(state);
   }
 

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaAvgRecordTimeBasedWorkUnitSizeEstimator.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaAvgRecordTimeBasedWorkUnitSizeEstimator.java
@@ -63,7 +63,7 @@ public class KafkaAvgRecordTimeBasedWorkUnitSizeEstimator implements KafkaWorkUn
   private final Map<String, Double> estAvgMillis = Maps.newHashMap();
   private double avgEstAvgMillis = 0.0;
 
-  KafkaAvgRecordTimeBasedWorkUnitSizeEstimator(SourceState state) {
+  public KafkaAvgRecordTimeBasedWorkUnitSizeEstimator(SourceState state) {
     readPrevAvgRecordMillis(state);
   }
 

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaBiLevelWorkUnitPacker.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaBiLevelWorkUnitPacker.java
@@ -58,7 +58,7 @@ public class KafkaBiLevelWorkUnitPacker extends KafkaWorkUnitPacker {
   public static final String WORKUNIT_PRE_GROUPING_SIZE_FACTOR = "workunit.pre.grouping.size.factor";
   public static final double DEFAULT_WORKUNIT_PRE_GROUPING_SIZE_FACTOR = 3.0;
 
-  protected KafkaBiLevelWorkUnitPacker(AbstractSource<?, ?> source, SourceState state) {
+  public KafkaBiLevelWorkUnitPacker(AbstractSource<?, ?> source, SourceState state) {
     super(source, state);
   }
 
@@ -103,7 +103,7 @@ public class KafkaBiLevelWorkUnitPacker extends KafkaWorkUnitPacker {
    * Group {@link WorkUnit}s into groups. Each group is a {@link MultiWorkUnit}. Each group has a capacity of
    * avgGroupSize. If there's a single {@link WorkUnit} whose size is larger than avgGroupSize, it forms a group itself.
    */
-  private static List<MultiWorkUnit> bestFitDecreasingBinPacking(List<WorkUnit> workUnits, double avgGroupSize) {
+  static List<MultiWorkUnit> bestFitDecreasingBinPacking(List<WorkUnit> workUnits, double avgGroupSize) {
 
     // Sort workunits by data size desc
     Collections.sort(workUnits, LOAD_DESC_COMPARATOR);

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaSingleLevelWorkUnitPacker.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaSingleLevelWorkUnitPacker.java
@@ -43,7 +43,7 @@ import org.apache.gobblin.source.workunit.WorkUnit;
  */
 public class KafkaSingleLevelWorkUnitPacker extends KafkaWorkUnitPacker {
 
-  protected KafkaSingleLevelWorkUnitPacker(AbstractSource<?, ?> source, SourceState state) {
+  public KafkaSingleLevelWorkUnitPacker(AbstractSource<?, ?> source, SourceState state) {
     super(source, state);
   }
 

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaWorkUnitPacker.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaWorkUnitPacker.java
@@ -44,7 +44,6 @@ import org.apache.gobblin.source.extractor.extract.kafka.KafkaPartition;
 import org.apache.gobblin.source.extractor.extract.kafka.KafkaSource;
 import org.apache.gobblin.source.extractor.extract.kafka.KafkaUtils;
 import org.apache.gobblin.source.extractor.extract.kafka.MultiLongWatermark;
-import org.apache.gobblin.source.workunit.Extract;
 import org.apache.gobblin.source.workunit.MultiWorkUnit;
 import org.apache.gobblin.source.workunit.WorkUnit;
 
@@ -72,13 +71,12 @@ public abstract class KafkaWorkUnitPacker {
   public enum PackerType {
     SINGLE_LEVEL,
     BI_LEVEL,
-    CUSTOMIZED
+    CUSTOM
   }
 
   public enum SizeEstimatorType {
     AVG_RECORD_TIME,
-    AVG_RECORD_SIZE,
-    CUSTOMIZED
+    AVG_RECORD_SIZE, CUSTOM
   }
 
   public static final String KAFKA_WORKUNIT_PACKER_TYPE = "kafka.workunit.packer.type";
@@ -144,7 +142,7 @@ public abstract class KafkaWorkUnitPacker {
         return new KafkaAvgRecordTimeBasedWorkUnitSizeEstimator(this.state);
       case AVG_RECORD_SIZE:
         return new KafkaAvgRecordSizeBasedWorkUnitSizeEstimator(this.state);
-      case CUSTOMIZED:
+      case CUSTOM:
         Preconditions.checkArgument(this.state.contains(KAFKA_WORKUNIT_SIZE_ESTIMATOR_CUSTOMIZED_TYPE));
         String className = this.state.getProp(KAFKA_WORKUNIT_SIZE_ESTIMATOR_CUSTOMIZED_TYPE);
         return GobblinConstructorUtils.invokeConstructor(KafkaWorkUnitSizeEstimator.class, className, this.state);
@@ -377,7 +375,7 @@ public abstract class KafkaWorkUnitPacker {
         return new KafkaSingleLevelWorkUnitPacker(source, state);
       case BI_LEVEL:
         return new KafkaBiLevelWorkUnitPacker(source, state);
-      case CUSTOMIZED:
+      case CUSTOM:
         Preconditions.checkArgument(state.contains(KAFKA_WORKUNIT_PACKER_CUSTOMIZED_TYPE));
         String className = state.getProp(KAFKA_WORKUNIT_PACKER_CUSTOMIZED_TYPE);
         return GobblinConstructorUtils.invokeConstructor(KafkaWorkUnitPacker.class, className, source, state);

--- a/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaWorkUnitPackerTest.java
+++ b/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaWorkUnitPackerTest.java
@@ -44,10 +44,10 @@ public class KafkaWorkUnitPackerTest {
     state = new SourceState();
 
     // Using customized type and having customized as a known class.
-    state.setProp(KAFKA_WORKUNIT_PACKER_TYPE, "CUSTOMIZED");
+    state.setProp(KAFKA_WORKUNIT_PACKER_TYPE, "CUSTOM");
     state.setProp(KAFKA_WORKUNIT_PACKER_CUSTOMIZED_TYPE,
         "org.apache.gobblin.source.extractor.extract.kafka.workunit.packer.KafkaSingleLevelWorkUnitPacker");
-    state.setProp(KAFKA_WORKUNIT_SIZE_ESTIMATOR_TYPE, "CUSTOMIZED");
+    state.setProp(KAFKA_WORKUNIT_SIZE_ESTIMATOR_TYPE, "CUSTOM");
     state.setProp(KAFKA_WORKUNIT_SIZE_ESTIMATOR_CUSTOMIZED_TYPE,
         "org.apache.gobblin.source.extractor.extract.kafka.workunit.packer.KafkaAvgRecordTimeBasedWorkUnitSizeEstimator");
     packer = new TestKafkaWorkUnitPacker(source, state);

--- a/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaWorkUnitPackerTest.java
+++ b/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaWorkUnitPackerTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.source.extractor.extract.kafka.workunit.packer;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.gobblin.configuration.SourceState;
+import org.apache.gobblin.source.extractor.extract.AbstractSource;
+import org.apache.gobblin.source.workunit.WorkUnit;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.apache.gobblin.source.extractor.extract.kafka.workunit.packer.KafkaWorkUnitPacker.KAFKA_WORKUNIT_PACKER_CUSTOMIZED_TYPE;
+import static org.apache.gobblin.source.extractor.extract.kafka.workunit.packer.KafkaWorkUnitPacker.KAFKA_WORKUNIT_PACKER_TYPE;
+import static org.apache.gobblin.source.extractor.extract.kafka.workunit.packer.KafkaWorkUnitPacker.KAFKA_WORKUNIT_SIZE_ESTIMATOR_CUSTOMIZED_TYPE;
+import static org.apache.gobblin.source.extractor.extract.kafka.workunit.packer.KafkaWorkUnitPacker.KAFKA_WORKUNIT_SIZE_ESTIMATOR_TYPE;
+
+
+public class KafkaWorkUnitPackerTest {
+  private KafkaWorkUnitPacker packer;
+  AbstractSource source = Mockito.mock(AbstractSource.class);
+  SourceState state;
+
+  @BeforeMethod
+  public void setUp() {
+    state = new SourceState();
+
+    // Using customized type and having customized as a known class.
+    state.setProp(KAFKA_WORKUNIT_PACKER_TYPE, "CUSTOMIZED");
+    state.setProp(KAFKA_WORKUNIT_PACKER_CUSTOMIZED_TYPE,
+        "org.apache.gobblin.source.extractor.extract.kafka.workunit.packer.KafkaSingleLevelWorkUnitPacker");
+    state.setProp(KAFKA_WORKUNIT_SIZE_ESTIMATOR_TYPE, "CUSTOMIZED");
+    state.setProp(KAFKA_WORKUNIT_SIZE_ESTIMATOR_CUSTOMIZED_TYPE,
+        "org.apache.gobblin.source.extractor.extract.kafka.workunit.packer.KafkaAvgRecordTimeBasedWorkUnitSizeEstimator");
+    packer = new TestKafkaWorkUnitPacker(source, state);
+  }
+
+  @Test
+  public void testGetWorkUnitSizeEstimator() {
+    KafkaWorkUnitSizeEstimator estimator = packer.getWorkUnitSizeEstimator();
+    Assert.assertTrue(estimator instanceof KafkaAvgRecordTimeBasedWorkUnitSizeEstimator);
+  }
+
+  @Test
+  public void testGetInstance() {
+    KafkaWorkUnitPacker anotherPacker = KafkaWorkUnitPacker.getInstance(source, state);
+    Assert.assertTrue(anotherPacker instanceof KafkaSingleLevelWorkUnitPacker);
+  }
+
+  public class TestKafkaWorkUnitPacker extends KafkaWorkUnitPacker {
+    public TestKafkaWorkUnitPacker(AbstractSource<?, ?> source, SourceState state) {
+      super(source, state);
+    }
+
+    // Dummy implementation for making abstract class instantiable only.
+    @Override
+    public List<WorkUnit> pack(Map<String, List<WorkUnit>> workUnitsByTopic, int numContainers) {
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following
    - https://issues.apache.org/jira/browse/GOBBLIN-874


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):

Leave the original enum there for backward-compatible. 

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

