### PR TITLE
[GOBBLIN-877]Add column metadata for partition for inline hive registration

### DIFF
--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/metastore/HiveMetaStoreUtils.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/metastore/HiveMetaStoreUtils.java
@@ -212,7 +212,7 @@ public class HiveMetaStoreUtils {
     State props = unit.getStorageProps();
     StorageDescriptor sd = new StorageDescriptor();
     sd.setParameters(getParameters(props));
-    if (unit.isRegisterSchema()|| !unit.getInputFormat().equals(AvroContainerInputFormat.class.getName())) {
+    if (unit.isRegisterSchema() || !unit.getInputFormat().equals(AvroContainerInputFormat.class.getName())) {
       sd.setCols(getFieldSchemas(unit));
     }
     if (unit.getLocation().isPresent()) {

--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/metastore/HiveMetaStoreUtils.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/metastore/HiveMetaStoreUtils.java
@@ -212,6 +212,7 @@ public class HiveMetaStoreUtils {
     State props = unit.getStorageProps();
     StorageDescriptor sd = new StorageDescriptor();
     sd.setParameters(getParameters(props));
+    //Treat AVRO and other formats differently. Details can be found in GOBBLIN-877
     if (unit.isRegisterSchema() || !unit.getInputFormat().equals(AvroContainerInputFormat.class.getName())) {
       sd.setCols(getFieldSchemas(unit));
     }

--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/metastore/HiveMetaStoreUtils.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/metastore/HiveMetaStoreUtils.java
@@ -213,7 +213,8 @@ public class HiveMetaStoreUtils {
     StorageDescriptor sd = new StorageDescriptor();
     sd.setParameters(getParameters(props));
     //Treat AVRO and other formats differently. Details can be found in GOBBLIN-877
-    if (unit.isRegisterSchema() || !unit.getInputFormat().equals(AvroContainerInputFormat.class.getName())) {
+    if (unit.isRegisterSchema() ||
+        (unit.getInputFormat().isPresent() && !unit.getInputFormat().get().equals(AvroContainerInputFormat.class.getName()))) {
       sd.setCols(getFieldSchemas(unit));
     }
     if (unit.getLocation().isPresent()) {

--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/metastore/HiveMetaStoreUtils.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/metastore/HiveMetaStoreUtils.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.SerDeInfo;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat;
 import org.apache.hadoop.hive.serde2.Deserializer;
 import org.apache.hadoop.hive.serde2.SerDeException;
 import org.apache.hadoop.hive.serde2.SerDeUtils;
@@ -211,7 +212,7 @@ public class HiveMetaStoreUtils {
     State props = unit.getStorageProps();
     StorageDescriptor sd = new StorageDescriptor();
     sd.setParameters(getParameters(props));
-    if (unit.isRegisterSchema()) {
+    if (unit.isRegisterSchema()|| !unit.getInputFormat().equals(AvroContainerInputFormat.class.getName())) {
       sd.setCols(getFieldSchemas(unit));
     }
     if (unit.getLocation().isPresent()) {


### PR DESCRIPTION

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-877


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Previously, we remove the schema.literal for partition.  Because Avro schemas should only be defined at the table level. Hive overrides table properties if the same property is defined on the partition. Defining them at the partition level may lead to partitions with inconsistent schemas. And because column metadata is calculated from schema.literal, so we remove the column metadata as well.

Then we encounter a problem that presto cannot read data from orc file. Because ORC (and other Hive serdes) need metadata in the partitions so that coercion can be done between a partition schema and the table schema.

So we need to treat Avro and other formate separately to make sure hive registration works well so that user can read right data from Presto.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Test on dataset written in orc format and I can read data from presto 

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

