### PR TITLE
[GOBBLIN-888] Make yyyy-MM-dd-HH-mm recognizable in TimeAwareRecursiveCopyableDataset

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/TimeAwareRecursiveCopyableDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/TimeAwareRecursiveCopyableDataset.java
@@ -50,22 +50,29 @@ public class TimeAwareRecursiveCopyableDataset extends RecursiveCopyableDataset 
   private final String datePattern;
   private final Period lookbackPeriod;
   private final boolean isPatternHourly;
+  private final boolean isPatternMinutely;
   private final LocalDateTime currentTime;
 
   public TimeAwareRecursiveCopyableDataset(FileSystem fs, Path rootPath, Properties properties, Path glob) {
     super(fs, rootPath, properties, glob);
     this.lookbackTime = properties.getProperty(LOOKBACK_TIME_KEY);
-    PeriodFormatter periodFormatter = new PeriodFormatterBuilder().appendDays().appendSuffix("d").appendHours().appendSuffix("h").toFormatter();
+    PeriodFormatter periodFormatter = new PeriodFormatterBuilder().appendDays().appendSuffix("d").appendHours().appendSuffix("h").appendMinutes().appendSuffix("m").toFormatter();
     this.lookbackPeriod = periodFormatter.parsePeriod(lookbackTime);
     this.datePattern = properties.getProperty(DATE_PATTERN_KEY);
-    this.isPatternHourly = isDatePatternHourly(datePattern);
+    this.isPatternMinutely = isDatePatternMinutely(datePattern);
+    this.isPatternHourly = !this.isPatternMinutely && isDatePatternHourly(datePattern);
     this.currentTime = properties.containsKey(DATE_PATTERN_TIMEZONE_KEY) ? LocalDateTime.now(
         DateTimeZone.forID(DATE_PATTERN_TIMEZONE_KEY))
         : LocalDateTime.now(DateTimeZone.forID(DEFAULT_DATE_PATTERN_TIMEZONE));
 
-    //Daily directories cannot have a "hourly" lookback pattern. But hourly directories can accept lookback pattern with days.
-    if (!this.isPatternHourly) {
-      Assert.assertTrue(isLookbackTimeStringDaily(this.lookbackTime), "Expected day format for lookback time; found hourly format");
+    if (!this.isPatternMinutely) {
+      //Daily directories cannot have a "hourly" lookback pattern. But hourly directories can accept lookback pattern with days.
+      if (!this.isPatternHourly) {
+        Assert.assertTrue(isLookbackTimeStringDaily(this.lookbackTime), "Expected day format for lookback time; found hourly or minutely format");
+      } else {
+        //hourly directories cannot have a "minutely" lookback pattern. But minutely directories can accept lookback pattern with hours.
+        Assert.assertTrue(isLookbackTimeStringHourly(this.lookbackTime), "Expected hourly format for lookback time; found minutely format");
+      }
     }
   }
 
@@ -73,11 +80,19 @@ public class TimeAwareRecursiveCopyableDataset extends RecursiveCopyableDataset 
     private LocalDateTime startDate;
     private LocalDateTime endDate;
     private boolean isDatePatternHourly;
+    private boolean isDatePatternMinutely;
 
     public DateRangeIterator(LocalDateTime startDate, LocalDateTime endDate, boolean isDatePatternHourly) {
       this.startDate = startDate;
       this.endDate = endDate;
       this.isDatePatternHourly = isDatePatternHourly;
+    }
+
+    public DateRangeIterator(LocalDateTime startDate, LocalDateTime endDate, boolean isDatePatternHourly, boolean isDatePatternMinutely) {
+      this.startDate = startDate;
+      this.endDate = endDate;
+      this.isDatePatternHourly = isDatePatternHourly;
+      this.isDatePatternMinutely = isDatePatternMinutely;
     }
 
     @Override
@@ -88,7 +103,7 @@ public class TimeAwareRecursiveCopyableDataset extends RecursiveCopyableDataset 
     @Override
     public LocalDateTime next() {
       LocalDateTime dateTime = startDate;
-      startDate = this.isDatePatternHourly ? startDate.plusHours(1) : startDate.plusDays(1);
+      startDate = this.isDatePatternHourly ? startDate.plusHours(1) : this.isDatePatternMinutely ? startDate.plusMinutes(1) : startDate.plusDays(1);
       return dateTime;
     }
 
@@ -99,16 +114,35 @@ public class TimeAwareRecursiveCopyableDataset extends RecursiveCopyableDataset 
   }
 
   private boolean isDatePatternHourly(String datePattern) {
-    DateTimeFormatter formatter = DateTimeFormat.forPattern(datePattern);
+    DateTimeFormatter formatter = DateTimeFormat.forPattern(datePattern); // yyyy-mm-dd-hh   // yyyy-mm-dd  // yyyy-mm-dd-hh-mm
     LocalDateTime refDateTime = new LocalDateTime(2017, 01, 01, 10, 0, 0);
-    String refDateTimeString = refDateTime.toString(formatter);
+    String refDateTimeString = refDateTime.toString(formatter);  //2017-01-01-10   // 2017-01-01  // 2017-01-01-10-00
     LocalDateTime refDateTimeAtStartOfDay = refDateTime.withHourOfDay(0);
-    String refDateTimeStringAtStartOfDay = refDateTimeAtStartOfDay.toString(formatter);
+    String refDateTimeStringAtStartOfDay = refDateTimeAtStartOfDay.toString(formatter);// 2017-01-01-00  // 2017-01-01  // 2017-01-01-00-00
     return !refDateTimeString.equals(refDateTimeStringAtStartOfDay);
+  }
+
+  private boolean isDatePatternMinutely(String datePattern) {
+    DateTimeFormatter formatter = DateTimeFormat.forPattern(datePattern); // yyyy-mm-dd-hh-mm
+    LocalDateTime refDateTime = new LocalDateTime(2017, 01, 01, 10, 59, 0);
+    String refDateTimeString = refDateTime.toString(formatter);  //2017-01-01-10-59
+    LocalDateTime refDateTimeAtStartOfHour = refDateTime.withMinuteOfHour(0);
+    String refDateTimeStringAtStartOfHour = refDateTimeAtStartOfHour.toString(formatter);// 2017-01-01-10-00
+    return !refDateTimeString.equals(refDateTimeStringAtStartOfHour);
   }
 
   private boolean isLookbackTimeStringDaily(String lookbackTime) {
     PeriodFormatter periodFormatter = new PeriodFormatterBuilder().appendDays().appendSuffix("d").toFormatter();
+    try {
+      periodFormatter.parsePeriod(lookbackTime);
+      return true;
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+  private boolean isLookbackTimeStringHourly(String lookbackTime) {
+    PeriodFormatter periodFormatter = new PeriodFormatterBuilder().appendDays().appendSuffix("d").appendHours().appendSuffix("h").toFormatter();
     try {
       periodFormatter.parsePeriod(lookbackTime);
       return true;
@@ -123,7 +157,7 @@ public class TimeAwareRecursiveCopyableDataset extends RecursiveCopyableDataset 
     LocalDateTime endDate = currentTime;
     LocalDateTime startDate = endDate.minus(this.lookbackPeriod);
 
-    DateRangeIterator dateRangeIterator = new DateRangeIterator(startDate, endDate, isPatternHourly);
+    DateRangeIterator dateRangeIterator = new DateRangeIterator(startDate, endDate, isPatternHourly, isPatternMinutely);
     List<FileStatus> fileStatuses = Lists.newArrayList();
     while (dateRangeIterator.hasNext()) {
       Path pathWithDateTime = new Path(path, dateRangeIterator.next().toString(formatter));

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/DateRangeIteratorTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/DateRangeIteratorTest.java
@@ -53,5 +53,15 @@ public class DateRangeIteratorTest {
     dateTime = dateRangeIterator.next();
     Assert.assertEquals(dateTime.toString(format), "2017/01/01");
     Assert.assertEquals(dateRangeIterator.hasNext(), false);
+
+    datePattern = "yyyy-MM-dd-HH-mm";
+    format = DateTimeFormat.forPattern(datePattern);
+    startDate = endDate.minusHours(1);
+    dateRangeIterator = new TimeAwareRecursiveCopyableDataset.DateRangeIterator(startDate, endDate, false, true);
+    dateTime = dateRangeIterator.next();
+    Assert.assertEquals(dateTime.toString(format), "2016-12-31-23-00");
+    dateTime = dateRangeIterator.next();
+    Assert.assertEquals(dateTime.toString(format), "2016-12-31-23-01");
+    Assert.assertEquals(dateRangeIterator.hasNext(), true);
   }
 }

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/TimeAwareRecursiveCopyableDatasetTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/TimeAwareRecursiveCopyableDatasetTest.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.Set;
 
 import org.apache.hadoop.conf.Configuration;
@@ -42,11 +43,14 @@ import org.testng.annotations.Test;
 
 import org.apache.gobblin.util.PathUtils;
 import org.apache.gobblin.util.filters.HiddenFilter;
+import sun.jvm.hotspot.runtime.Thread;
+
 
 public class TimeAwareRecursiveCopyableDatasetTest {
   private FileSystem fs;
   private Path baseDir1;
   private Path baseDir2;
+  private Path baseDir3;
 
   private static final String NUM_LOOKBACK_DAYS_STR = "2d";
   private static final Integer NUM_LOOKBACK_DAYS = 2;
@@ -56,6 +60,7 @@ public class TimeAwareRecursiveCopyableDatasetTest {
   private static final Integer MAX_NUM_HOURLY_DIRS = 48;
   private static final String NUM_LOOKBACK_DAYS_HOURS_STR = "1d1h";
   private static final Integer NUM_DAYS_HOURS_DIRS = 25;
+  private static final String NUM_LOOKBACK_HOURS_MINS_STR = "1h1m";
 
   @BeforeClass
   public void setUp() throws IOException {
@@ -75,6 +80,12 @@ public class TimeAwareRecursiveCopyableDatasetTest {
       fs.delete(baseDir2, true);
     }
     fs.mkdirs(baseDir2);
+
+    baseDir3 = new Path("/tmp/src/ds2/daily");
+    if (fs.exists(baseDir3)) {
+      fs.delete(baseDir3, true);
+    }
+    fs.mkdirs(baseDir3);
     PeriodFormatter formatter = new PeriodFormatterBuilder().appendDays().appendSuffix("d").appendHours().appendSuffix("h").toFormatter();
     Period period = formatter.parsePeriod(NUM_LOOKBACK_DAYS_HOURS_STR);
   }
@@ -168,6 +179,44 @@ public class TimeAwareRecursiveCopyableDatasetTest {
     for (FileStatus fileStatus: fileStatusList) {
       Assert.assertTrue(candidateFiles.contains(PathUtils.getPathWithoutSchemeAndAuthority(fileStatus.getPath()).toString()));
     }
+
+    // test ds of daily/yyyy-MM-dd-HH-mm
+    datePattern = "yyyy-MM-dd-HH-mm";
+    formatter = DateTimeFormat.forPattern(datePattern);
+    endDate = LocalDateTime.now(DateTimeZone.forID(TimeAwareRecursiveCopyableDataset.DEFAULT_DATE_PATTERN_TIMEZONE));
+
+    Random random = new Random();
+
+    candidateFiles = new HashSet<>();
+    for (int i = 0; i < MAX_NUM_DAILY_DIRS; i++) {
+      String startDate = endDate.minusDays(i).withMinuteOfHour(random.nextInt(60)).toString(formatter);
+      if (i == 0) {
+        // avoid future dates on minutes, so have consistency test result
+        startDate = endDate.minusHours(i).withMinuteOfHour(0).toString(formatter);
+      }
+      Path subDirPath = new Path(baseDir3, new Path(startDate));
+      fs.mkdirs(subDirPath);
+      Path filePath = new Path(subDirPath, i + ".avro");
+      fs.create(filePath);
+      if (i < (NUM_LOOKBACK_DAYS + 1)) {
+        candidateFiles.add(filePath.toString());
+      }
+    }
+
+    properties = new Properties();
+    properties.setProperty(TimeAwareRecursiveCopyableDataset.LOOKBACK_TIME_KEY, "2d1h");
+    properties.setProperty(TimeAwareRecursiveCopyableDataset.DATE_PATTERN_KEY, "yyyy-MM-dd-HH-mm");
+
+    dataset = new TimeAwareRecursiveCopyableDataset(fs, baseDir3, properties,
+        new Path("/tmp/src/ds2/daily"));
+
+    fileStatusList = dataset.getFilesAtPath(fs, baseDir3, pathFilter);
+
+    Assert.assertEquals(fileStatusList.size(), NUM_LOOKBACK_DAYS + 1);
+    for (FileStatus fileStatus: fileStatusList) {
+      Assert.assertTrue(candidateFiles.contains(PathUtils.getPathWithoutSchemeAndAuthority(fileStatus.getPath()).toString()));
+    }
+
   }
 
   @Test (expectedExceptions = AssertionError.class)
@@ -179,6 +228,15 @@ public class TimeAwareRecursiveCopyableDatasetTest {
 
     TimeAwareRecursiveCopyableDataset dataset = new TimeAwareRecursiveCopyableDataset(fs, baseDir2, properties,
         new Path("/tmp/src/*/daily"));
+
+    // hourly directories, but look back time has hours and minutes. We should expect an assertion error.
+    properties = new Properties();
+    properties.setProperty(TimeAwareRecursiveCopyableDataset.LOOKBACK_TIME_KEY, NUM_LOOKBACK_HOURS_MINS_STR);
+    properties.setProperty(TimeAwareRecursiveCopyableDataset.DATE_PATTERN_KEY, "yyyy-MM-dd-HH");
+
+    dataset = new TimeAwareRecursiveCopyableDataset(fs, baseDir3, properties,
+        new Path("/tmp/src/ds2/daily"));
+
   }
 
   @AfterClass
@@ -186,5 +244,6 @@ public class TimeAwareRecursiveCopyableDatasetTest {
     //Delete tmp directories
     this.fs.delete(baseDir1, true);
     this.fs.delete(baseDir2, true);
+    this.fs.delete(baseDir3, true);
   }
 }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-888


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):

- support datePattern till minute column: yyyy-MM-dd-HH-mm

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Add tests in 
DateRangeIteratorTest
TimeAwareRecursiveCopyableDatasetTest


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

