### PR TITLE
GOBBLIN-876: Expose metrics() API in GobblinKafkaConsumerClient to al…

### DIFF
--- a/gobblin-modules/gobblin-kafka-09/src/main/java/org/apache/gobblin/kafka/client/Kafka09ConsumerClient.java
+++ b/gobblin-modules/gobblin-kafka-09/src/main/java/org/apache/gobblin/kafka/client/Kafka09ConsumerClient.java
@@ -171,7 +171,7 @@ public class Kafka09ConsumerClient<K, V> extends AbstractBaseKafkaConsumerClient
   }
 
   @Override
-  public Map<String, Metric> metrics() {
+  public Map<String, Metric> getMetrics() {
     Map<MetricName, KafkaMetric> kafkaMetrics = (Map<MetricName, KafkaMetric>) this.consumer.metrics();
     Map<String, Metric> codaHaleMetricMap = new HashMap<>();
 

--- a/gobblin-modules/gobblin-kafka-09/src/main/java/org/apache/gobblin/kafka/client/Kafka09ConsumerClient.java
+++ b/gobblin-modules/gobblin-kafka-09/src/main/java/org/apache/gobblin/kafka/client/Kafka09ConsumerClient.java
@@ -176,7 +176,7 @@ public class Kafka09ConsumerClient<K, V> extends AbstractBaseKafkaConsumerClient
     Map<String, Metric> codaHaleMetricMap = new HashMap<>();
 
     kafkaMetrics
-        .forEach((key, value) -> codaHaleMetricMap.put(canonicalMerticName(value), kafkaToCodaHaleMetric(value)));
+        .forEach((key, value) -> codaHaleMetricMap.put(canonicalMetricName(value), kafkaToCodaHaleMetric(value)));
     return codaHaleMetricMap;
   }
 
@@ -193,7 +193,7 @@ public class Kafka09ConsumerClient<K, V> extends AbstractBaseKafkaConsumerClient
     return gauge;
   }
 
-  private String canonicalMerticName(KafkaMetric kafkaMetric) {
+  private String canonicalMetricName(KafkaMetric kafkaMetric) {
     MetricName name = kafkaMetric.metricName();
     return canonicalMetricName(name.group(), name.tags().values(), name.name());
   }

--- a/gobblin-modules/gobblin-kafka-09/src/main/java/org/apache/gobblin/kafka/client/Kafka09ConsumerClient.java
+++ b/gobblin-modules/gobblin-kafka-09/src/main/java/org/apache/gobblin/kafka/client/Kafka09ConsumerClient.java
@@ -18,8 +18,10 @@ package org.apache.gobblin.kafka.client;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
 
@@ -27,9 +29,13 @@ import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.metrics.KafkaMetric;
 
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Metric;
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
@@ -43,6 +49,7 @@ import com.typesafe.config.ConfigFactory;
 import javax.annotation.Nonnull;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
 
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.source.extractor.extract.kafka.KafkaOffsetRetrievalFailureException;
@@ -58,6 +65,7 @@ import org.apache.gobblin.util.ConfigUtils;
  * @param <K> Message key type
  * @param <V> Message value type
  */
+@Slf4j
 public class Kafka09ConsumerClient<K, V> extends AbstractBaseKafkaConsumerClient {
 
   private static final String KAFKA_09_CLIENT_BOOTSTRAP_SERVERS_KEY = "bootstrap.servers";
@@ -161,6 +169,35 @@ public class Kafka09ConsumerClient<K, V> extends AbstractBaseKafkaConsumerClient
       }
     });
   }
+
+  @Override
+  public Map<String, Metric> metrics() {
+    Map<MetricName, KafkaMetric> kafkaMetrics = (Map<MetricName, KafkaMetric>) this.consumer.metrics();
+    Map<String, Metric> codaHaleMetricMap = new HashMap<>();
+
+    kafkaMetrics
+        .forEach((key, value) -> codaHaleMetricMap.put(canonicalMerticName(value), kafkaToCodaHaleMetric(value)));
+    return codaHaleMetricMap;
+  }
+
+  /**
+   * Convert a {@link KafkaMetric} instance to a {@link Metric}.
+   * @param kafkaMetric
+   * @return
+   */
+  private Metric kafkaToCodaHaleMetric(final KafkaMetric kafkaMetric) {
+    if (log.isDebugEnabled()) {
+      log.debug("Processing a metric change for {}", kafkaMetric.metricName().toString());
+    }
+    Gauge<Double> gauge = () -> kafkaMetric.value();
+    return gauge;
+  }
+
+  private String canonicalMerticName(KafkaMetric kafkaMetric) {
+    MetricName name = kafkaMetric.metricName();
+    return canonicalMetricName(name.group(), name.tags().values(), name.name());
+  }
+
 
   @Override
   public void close() throws IOException {

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/kafka/client/AbstractBaseKafkaConsumerClient.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/kafka/client/AbstractBaseKafkaConsumerClient.java
@@ -85,15 +85,15 @@ public abstract class AbstractBaseKafkaConsumerClient implements GobblinKafkaCon
 
   /**
    * A helper method that returns the canonical metric name for a kafka metric. A typical canonicalized metric name would
-   * be of the following format: "{metric-group}_{client-id}_{metric-name}". This method is invoked in {@link GobblinKafkaConsumerClient#metrics()}
+   * be of the following format: "{metric-group}_{client-id}_{metric-name}". This method is invoked in {@link GobblinKafkaConsumerClient#getMetrics()}
    * implementations to convert KafkaMetric names to a Coda Hale metric name. Note that the canonicalization is done on every invocation of the
-   * {@link GobblinKafkaConsumerClient#metrics()} API.
+   * {@link GobblinKafkaConsumerClient#getMetrics()} ()} API.
    * @param metricGroup the type of the Kafka metric e.g."consumer-fetch-manager-metrics", "consumer-coordinator-metrics" etc.
    * @param metricTags any tags associated with the Kafka metric, typically include the kafka client id, topic name, partition number etc.
    * @param metricName the name of the Kafka metric e.g. "records-lag-max", "fetch-throttle-time-max" etc.
    * @return the canonicalized metric name.
    */
-  String canonicalMetricName(String metricGroup, Collection<String> metricTags, String metricName) {
+  public String canonicalMetricName(String metricGroup, Collection<String> metricTags, String metricName) {
     List<String> nameParts = new ArrayList<>();
     nameParts.add(metricGroup);
     nameParts.addAll(metricTags);

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/kafka/client/AbstractBaseKafkaConsumerClient.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/kafka/client/AbstractBaseKafkaConsumerClient.java
@@ -85,7 +85,9 @@ public abstract class AbstractBaseKafkaConsumerClient implements GobblinKafkaCon
 
   /**
    * A helper method that returns the canonical metric name for a kafka metric. A typical canonicalized metric name would
-   * be of the following format: "{metric-group}_{client-id}_{metric-name}".
+   * be of the following format: "{metric-group}_{client-id}_{metric-name}". This method is invoked in {@link GobblinKafkaConsumerClient#metrics()}
+   * implementations to convert KafkaMetric names to a Coda Hale metric name. Note that the canonicalization is done on every invocation of the
+   * {@link GobblinKafkaConsumerClient#metrics()} API.
    * @param metricGroup the type of the Kafka metric e.g."consumer-fetch-manager-metrics", "consumer-coordinator-metrics" etc.
    * @param metricTags any tags associated with the Kafka metric, typically include the kafka client id, topic name, partition number etc.
    * @param metricName the name of the Kafka metric e.g. "records-lag-max", "fetch-throttle-time-max" etc.

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/kafka/client/AbstractBaseKafkaConsumerClient.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/kafka/client/AbstractBaseKafkaConsumerClient.java
@@ -91,7 +91,7 @@ public abstract class AbstractBaseKafkaConsumerClient implements GobblinKafkaCon
    * @param metricName the name of the Kafka metric e.g. "records-lag-max", "fetch-throttle-time-max" etc.
    * @return the canonicalized metric name.
    */
-  public String canonicalMetricName(String metricGroup, Collection<String> metricTags, String metricName) {
+  String canonicalMetricName(String metricGroup, Collection<String> metricTags, String metricName) {
     List<String> nameParts = new ArrayList<>();
     nameParts.add(metricGroup);
     nameParts.addAll(metricTags);

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/kafka/client/AbstractBaseKafkaConsumerClient.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/kafka/client/AbstractBaseKafkaConsumerClient.java
@@ -16,24 +16,23 @@
  */
 package org.apache.gobblin.kafka.client;
 
-import com.google.common.base.Function;
-import com.google.common.base.Predicate;
-import com.google.common.collect.FluentIterable;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-import org.apache.gobblin.source.extractor.extract.kafka.KafkaTopic;
-import org.apache.gobblin.util.DatasetFilterUtils;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.typesafe.config.Config;
 
-import org.apache.gobblin.configuration.ConfigurationKeys;
-import org.apache.gobblin.util.ConfigUtils;
-import java.util.Map;
-import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.source.extractor.extract.kafka.KafkaTopic;
+import org.apache.gobblin.util.ConfigUtils;
+import org.apache.gobblin.util.DatasetFilterUtils;
 
 
 /**
@@ -83,6 +82,33 @@ public abstract class AbstractBaseKafkaConsumerClient implements GobblinKafkaCon
       }
     }));
   }
+
+  /**
+   * A helper method that returns the canonical metric name for a kafka metric. A typical canonicalized metric name would
+   * be of the following format: "{metric-group}_{client-id}_{metric-name}".
+   * @param metricGroup the type of the Kafka metric e.g."consumer-fetch-manager-metrics", "consumer-coordinator-metrics" etc.
+   * @param metricTags any tags associated with the Kafka metric, typically include the kafka client id, topic name, partition number etc.
+   * @param metricName the name of the Kafka metric e.g. "records-lag-max", "fetch-throttle-time-max" etc.
+   * @return the canonicalized metric name.
+   */
+  public String canonicalMetricName(String metricGroup, Collection<String> metricTags, String metricName) {
+    List<String> nameParts = new ArrayList<>();
+    nameParts.add(metricGroup);
+    nameParts.addAll(metricTags);
+    nameParts.add(metricName);
+
+    StringBuilder builder = new StringBuilder();
+    for (String namePart : nameParts) {
+      builder.append(namePart);
+      builder.append(".");
+    }
+    // Remove the trailing dot.
+    builder.setLength(builder.length() - 1);
+    String processedName = builder.toString().replace(' ', '_').replace("\\.", "_");
+
+    return processedName;
+  }
+
 
   /**
    * Get a list of all kafka topics

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/kafka/client/AbstractBaseKafkaConsumerClient.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/kafka/client/AbstractBaseKafkaConsumerClient.java
@@ -93,7 +93,7 @@ public abstract class AbstractBaseKafkaConsumerClient implements GobblinKafkaCon
    * @param metricName the name of the Kafka metric e.g. "records-lag-max", "fetch-throttle-time-max" etc.
    * @return the canonicalized metric name.
    */
-  public String canonicalMetricName(String metricGroup, Collection<String> metricTags, String metricName) {
+  protected String canonicalMetricName(String metricGroup, Collection<String> metricTags, String metricName) {
     List<String> nameParts = new ArrayList<>();
     nameParts.add(metricGroup);
     nameParts.addAll(metricTags);

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/kafka/client/GobblinKafkaConsumerClient.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/kafka/client/GobblinKafkaConsumerClient.java
@@ -19,8 +19,11 @@ package org.apache.gobblin.kafka.client;
 import java.io.Closeable;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
 
+import com.codahale.metrics.Metric;
+import com.google.common.collect.Maps;
 import com.typesafe.config.Config;
 
 import org.apache.gobblin.source.extractor.extract.kafka.KafkaOffsetRetrievalFailureException;
@@ -85,6 +88,15 @@ public interface GobblinKafkaConsumerClient extends Closeable {
    * @return An {@link Iterator} of {@link KafkaConsumerRecord}s
    */
   public Iterator<KafkaConsumerRecord> consume(KafkaPartition partition, long nextOffset, long maxOffset);
+
+  /**
+   * API to return underlying Kafka consumer metrics. The individual implementations must translate
+   * org.apache.kafka.common.Metric to Coda Hale Metrics.
+   * @return
+   */
+  public default Map<String, Metric> metrics() {
+    return Maps.newHashMap();
+  }
 
   /**
    * A factory to create {@link GobblinKafkaConsumerClient}s

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/kafka/client/GobblinKafkaConsumerClient.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/kafka/client/GobblinKafkaConsumerClient.java
@@ -94,7 +94,7 @@ public interface GobblinKafkaConsumerClient extends Closeable {
    * org.apache.kafka.common.Metric to Coda Hale Metrics.
    * @return
    */
-  public default Map<String, Metric> metrics() {
+  public default Map<String, Metric> getMetrics() {
     return Maps.newHashMap();
   }
 

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/kafka/client/GobblinKafkaConsumerClient.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/kafka/client/GobblinKafkaConsumerClient.java
@@ -91,7 +91,8 @@ public interface GobblinKafkaConsumerClient extends Closeable {
 
   /**
    * API to return underlying Kafka consumer metrics. The individual implementations must translate
-   * org.apache.kafka.common.Metric to Coda Hale Metrics.
+   * org.apache.kafka.common.Metric to Coda Hale Metrics. A typical use case for reporting the consumer metrics
+   * will call this method inside a scheduled thread.
    * @return
    */
   public default Map<String, Metric> getMetrics() {


### PR DESCRIPTION
…low consume metrics to be reported.

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-876


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Newer Kafka consumer expose metrics() API that report a number of consumer metrics such as lag, latency, etc. which are very useful for monitoring and debugging. We expose a metrics() API in GobblinKafkaConsumerClient to allow consumer metrics to be reported. 



### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
NA.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

