### PR TITLE
[GOBBLIN-892] reverting back bad changes done in PR 2720

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/SafeDatasetCommit.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/SafeDatasetCommit.java
@@ -326,6 +326,9 @@ final class SafeDatasetCommit implements Callable<Void> {
         // The dataset state is set to FAILED if any task failed and COMMIT_ON_FULL_SUCCESS is used
         datasetState.setState(JobState.RunningState.FAILED);
         datasetState.incrementJobFailures();
+        Optional<String> taskStateException = taskState.getTaskFailureException();
+        log.warn("At least one task did not committed successfully. Setting dataset state to FAILED. "
+            + (taskStateException.isPresent() ? taskStateException.get() : "Exception not set."));
         return;
       }
     }

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/SafeDatasetCommit.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/SafeDatasetCommit.java
@@ -326,11 +326,6 @@ final class SafeDatasetCommit implements Callable<Void> {
         // The dataset state is set to FAILED if any task failed and COMMIT_ON_FULL_SUCCESS is used
         datasetState.setState(JobState.RunningState.FAILED);
         datasetState.incrementJobFailures();
-        Optional<String> taskStateException = taskState.getTaskFailureException();
-        String errMsg = "At least one task did not committed successfully. Setting dataset state to FAILED. "
-            + (taskStateException.isPresent() ? taskStateException.get() : "Exception not set.");
-        log.warn(errMsg);
-        datasetState.setJobFailureMessage(errMsg);
         return;
       }
     }
@@ -406,10 +401,8 @@ final class SafeDatasetCommit implements Callable<Void> {
           //    dataset failed to be committed.
           datasetState.setState(JobState.RunningState.FAILED);
           Optional<String> taskStateException = taskState.getTaskFailureException();
-          String errMsg = "At least one task did not committed successfully. Setting dataset state to FAILED. "
-              + (taskStateException.isPresent() ? taskStateException.get() : "Exception not set.");
-          log.warn(errMsg);
-          datasetState.setJobFailureMessage(errMsg);
+          log.warn("At least one task did not committed successfully. Setting dataset state to FAILED. {}",
+              taskStateException.isPresent() ? taskStateException.get() : "Exception not set.");
         }
       }
     }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-892

### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

fix a bug where we are setting/getting props in dataset state. it is not a supported operation.
This bug was introduced in https://github.com/apache/incubator-gobblin/pull/2720 (Jira GOBBLIN-864)

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
reverting back to older, more stable state

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

