### PR TITLE
[GOBBLIN-881] Add job tag field that can be used to filter job statuses

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -152,6 +152,7 @@ public class ConfigurationKeys {
    */
   public static final String JOB_NAME_KEY = "job.name";
   public static final String JOB_GROUP_KEY = "job.group";
+  public static final String JOB_TAG_KEY = "job.tag";
   public static final String JOB_DESCRIPTION_KEY = "job.description";
   // Job launcher type
   public static final String JOB_LAUNCHER_TYPE_KEY = "launcher.type";

--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/TimingEvent.java
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/TimingEvent.java
@@ -78,6 +78,7 @@ public class TimingEvent extends GobblinEventBuilder implements Closeable {
     public static final String FLOW_EXECUTION_ID_FIELD = "flowExecutionId";
     public static final String JOB_NAME_FIELD = "jobName";
     public static final String JOB_GROUP_FIELD = "jobGroup";
+    public static final String JOB_TAG_FIELD = "jobTag";
     public static final String JOB_EXECUTION_ID_FIELD = "jobExecutionId";
     public static final String SPEC_EXECUTOR_FIELD = "specExecutor";
     public static final String LOW_WATERMARK_FIELD = "lowWatermark";

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-api/src/main/idl/org.apache.gobblin.service.flowstatuses.restspec.json
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-api/src/main/idl/org.apache.gobblin.service.flowstatuses.restspec.json
@@ -24,6 +24,10 @@
         "name" : "count",
         "type" : "int",
         "optional" : true
+      }, {
+        "name" : "tag",
+        "type" : "string",
+        "optional" : true
       } ]
     } ],
     "entity" : {

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-api/src/main/pegasus/org/apache/gobblin/service/JobStatus.pdsc
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-api/src/main/pegasus/org/apache/gobblin/service/JobStatus.pdsc
@@ -15,6 +15,12 @@
       "doc" : "Identifier of the job"
     },
     {
+      "name" : "jobTag",
+      "type" : "string",
+      "optional" : true,
+      "doc" : "Tag of the job"
+    },
+    {
       "name" : "executionStatus",
       "type" : "ExecutionStatus",
       "doc" : "Job execution status"

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-api/src/main/snapshot/org.apache.gobblin.service.flowstatuses.snapshot.json
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-api/src/main/snapshot/org.apache.gobblin.service.flowstatuses.snapshot.json
@@ -144,6 +144,11 @@
       "type" : "JobId",
       "doc" : "Identifier of the job"
     }, {
+      "name" : "jobTag",
+      "type" : "string",
+      "doc" : "Tag of the job",
+      "optional" : true
+    }, {
       "name" : "executionStatus",
       "type" : "ExecutionStatus",
       "doc" : "Job execution status"
@@ -224,6 +229,10 @@
         }, {
           "name" : "count",
           "type" : "int",
+          "optional" : true
+        }, {
+          "name" : "tag",
+          "type" : "string",
           "optional" : true
         } ]
       } ],

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-client/src/main/java/org/apache/gobblin/service/FlowStatusClient.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-client/src/main/java/org/apache/gobblin/service/FlowStatusClient.java
@@ -131,7 +131,8 @@ public class FlowStatusClient implements Closeable {
   /**
    * Get the latest flow status
    * @param flowId identifier of flow status to get
-   * @return a list of {@link FlowStatus}es corresponding to the latest <code>count</code> executions.
+   * @return a list of {@link FlowStatus}es corresponding to the latest <code>count</code> executions, containing only
+   * jobStatuses that match the given tag.
    * @throws RemoteInvocationException
    */
   public List<FlowStatus> getLatestFlowStatus(FlowId flowId, Integer count, String tag)

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-client/src/main/java/org/apache/gobblin/service/FlowStatusClient.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-client/src/main/java/org/apache/gobblin/service/FlowStatusClient.java
@@ -134,13 +134,13 @@ public class FlowStatusClient implements Closeable {
    * @return a list of {@link FlowStatus}es corresponding to the latest <code>count</code> executions.
    * @throws RemoteInvocationException
    */
-  public List<FlowStatus> getLatestFlowStatus(FlowId flowId, Integer count)
+  public List<FlowStatus> getLatestFlowStatus(FlowId flowId, Integer count, String tag)
       throws RemoteInvocationException {
     LOG.debug("getFlowConfig with groupName " + flowId.getFlowGroup() + " flowName " +
         flowId.getFlowName() + " count " + Integer.toString(count));
 
     FindRequest<FlowStatus> findRequest = _flowstatusesRequestBuilders.findByLatestFlowStatus().flowIdParam(flowId).
-        addReqParam("count", count, Integer.class).build();
+        addReqParam("count", count, Integer.class).addParam("tag", tag, String.class).build();
 
     Response<CollectionResponse<FlowStatus>> response =
         _restClient.get().sendRequest(findRequest).getResponse();

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowStatusResource.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowStatusResource.java
@@ -26,6 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.inject.Inject;
+import com.linkedin.data.template.SetMode;
 import com.linkedin.restli.common.ComplexResourceKey;
 import com.linkedin.restli.common.EmptyRecord;
 import com.linkedin.restli.server.PagingContext;
@@ -68,7 +69,7 @@ public class FlowStatusResource extends ComplexKeyResourceTemplate<FlowStatusId,
     LOG.info("Get called with flowGroup " + flowGroup + " flowName " + flowName + " flowExecutionId " + flowExecutionId);
 
     org.apache.gobblin.service.monitoring.FlowStatus flowStatus =
-        _flowStatusGenerator.getFlowStatus(flowName, flowGroup, flowExecutionId);
+        _flowStatusGenerator.getFlowStatus(flowName, flowGroup, flowExecutionId, null);
 
     // this returns null to raise a 404 error if flowStatus is null
     return convertFlowStatus(flowStatus);
@@ -76,14 +77,14 @@ public class FlowStatusResource extends ComplexKeyResourceTemplate<FlowStatusId,
 
   @Finder("latestFlowStatus")
   public List<FlowStatus> getLatestFlowStatus(@Context PagingContext context,
-      @QueryParam("flowId") FlowId flowId, @Optional @QueryParam("count") Integer count) {
+      @QueryParam("flowId") FlowId flowId, @Optional @QueryParam("count") Integer count, @Optional @QueryParam("tag") String tag) {
     if (count == null) {
       count = 1;
     }
     LOG.info("getLatestFlowStatus called with flowGroup " + flowId.getFlowGroup() + " flowName " + flowId.getFlowName() + " count " + count);
 
     List<org.apache.gobblin.service.monitoring.FlowStatus> flowStatuses =
-        _flowStatusGenerator.getLatestFlowStatus(flowId.getFlowName(), flowId.getFlowGroup(), count);
+        _flowStatusGenerator.getLatestFlowStatus(flowId.getFlowName(), flowId.getFlowGroup(), count, tag);
 
     if (flowStatuses != null) {
       return flowStatuses.stream().map(this::convertFlowStatus).collect(Collectors.toList());
@@ -128,6 +129,7 @@ public class FlowStatusResource extends ComplexKeyResourceTemplate<FlowStatusId,
       jobStatus.setFlowId(flowId)
           .setJobId(new JobId().setJobName(queriedJobStatus.getJobName())
               .setJobGroup(queriedJobStatus.getJobGroup()))
+          .setJobTag(queriedJobStatus.getJobTag(), SetMode.IGNORE_NULL)
           .setExecutionStatistics(new JobStatistics()
               .setExecutionStartTime(queriedJobStatus.getStartTime())
               .setExecutionEndTime(queriedJobStatus.getEndTime())

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/FlowStatusGenerator.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/FlowStatusGenerator.java
@@ -21,6 +21,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 
 import lombok.Builder;
@@ -45,14 +46,14 @@ public class FlowStatusGenerator {
    * @param count
    * @return the latest <code>count</code>{@link FlowStatus}es. null is returned if there is no flow execution found.
    */
-  public List<FlowStatus> getLatestFlowStatus(String flowName, String flowGroup, int count) {
+  public List<FlowStatus> getLatestFlowStatus(String flowName, String flowGroup, int count, String tag) {
     List<Long> flowExecutionIds = jobStatusRetriever.getLatestExecutionIdsForFlow(flowName, flowGroup, count);
 
     if (flowExecutionIds == null || flowExecutionIds.isEmpty()) {
       return null;
     }
     List<FlowStatus> flowStatuses =
-        flowExecutionIds.stream().map(flowExecutionId -> getFlowStatus(flowName, flowGroup, flowExecutionId))
+        flowExecutionIds.stream().map(flowExecutionId -> getFlowStatus(flowName, flowGroup, flowExecutionId, tag))
             .collect(Collectors.toList());
 
     return flowStatuses;
@@ -63,12 +64,19 @@ public class FlowStatusGenerator {
    * @param flowName
    * @param flowGroup
    * @param flowExecutionId
-   * @return the flow status, null is returned if the flow status does not exist
+   * @param tag
+   * @return the flow status, null is returned if the flow status does not exist. If tag is not null, the job status
+   * list only contains jobs matching the tag.
    */
-  public FlowStatus getFlowStatus(String flowName, String flowGroup, long flowExecutionId) {
+  public FlowStatus getFlowStatus(String flowName, String flowGroup, long flowExecutionId, String tag) {
     FlowStatus flowStatus = null;
     Iterator<JobStatus> jobStatusIterator =
         jobStatusRetriever.getJobStatusesForFlowExecution(flowName, flowGroup, flowExecutionId);
+
+    if (tag != null) {
+      jobStatusIterator = Iterators.filter(jobStatusIterator, js -> JobStatusRetriever.isFlowStatus(js) ||
+          (js.getJobTag() != null && js.getJobTag().equals(tag)));
+    }
 
     if (jobStatusIterator.hasNext()) {
       flowStatus = new FlowStatus(flowName, flowGroup, flowExecutionId, jobStatusIterator);
@@ -85,7 +93,7 @@ public class FlowStatusGenerator {
    * @return true, if any jobs of the flow are RUNNING.
    */
   public boolean isFlowRunning(String flowName, String flowGroup) {
-    List<FlowStatus> flowStatusList = getLatestFlowStatus(flowName, flowGroup, 1);
+    List<FlowStatus> flowStatusList = getLatestFlowStatus(flowName, flowGroup, 1, null);
     if (flowStatusList == null || flowStatusList.isEmpty()) {
       return false;
     } else {

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/FlowStatusGenerator.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/FlowStatusGenerator.java
@@ -44,7 +44,9 @@ public class FlowStatusGenerator {
    * @param flowName
    * @param flowGroup
    * @param count
+   * @param tag
    * @return the latest <code>count</code>{@link FlowStatus}es. null is returned if there is no flow execution found.
+   * If tag is not null, the job status list only contains jobs matching the tag.
    */
   public List<FlowStatus> getLatestFlowStatus(String flowName, String flowGroup, int count, String tag) {
     List<Long> flowExecutionIds = jobStatusRetriever.getLatestExecutionIdsForFlow(flowName, flowGroup, count);
@@ -64,7 +66,7 @@ public class FlowStatusGenerator {
    * @param flowName
    * @param flowGroup
    * @param flowExecutionId
-   * @param tag
+   * @param tag String to filter the returned job statuses
    * @return the flow status, null is returned if the flow status does not exist. If tag is not null, the job status
    * list only contains jobs matching the tag.
    */

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/JobStatus.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/JobStatus.java
@@ -32,6 +32,7 @@ import lombok.Getter;
 public class JobStatus {
   private final String jobName;
   private final String jobGroup;
+  private final String jobTag;
   private final long jobExecutionId;
   private final long flowExecutionId;
   private final String flowName;

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/JobStatusRetriever.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/JobStatusRetriever.java
@@ -71,6 +71,7 @@ public abstract class JobStatusRetriever implements LatestFlowExecutionIdTracker
     long flowExecutionId = Long.parseLong(jobState.getProp(TimingEvent.FlowEventConstants.FLOW_EXECUTION_ID_FIELD));
     String jobName = jobState.getProp(TimingEvent.FlowEventConstants.JOB_NAME_FIELD);
     String jobGroup = jobState.getProp(TimingEvent.FlowEventConstants.JOB_GROUP_FIELD);
+    String jobTag = jobState.getProp(TimingEvent.FlowEventConstants.JOB_TAG_FIELD);
     long jobExecutionId = Long.parseLong(jobState.getProp(TimingEvent.FlowEventConstants.JOB_EXECUTION_ID_FIELD, "0"));
     String eventName = jobState.getProp(JobStatusRetriever.EVENT_NAME_FIELD);
     long startTime = Long.parseLong(jobState.getProp(TimingEvent.JOB_START_TIME, "0"));
@@ -84,7 +85,7 @@ public abstract class JobStatusRetriever implements LatestFlowExecutionIdTracker
     boolean shouldRetry = Boolean.parseBoolean(jobState.getProp(TimingEvent.FlowEventConstants.SHOULD_RETRY_FIELD, "false"));
 
     return JobStatus.builder().flowName(flowName).flowGroup(flowGroup).flowExecutionId(flowExecutionId).
-        jobName(jobName).jobGroup(jobGroup).jobExecutionId(jobExecutionId).eventName(eventName).
+        jobName(jobName).jobGroup(jobGroup).jobTag(jobTag).jobExecutionId(jobExecutionId).eventName(eventName).
         lowWatermark(lowWatermark).highWatermark(highWatermark).startTime(startTime).endTime(endTime).
         message(message).processedCount(processedCount).maxAttempts(maxAttempts).currentAttempts(currentAttempts).
         shouldRetry(shouldRetry).build();

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/TimingEventUtils.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/TimingEventUtils.java
@@ -27,6 +27,7 @@ import org.apache.gobblin.runtime.api.FlowSpec;
 import org.apache.gobblin.runtime.api.JobSpec;
 import org.apache.gobblin.runtime.api.SpecExecutor;
 import org.apache.gobblin.service.modules.spec.JobExecutionPlan;
+import org.apache.gobblin.util.ConfigUtils;
 
 
 class TimingEventUtils {
@@ -57,6 +58,7 @@ class TimingEventUtils {
     jobMetadata.put(TimingEvent.FlowEventConstants.FLOW_EXECUTION_ID_FIELD, jobSpec.getConfig().getString(ConfigurationKeys.FLOW_EXECUTION_ID_KEY));
     jobMetadata.put(TimingEvent.FlowEventConstants.JOB_NAME_FIELD, jobSpec.getConfig().getString(ConfigurationKeys.JOB_NAME_KEY));
     jobMetadata.put(TimingEvent.FlowEventConstants.JOB_GROUP_FIELD, jobSpec.getConfig().getString(ConfigurationKeys.JOB_GROUP_KEY));
+    jobMetadata.put(TimingEvent.FlowEventConstants.JOB_TAG_FIELD, ConfigUtils.getString(jobSpec.getConfig(), ConfigurationKeys.JOB_TAG_KEY, null));
     jobMetadata.put(TimingEvent.FlowEventConstants.SPEC_EXECUTOR_FIELD, specExecutor.getClass().getCanonicalName());
     jobMetadata.put(TimingEvent.FlowEventConstants.MAX_ATTEMPTS_FIELD, Integer.toString(jobExecutionPlan.getMaxAttempts()));
     jobMetadata.put(TimingEvent.FlowEventConstants.CURRENT_ATTEMPTS_FIELD, Integer.toString(jobExecutionPlan.getCurrentAttempts()));


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-881


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

With multi-dataset support in gaas, it is more convenient to have an extra field that can be used to filter when querying the job status (this would be dataset name in most cases).

This PR allows jobs to include `job.tag` field then when querying jobStatus, specifying tag in the query will return only job statuses with that tag.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Updated test

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

