### PR TITLE
correct job listener method call when job finishes without fail

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/AbstractJobLauncher.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/AbstractJobLauncher.java
@@ -532,7 +532,7 @@ public abstract class AbstractJobLauncher implements JobLauncher {
           @Override
           public void apply(JobListener jobListener, JobContext jobContext)
               throws Exception {
-            jobListener.onJobFailure(jobContext);
+            jobListener.onJobCompletion(jobContext);
           }
         });
       }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-898

### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
we came across this code snippet which registers jobListner for JobCompleteTimer and JobSucceededTimer event and looks like JobSucceededTimer event calls onJobFailure function instead of onJobSucced function.

notifyListeners(this.jobContext, jobListener, TimingEvent.LauncherTimings.JOB_SUCCEEDED, new JobListenerAction() {
@Override
public void apply(JobListener jobListener, JobContext jobContext)
throws Exception

{ jobListener.onJobFailure(jobContext); }
});
Qinghe from our team found this, so reporting on behalf of him here


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: its a bugfix


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

