### PR TITLE
[GOBBLIN-894] Add option to combine datasets into a single flow

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -898,6 +898,7 @@ public class ConfigurationKeys {
   public static final String DATASET_SUBPATHS_KEY = "gobblin.flow.dataset.subPaths";
   public static final String DATASET_BASE_INPUT_PATH_KEY = "gobblin.flow.dataset.baseInputPath";
   public static final String DATASET_BASE_OUTPUT_PATH_KEY = "gobblin.flow.dataset.baseOutputPath";
+  public static final String DATASET_COMBINE_KEY = "gobblin.flow.dataset.combine";
 
   /***
    * Configuration properties related to TopologySpec Store

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/dataset/BaseDatasetDescriptor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/dataset/BaseDatasetDescriptor.java
@@ -62,7 +62,7 @@ public abstract class BaseDatasetDescriptor implements DatasetDescriptor {
   /**
    * {@inheritDoc}
    */
-  protected abstract boolean isPathContaining(String otherPath);
+  protected abstract boolean isPathContaining(DatasetDescriptor other);
 
   /**
    * @return true if this {@link DatasetDescriptor} contains the other {@link DatasetDescriptor} i.e. the
@@ -75,7 +75,7 @@ public abstract class BaseDatasetDescriptor implements DatasetDescriptor {
     if (this == other) {
       return true;
     }
-    
+
     if (other == null || !getClass().equals(other.getClass())) {
       return false;
     }
@@ -88,6 +88,6 @@ public abstract class BaseDatasetDescriptor implements DatasetDescriptor {
       return false;
     }
 
-    return isPathContaining(other.getPath()) && getFormatConfig().contains(other.getFormatConfig());
+    return isPathContaining(other) && getFormatConfig().contains(other.getFormatConfig());
   }
 }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/dataset/SqlDatasetDescriptor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/dataset/SqlDatasetDescriptor.java
@@ -89,7 +89,7 @@ public class SqlDatasetDescriptor extends BaseDatasetDescriptor implements Datas
     return Enums.getIfPresent(Platform.class, getPlatform().toUpperCase()).isPresent();
   }
   /**
-   * Check if the dbName and tableName specified in {@param otherPath} are accepted by the set of dbName.tableName
+   * Check if the dbName and tableName specified in {@param other}'s path are accepted by the set of dbName.tableName
    * combinations defined by the current {@link SqlDatasetDescriptor}. For example, let:
    * this.path = "test_.*;test_table_.*". Then:
    * isPathContaining("test_db1;test_table_1") = true
@@ -98,10 +98,11 @@ public class SqlDatasetDescriptor extends BaseDatasetDescriptor implements Datas
    * NOTE: otherPath cannot be a globPattern. So:
    * isPathContaining("test_db.*;test_table_*") = false
    *
-   * @param otherPath which should be in the format of dbName.tableName
+   * @param other whose path should be in the format of dbName.tableName
    */
   @Override
-  protected boolean isPathContaining(String otherPath) {
+  protected boolean isPathContaining(DatasetDescriptor other) {
+    String otherPath = other.getPath();
     if (otherPath == null) {
       return false;
     }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/DatasetDescriptorConfigKeys.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/DatasetDescriptorConfigKeys.java
@@ -31,6 +31,7 @@ public class DatasetDescriptorConfigKeys {
   public static final String CLASS_KEY = "class";
   public static final String PLATFORM_KEY = "platform";
   public static final String PATH_KEY = "path";
+  public static final String SUBPATHS_KEY = "subPaths";
   public static final String DATABASE_KEY = "databaseName";
   public static final String TABLE_KEY = "tableName";
   public static final String FORMAT_KEY = "format";

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/dataset/FSDatasetDescriptorTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/dataset/FSDatasetDescriptorTest.java
@@ -72,6 +72,14 @@ public class FSDatasetDescriptorTest {
     Assert.assertFalse(descriptor3.contains(descriptor5));
     Assert.assertFalse(descriptor2.contains(descriptor5));
     Assert.assertFalse(descriptor1.contains(descriptor5));
+
+    // Test subpaths
+    Config subPathConfig = ConfigFactory.empty().withValue(DatasetDescriptorConfigKeys.PATH_KEY, ConfigValueFactory.fromAnyRef("/a/b/c"))
+        .withValue(DatasetDescriptorConfigKeys.SUBPATHS_KEY, ConfigValueFactory.fromAnyRef("{e,f,g}"))
+        .withValue(DatasetDescriptorConfigKeys.PLATFORM_KEY, ConfigValueFactory.fromAnyRef("hdfs"));
+    FSDatasetDescriptor descriptor6 = new FSDatasetDescriptor(subPathConfig);
+    Assert.assertTrue(descriptor1.contains(descriptor6));
+    Assert.assertFalse(descriptor2.contains(descriptor6));
   }
 
   @Test

--- a/gobblin-service/src/test/resources/flow/flow4.conf
+++ b/gobblin-service/src/test/resources/flow/flow4.conf
@@ -1,0 +1,14 @@
+user.to.proxy=testUser
+
+#Input dataset - uncompressed and unencrypted
+gobblin.flow.input.dataset.descriptor.class=org.apache.gobblin.service.modules.dataset.FSDatasetDescriptor
+gobblin.flow.input.dataset.descriptor.platform=hdfs
+gobblin.flow.dataset.baseInputPath=/data/input
+
+#Output dataset - same as input dataset
+gobblin.flow.output.dataset.descriptor.class=${gobblin.flow.input.dataset.descriptor.class}
+gobblin.flow.output.dataset.descriptor.platform=${gobblin.flow.input.dataset.descriptor.platform}
+gobblin.flow.dataset.baseOutputPath=/data/output
+
+gobblin.flow.dataset.subPaths="dataset0,dataset1,dataset2"
+gobblin.flow.dataset.combine=true

--- a/gobblin-service/src/test/resources/template_catalog/multihop/flowEdgeTemplates/hdfsSnapshotRetention/flow.conf
+++ b/gobblin-service/src/test/resources/template_catalog/multihop/flowEdgeTemplates/hdfsSnapshotRetention/flow.conf
@@ -51,3 +51,12 @@ gobblin.flow.edge.output.dataset.descriptor.5.class=${gobblin.flow.edge.input.da
 gobblin.flow.edge.output.dataset.descriptor.5.platform=${gobblin.flow.edge.input.dataset.descriptor.5.platform}
 gobblin.flow.edge.output.dataset.descriptor.5.path=${gobblin.flow.output.dataset.descriptor.path}
 gobblin.flow.edge.output.dataset.descriptor.5.isRetentionApplied=true
+
+gobblin.flow.edge.input.dataset.descriptor.6.class=org.apache.gobblin.service.modules.dataset.FSDatasetDescriptor
+gobblin.flow.edge.input.dataset.descriptor.6.platform=hdfs
+gobblin.flow.edge.input.dataset.descriptor.6.path="/data/output/*"
+
+gobblin.flow.edge.output.dataset.descriptor.6.class=${gobblin.flow.edge.input.dataset.descriptor.6.class}
+gobblin.flow.edge.output.dataset.descriptor.6.platform=${gobblin.flow.edge.input.dataset.descriptor.6.platform}
+gobblin.flow.edge.output.dataset.descriptor.6.path=${gobblin.flow.output.dataset.descriptor.path}
+gobblin.flow.edge.output.dataset.descriptor.6.isRetentionApplied=true

--- a/gobblin-service/src/test/resources/template_catalog/multihop/flowEdgeTemplates/hdfsToHdfs/flow.conf
+++ b/gobblin-service/src/test/resources/template_catalog/multihop/flowEdgeTemplates/hdfsToHdfs/flow.conf
@@ -24,3 +24,12 @@ gobblin.flow.edge.input.dataset.descriptor.2.isRetentionApplied=${flow.applyRete
 gobblin.flow.edge.output.dataset.descriptor.2.class=${gobblin.flow.edge.input.dataset.descriptor.2.class}
 gobblin.flow.edge.output.dataset.descriptor.2.platform=${gobblin.flow.edge.input.dataset.descriptor.2.platform}
 gobblin.flow.edge.output.dataset.descriptor.2.path=${gobblin.flow.output.dataset.descriptor.path}
+
+gobblin.flow.edge.input.dataset.descriptor.3.class=org.apache.gobblin.service.modules.dataset.FSDatasetDescriptor
+gobblin.flow.edge.input.dataset.descriptor.3.platform=hdfs
+gobblin.flow.edge.input.dataset.descriptor.3.path="/data/input/*"
+gobblin.flow.edge.input.dataset.descriptor.3.isRetentionApplied=${flow.applyRetention}
+
+gobblin.flow.edge.output.dataset.descriptor.3.class=${gobblin.flow.edge.input.dataset.descriptor.3.class}
+gobblin.flow.edge.output.dataset.descriptor.3.platform=${gobblin.flow.edge.input.dataset.descriptor.3.platform}
+gobblin.flow.edge.output.dataset.descriptor.3.path=${gobblin.flow.output.dataset.descriptor.path}

--- a/gobblin-service/src/test/resources/template_catalog/multihop/jobTemplates/distcp.template
+++ b/gobblin-service/src/test/resources/template_catalog/multihop/jobTemplates/distcp.template
@@ -36,7 +36,7 @@ gobblin.dataset.profile.class="org.apache.gobblin.data.management.copy.CopyableG
 
 # target location for copy
 data.publisher.final.dir=${to}
-gobblin.dataset.pattern=${from}
+gobblin.dataset.pattern=${from}/${?gobblin.flow.edge.input.dataset.descriptor.subPaths}
 
 data.publisher.type="org.apache.gobblin.data.management.copy.publisher.CopyDataPublisher"
 source.class="org.apache.gobblin.data.management.copy.CopySource"

--- a/gobblin-service/src/test/resources/template_catalog/multihop/jobTemplates/hdfs-retention.template
+++ b/gobblin-service/src/test/resources/template_catalog/multihop/jobTemplates/hdfs-retention.template
@@ -4,7 +4,7 @@
 job.name=SnapshotRetention
 job.class=gobblin.data.management.retention.DatasetCleanerJob
 #Dataset pattern
-gobblin.dataset.pattern=${gobblin.flow.edge.input.dataset.descriptor.path}
+gobblin.dataset.pattern=${gobblin.flow.edge.input.dataset.descriptor.path}/${?gobblin.flow.edge.input.dataset.descriptor.subPaths}
 #Dataset finder class
 gobblin.dataset.profile.class="org.apache.gobblin.data.management.retention.profile.SnapshotDatasetProfile"
 # Dataset version finder


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-894


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

This change allows GaaS to combine datasets using a glob pattern. Classes changed:
- Modify flow `MultiHopFlowCompiler` to set subpath config in the flow spec if combining is specified
- Modify `FSDatasetDescriptor` to concatenate subpaths with base path and check each against a glob pattern
- Modify `FSFlowTemplateCatalog` to not resolve config until later (this is unnecessary and causes issues with optional configs)

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Updated tests


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

