### PR TITLE
GOBBLIN-880 Bump CouchbaseWriter Couchbase SDK version + write docs +…

### DIFF
--- a/gobblin-docs/writers/CouchbaseWriter.md
+++ b/gobblin-docs/writers/CouchbaseWriter.md
@@ -1,0 +1,147 @@
+[TOC]
+
+# Introduction
+A CouchbaseWriter is both an AsyncDataWriter a SyncDataWriter that pushes Documents to a couchbase bucket though the [JAVA SDK](https://docs.couchbase.com/java-sdk/current/start-using-sdk.html). Note that CouchbaseWiter only supports writing to a single bucket as there should be only 1 CouchbaseEnvironment per JVM.
+
+
+# Record format
+Couchbase writer currently support `AVRO` and `JSON` as data inputs. On both of them it requires the following structured schema:
+
+
+| Document field | Description |
+| -------------- | ----------- |
+| `key` | Unique key used to store the document on the bucket. For more info view [Couchbase docs](https://developer.couchbase.com/documentation/server/3.x/developer/dev-guide-3.0/keys-values.html)  |
+| `data.data` | Object or value containing the information associated with the `key` for this document |
+| `data.flags` | [Couchbase flags](https://docs.couchbase.com/server/4.1/developer-guide/transcoders.html) To store JSON on `data.data` use `0x02 << 24` for UTF-8 `0x04 << 24` . |
+
+The following is a sample input record with JSON data
+
+```json
+{
+ "key": "myKey123",
+ "data": {
+    "data": {
+        "field1": "field1Value",
+        "field2": 123
+    },
+    "flags": 33554432
+  }
+}
+```
+
+or to store plain text:
+
+```json
+{
+ "key": "myKey123",
+ "data": {
+    "data": "singleValueData",
+    "flags": 67108864
+  }
+}
+```
+
+If using AVRO, use the following schema:
+
+```json
+{
+  "type" : "record",
+  "name" : "topLevelRecord",
+  "fields" : [ {
+    "name" : "key",
+    "type" : "string"
+  }, {
+    "name" : "data",
+    "type" : {
+      "type" : "record",
+      "name" : "data",
+      "namespace" : "topLevelRecord",
+      "fields" : [ {
+        "name" : "data",
+        "type" : [ "bytes", "null" ]
+      }, {
+        "name" : "flags",
+        "type" : "int"
+      } ]
+    }
+  } ]
+}
+```
+Note that the key can be other than string if needed.
+# Configuration
+## General configuration values
+| Configuration Key | Default Value | Description |
+| ----------------- | ------------- | ----------- |
+| `writer.couchbase.bucket` | Optional | Name of the couchbase bucket. Change if using other than default bucket |
+| `writer.couchbase.default` | `"default"` | Name of the default bucket if `writer.couchbase.bucket` is not provided |
+| `writer.couchbase.dnsSrvEnabled` | `"false"` | Enable DNS SRV bootstrapping [docs](https://docs.couchbase.com/java-sdk/current/managing-connections.html) | 
+| `writer.couchbase.bootstrapServers | `localhost` | URL to bootstrap servers. If using DNS SRV set `writer.couchbase.dnsSrvEnabled` to true |
+| `writer.couchbase.sslEnabled` | `false` | Use SSL to connect to couchbase |
+| `writer.couchbase.password` | Optional | Bucket password. Will be ignored if `writer.couchbase.certAuthEnabled` is true |
+| `writer.couchbase.certAuthEnabled` | `false` | Set to true if using certificate authentication. Must also specify `writer.couchbase.sslKeystoreFile`, `writer.couchbase.sslKeystorePassword`, `writer.couchbase.sslTruststoreFile`, and `writer.couchbase.sslTruststorePassword` |
+| `writer.couchbase.sslKeystoreFile` | Optional | Path to the keystore file location |
+| `writer.couchbase.sslKeystorePassword` | Optional | Keystore password |
+| `writer.couchbase.sslTruststoreFile` | Optional | Path to the trustStore file location |
+| `writer.couchbase.sslTruststorePassword` | Optional | TrustStore password |
+| `writer.couchbase.documentTTL` | `0` | Time To Live of each document. Units are specified in `writer.couchbase.documentTTLOriginField` |
+| `writer.couchbase.documentTTLUnits` | `SECONDS` | Unit for `writer.couchbase.documentTTL`. Must be one of [java.util.concurrent.TimeUnit](https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/TimeUnit.html). Case insensitive  |
+| `writer.couchbase.documentTTLOriginField` | Optional | Time To Live of each document. Units are specified in `writer.couchbase.documentTTLOriginField` |
+| `writer.couchbase.documentTTLOriginUnits` | `MILLISECONDS` | Unit for `writer.couchbase.documentTTL`. Must be one of [java.util.concurrent.TimeUnit](https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/TimeUnit.html). Case insensitive. As an example a `writer.couchbase.documentTTLOriginField` value of `1568240399000` and `writer.couchbase.documentTTLOriginUnits` value of `MILLISECONDS` timeunit would be `Wed Sep 11 15:19:59 PDT 2019` |
+| `writer.couchbase.retriesEnabled` | `false` | Enable write retries on failures |
+| `writer.couchbase.maxRetries` | `5` | Maximum number of retries |
+| `writer.couchbase.failureAllowancePercentage` | `0.0` | The percentage of failures that you are willing to tolerate while writing to Couchbase. Gobblin will mark the workunit successful and move on if there are failures but not enough to trip the failure threshold. Only successfully acknowledged writes are counted as successful, all others are considered as failures. The default for the failureAllowancePercentage is set to 0.0. For example, if the value is set to 0.2 This means that as long as 80% of the data is acknowledged by Kafka, Gobblin will move on. If you want higher guarantees, set this config value to a lower value. e.g. If you want 99% delivery guarantees, set this value to 0.01 |
+|`operationTimeoutMillis` | `10000` | Global timeout for couchbase communication operations |
+
+## Authentication
+### No credentials
+NOT RECOMMENDED FOR PRODUCTION.
+
+Do not set `writer.couchbase.certAuthEnabled` nor `writer.couchbase.password`
+### Using certificates
+Set `writer.couchbase.certAuthEnabled` to `true` and values for `writer.couchbase.sslKeystoreFile`, `writer.couchbase.sslKeystorePassword`, `writer.couchbase.sslTruststoreFile`, and `writer.couchbase.sslTruststorePassword`.
+
+`writer.couchbase.password` setting will be ignored if `writer.couchbase.certAuthEnabled` is set
+### Using bucket password
+Set `writer.couchbase.password`
+
+## Document level expiration
+Couchbase writer allows to set expiration at the document level using the [expiry](https://docs.couchbase.com/java-sdk/current/document-operations.html) property of the couchbase document. PLease note that current couchbase implementation using timestamps limits it to January 19, 2038 03:14:07 GM given the type of expiry is set to int. CouchbaseWriter only works with global timestamps and does not use relative expiration in seconds (<30 days) for simplicity.
+Currently three modes are supported:
+### 1 - Expiration from write time
+Define only `writer.couchbase.documentTTL` and `writer.couchbase.documentTTLUnits`. For example for a 2 days expiration configs would look like:
+
+| Configuration Key | Value |
+| ----------------- | ------------- |
+| `writer.couchbase.documentTTL` | `2` |
+| `writer.couchbase.documentTTLUnits` | `DAYS` |
+
+### 2 - Expiration from an origin timestamp
+Define only `writer.couchbase.documentTTL` and `writer.couchbase.documentTTLUnits`.
+
+For example for a 2 days expiration configs using the `header.time` field that has timestamp in MILLISECONDS would look like:
+
+| Configuration Key | Value |
+| ----------------- | ------------- |
+| `writer.couchbase.documentTTL` | `2` |
+| `writer.couchbase.documentTTLUnits` | `"DAYS"` |
+| `writer.couchbase.documentTTLOriginField` | `"header.time"` |
+| `writer.couchbase.documentTTLOriginUnits` | `1568240399000` |
+
+So a sample document with origin on 1568240399 (Wed Sep 11 15:19:59 PDT 2019) would expire on 1568413199 (Fri Sep 13 15:19:59 PDT 2019). The following is a sample record format.
+
+```json
+{
+ "key": "sampleKey",
+ "data": {
+    "data": {
+        "field1": "field1Value",
+        "header": {
+            "time": 1568240399000
+        }
+    },
+    "flags": 33554432
+  }
+}
+```
+
+}

--- a/gobblin-modules/gobblin-couchbase/build.gradle
+++ b/gobblin-modules/gobblin-couchbase/build.gradle
@@ -23,7 +23,7 @@ dependencies {
   compile project(":gobblin-utility")
   compile project(":gobblin-metrics-libs:gobblin-metrics")
 
-  compile "com.couchbase.client:java-client:2.5.4"
+  compile "com.couchbase.client:java-client:2.7.6"
   compile externalDependency.avro
   compile externalDependency.jacksonCore
   compile externalDependency.jacksonMapper
@@ -44,6 +44,7 @@ dependencies {
   testCompile externalDependency.jsonAssert
   testCompile externalDependency.mockito
   testCompile externalDependency.testng
+  testCompile "com.couchbase.mock:CouchbaseMock:1.5.23"
 }
 
 

--- a/gobblin-modules/gobblin-couchbase/src/main/java/org/apache/gobblin/couchbase/writer/CouchbaseEnvironmentFactory.java
+++ b/gobblin-modules/gobblin-couchbase/src/main/java/org/apache/gobblin/couchbase/writer/CouchbaseEnvironmentFactory.java
@@ -45,23 +45,22 @@ public class CouchbaseEnvironmentFactory {
     String sslTruststoreFile = ConfigUtils.getString(config, CouchbaseWriterConfigurationKeys.SSL_TRUSTSTORE_FILE, "");
     String sslTruststorePassword = ConfigUtils.getString(config, CouchbaseWriterConfigurationKeys.SSL_TRUSTSTORE_PASSWORD, "");
     Boolean certAuthEnabled = ConfigUtils.getBoolean(config, CouchbaseWriterConfigurationKeys.CERT_AUTH_ENABLED, false);
+    Boolean dnsSrvEnabled = ConfigUtils.getBoolean(config, CouchbaseWriterConfigurationKeys.DNS_SRV_ENABLED, false);
 
-    DefaultCouchbaseEnvironment.Builder builder = DefaultCouchbaseEnvironment
-	.builder()
+
+    DefaultCouchbaseEnvironment.Builder builder = DefaultCouchbaseEnvironment.builder()
         .sslEnabled(sslEnabled)
         .sslKeystoreFile(sslKeystoreFile)
         .sslKeystorePassword(sslKeystorePassword)
         .sslTruststoreFile(sslTruststoreFile)
         .sslTruststorePassword(sslTruststorePassword)
-        .certAuthEnabled(certAuthEnabled);
+        .certAuthEnabled(certAuthEnabled)
+        .dnsSrvEnabled(dnsSrvEnabled);
 
     if (couchbaseEnvironment == null)
     {
       couchbaseEnvironment = builder.build();
-      return couchbaseEnvironment;
     }
-    else {
-      return couchbaseEnvironment;
-    }
+    return couchbaseEnvironment;
   }
 }

--- a/gobblin-modules/gobblin-couchbase/src/main/java/org/apache/gobblin/couchbase/writer/CouchbaseWriterConfigurationKeys.java
+++ b/gobblin-modules/gobblin-couchbase/src/main/java/org/apache/gobblin/couchbase/writer/CouchbaseWriterConfigurationKeys.java
@@ -19,6 +19,7 @@ package org.apache.gobblin.couchbase.writer;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 
 public class CouchbaseWriterConfigurationKeys {
@@ -40,6 +41,14 @@ public class CouchbaseWriterConfigurationKeys {
   public static final String SSL_TRUSTSTORE_FILE = prefix("sslTruststoreFile");
   public static final String SSL_TRUSTSTORE_PASSWORD = prefix("sslTruststorePassword");
   public static final String CERT_AUTH_ENABLED = prefix("certAuthEnabled");
+  public static final String DNS_SRV_ENABLED = prefix("dnsSrvEnabled");
+
+  public static final String DOCUMENT_TTL = prefix("documentTTL");
+  public static final String DOCUMENT_TTL_UNIT = prefix("documentTTLUnits");
+  public static final TimeUnit DOCUMENT_TTL_UNIT_DEFAULT = TimeUnit.SECONDS;
+  public static final String DOCUMENT_TTL_ORIGIN_FIELD = prefix("documentTTLOriginField");
+  public static final String DOCUMENT_TTL_ORIGIN_FIELD_UNITS = prefix("documentTTLOriginUnits");
+  public static final TimeUnit DOCUMENT_TTL_ORIGIN_FIELD_UNITS_DEFAULT = TimeUnit.MILLISECONDS;
 
   public static final String OPERATION_TIMEOUT_MILLIS = prefix("operationTimeoutMillis");
   public static final long OPERATION_TIMEOUT_DEFAULT = 10000; // 10 second default timeout

--- a/gobblin-modules/gobblin-couchbase/src/test/java/org/apache/gobblin/couchbase/CouchbaseTestServer.java
+++ b/gobblin-modules/gobblin-couchbase/src/test/java/org/apache/gobblin/couchbase/CouchbaseTestServer.java
@@ -17,8 +17,8 @@
 
 package org.apache.gobblin.couchbase;
 
+import com.couchbase.mock.CouchbaseMock;
 import java.io.BufferedReader;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
@@ -47,11 +47,7 @@ import org.apache.gobblin.test.TestUtils;
 @Slf4j
 public class CouchbaseTestServer {
 
-  private static final String COUCHBASE_JAR_PATH="gobblin-modules/gobblin-couchbase/mock-couchbase/target/";
-  private static final String COUCHBASE_MOCK_JAR=COUCHBASE_JAR_PATH + "CouchbaseMock-1.5.18.jar";
 
-
-  private Process couchbaseProcess;
   private int _port;
   private int _serverPort;
 
@@ -62,12 +58,8 @@ public class CouchbaseTestServer {
 
   public void start()
   {
-
     log.info("Starting couchbase server on port " + _port);
-    String[] commands = {"/usr/bin/java",
-      "-cp",
-      COUCHBASE_MOCK_JAR,
-      "com.couchbase.mock.CouchbaseMock",
+    String[] commands = {
       "--port",
       _port +"",
       "-n",
@@ -81,7 +73,7 @@ public class CouchbaseTestServer {
 
     try {
       System.out.println("Will run command " + Arrays.toString(commands));
-      couchbaseProcess = new ProcessBuilder().inheritIO().command(commands).start();
+      CouchbaseMock.main(commands);
     }
     catch (Exception e)
     {
@@ -157,16 +149,7 @@ public class CouchbaseTestServer {
   public int getPort() { return _port; }
 
 
-  public void stop() {
-
-    if (couchbaseProcess != null) {
-      try {
-        couchbaseProcess.destroy();
-      } catch (Exception e) {
-        log.warn("Failed to stop the couchbase server", e);
-      }
-    }
-  }
+  public void stop() {}
 
 
   @Test

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/ConfigUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/ConfigUtils.java
@@ -17,9 +17,11 @@
 
 package org.apache.gobblin.util;
 
+import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.io.StringReader;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -30,6 +32,8 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
 
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 
 import com.google.common.base.Function;
@@ -67,6 +71,13 @@ public class ConfigUtils {
    * property keys. This is used during Properties -> Config -> Properties conversion since
    * typesafe config does not allow such properties. */
   public static final String STRIP_SUFFIX = ".ROOT_VALUE";
+
+  /**
+   * Available TimeUnit values that can be parsed from a given String
+   */
+  private static final Set<String> validTimeUnits = Arrays.stream(TimeUnit.values())
+      .map(TimeUnit::name)
+      .collect(Collectors.toSet());
 
   public ConfigUtils(FileUtils fileUtils) {
     this.fileUtils = fileUtils;
@@ -322,6 +333,23 @@ public class ConfigUtils {
   public static String getString(Config config, String path, String def) {
     if (config.hasPath(path)) {
       return config.getString(path);
+    }
+    return def;
+  }
+
+  /**
+   * Return TimeUnit value at <code>path</code> if <code>config</code> has path. If not return <code>def</code>
+   *
+   * @param config in which the path may be present
+   * @param path key to look for in the config object
+   * @return TimeUnit value at <code>path</code> if <code>config</code> has path. If not return <code>def</code>
+   */
+  public static TimeUnit getTimeUnit(Config config, String path, TimeUnit def) {
+    if (config.hasPath(path)) {
+      String timeUnit = config.getString(path).toUpperCase();
+      Preconditions.checkArgument(validTimeUnits.contains(timeUnit),
+          "Passed invalid TimeUnit for documentTTLUnits: '%s'".format(timeUnit));
+      return TimeUnit.valueOf(timeUnit);
     }
     return def;
   }

--- a/gobblin-utility/src/test/java/org/apache/gobblin/util/ConfigUtilsTest.java
+++ b/gobblin-utility/src/test/java/org/apache/gobblin/util/ConfigUtilsTest.java
@@ -29,6 +29,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
 
+import java.util.concurrent.TimeUnit;
 import org.jasypt.util.text.BasicTextEncryptor;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -297,6 +298,37 @@ public class ConfigUtilsTest {
       Assert.assertEquals(val, entry.getValue());
     }
     keyFile.delete();
+  }
+
+  @Test
+  public void testGetTimeUnitValid() {
+    String key = "a.b.c";
+    TimeUnit expectedTimeUnit = TimeUnit.DAYS;
+    TimeUnit defaultTimeUnit = TimeUnit.MILLISECONDS;
+    Config cfg = ConfigFactory.parseMap(ImmutableMap.<String, Object>builder()
+        .put(key, TimeUnit.DAYS.name())
+        .build());
+    TimeUnit timeUnit = ConfigUtils.getTimeUnit(cfg, key, defaultTimeUnit);
+    Assert.assertEquals(timeUnit, expectedTimeUnit);
+  }
+
+  @Test
+  public void testGetTimeUnitInvalid() {
+    String key = "a.b.c";
+    final Config cfg = ConfigFactory.parseMap(ImmutableMap.<String, Object>builder()
+        .put(key, "INVALID_TIME_UNIT")
+        .build());
+    Assert.assertThrows(IllegalArgumentException.class, () -> {
+      ConfigUtils.getTimeUnit(cfg, key, TimeUnit.SECONDS);
+    });
+  }
+
+  @Test
+  public void testGetTimeUnitDefault() {
+    String key = "a.b.c";
+    TimeUnit defaultTimeUnit = TimeUnit.MINUTES;
+    final Config cfg = ConfigFactory.empty();
+    Assert.assertEquals(ConfigUtils.getTimeUnit(cfg, key, defaultTimeUnit), defaultTimeUnit);
   }
 
   private File newKeyFile(String masterPwd) throws IOException {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,8 @@ pages:
         - SQL Server: sources/SqlServerSource.md
         - Teradata: sources/TeradataSource.md
         - Wikipedia: sources/WikipediaSource.md
+    - Writers:
+        - CouchbaseWriter: CouchbaseWriter.md
     - Record Sinks:
         - Avro HDFS: sinks/AvroHdfsDataWriter.md
         - Parquet HDFS: sinks/ParquetHdfsDataWriter.md


### PR DESCRIPTION
### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-880


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
 Plese read https://issues.apache.org/jira/browse/GOBBLIN-880

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
 Added unit tests and tested to push data to a couchbase cluster though an azkaban job using hadoopJava and a snapshot of the library. Added log lines to verify expiration times are set correctly and tested pushing using cert based authentication. Please take a look at the following obfuscated data:

`13-09-2019 12:42:11 PDT gobblin-couchbase-push INFO - INFO Setting ttl timestamp 1569234590 for document 'key1' and data {"memberId":xxx,"targetId":xxx,"action":"xxx","requestId":"pvFbXpmKT7ytUn8WYBic8A==","time":1566642590043}
13-09-2019 12:42:11 PDT gobblin-couchbase-push INFO - INFO Setting ttl timestamp 1569013770 for document 'key2==' and data {"memberId":xxx,"targetId":xxx,"action":"xxx","requestId":"CtzzEq1rQ4qLXMT8zTD89w==","time":1566421770972}
`
and the records are on the bucket:
`
cbshell [bucketname]> get xxx_xxx_CtzzEq1rQ4qLXMT8zTD89w==
{
  "action": "xxx",
  "memberId": xxx,
  "requestId": "CtzzEq1rQ4qLXMT8zTD89w==",
  "targetId": xxx,
  "time": 1566421770972
}
`

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

GOBBLIN-880 Bump CouchbaseWriter Couchbase SDK version + write docs +…

… cert based auth + enable TTL + dnsSrv

JIRA ticket: https://issues.apache.org/jira/browse/GOBBLIN-880
RB Changes:
    1 - Added logic to connect using certificate based auth to the buckets (Will need to bump  com.couchbase.client:java-client to a newer version like 2.7.6) and associated configs
    2 - TTL  implementation
      * Added configs to allow setting a TTL (documentTTL) and also specify the timeunits (documentTTLUnits) of these settings
      * Added logic to specify the path to key to the field containing the source timestamp (documentTTLOriginField) and its units (documentTTLOriginUnits) to disambiguate between UNIX (sec) timestamps and other formats like timestamps in milliseconds.
    3 - Added missing dnsSrv config
    4 - Written proper documentation on gobblin-docs/writers/CouchbaseWriter.md
    5 - Brought in CouchbaseMock from Gradle and adapt existing unit tests.
    6 - Added getTimeUnit to ConfigUtils + Unit tests
