### PR TITLE
[GOBBLIN-882]: Modify GaaS configuration so that it runs through the startup script

### DIFF
--- a/conf/service/application.conf
+++ b/conf/service/application.conf
@@ -36,3 +36,12 @@ flowSpec.store.dir=${gobblin.service.work.dir}/flowSpecStore
 
 # Template Catalog
 gobblin.service.templateCatalogs.fullyQualifiedPath="file:///tmp/templateCatalog"
+
+# JobStatusMonitor
+gobblin.service.jobStatusMonitor.enabled=false
+
+# FsJobStatusRetriever
+fsJobStatusRetriever.state.store.dir=${gobblin.service.work.dir}/state-store
+
+# RestLI
+gobblin.service.port=6956


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-882#


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

Currently the script `./gobblin-service.sh start` fails to start the service. My changes modify the configuration to have the service running and accepting API calls minimally directly off the script.

After building the project, GaaS should be able to run directly with the script `./bin/gobblin-service.sh start`.

If the script complains about the templateCatalog path not existing, set it to wherever the templates are stored locally or create a folder in `/tmp/templateCatalog`

The JobStatusMonitor is disabled in the config for now to get the service running but will work on finding a way to have that running too.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

