### PR TITLE
[GOBBLIN-887] Fix the FileContext wrong fsUri issue.

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/writer/FsDataWriter.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/writer/FsDataWriter.java
@@ -104,7 +104,9 @@ public abstract class FsDataWriter<D> implements DataWriter<D>, FinalState, Meta
     // Add all job configuration properties so they are picked up by Hadoop
     JobConfigurationUtils.putStateIntoConfiguration(properties, conf);
     this.fs = WriterUtils.getWriterFS(properties, this.numBranches, this.branchId);
-    this.fileContext = FileContext.getFileContext(conf);
+    this.fileContext = FileContext.getFileContext(
+            WriterUtils.getWriterFsUri(properties, this.numBranches, this.branchId),
+            conf);
 
     // Initialize staging/output directory
     Path writerStagingDir = this.writerAttemptIdOptional.isPresent() ? WriterUtils

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/WriterUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/WriterUtils.java
@@ -24,6 +24,7 @@ import java.util.concurrent.ExecutionException;
 import org.apache.avro.file.CodecFactory;
 import org.apache.avro.file.DataFileConstants;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileContext;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
@@ -314,11 +315,15 @@ public class WriterUtils {
     }
   }
 
+  public static URI getWriterFsUri(State state, int numBranches, int branchId) {
+    return URI.create(state.getProp(
+            ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_FILE_SYSTEM_URI, numBranches, branchId),
+            ConfigurationKeys.LOCAL_FS_URI));
+  }
+
   public static FileSystem getWriterFS(State state, int numBranches, int branchId)
       throws IOException {
-    URI uri = URI.create(state.getProp(
-        ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_FILE_SYSTEM_URI, numBranches, branchId),
-        ConfigurationKeys.LOCAL_FS_URI));
+    URI uri = getWriterFsUri(state, numBranches, branchId);
 
     Configuration hadoopConf = getFsConfiguration(state);
     if (state.getPropAsBoolean(ConfigurationKeys.SHOULD_FS_PROXY_AS_USER,


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-887


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
  In FsDataWriter,  the FileContext doesn't take the fsUri into account during the creation.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

