### PR TITLE
[GOBBLIN-897] adds local FS spec executor to write jobs to a local dir

### DIFF
--- a/conf/gobblin-as-service/application.conf
+++ b/conf/gobblin-as-service/application.conf
@@ -21,24 +21,21 @@ fs.uri="file:///"
 
 # Topology Catalog and Store
 topologySpec.store.dir=${gobblin.service.work.dir}/topologySpecStore
-specStore.fs.dir=${gobblin.service.work.dir}/spec-store
 
 # TopologySpec Factory
 topologySpecFactory.topologyNames=localGobblinCluster
 topologySpecFactory.localGobblinCluster.description="StandaloneClusterTopology"
 topologySpecFactory.localGobblinCluster.version="1"
 topologySpecFactory.localGobblinCluster.uri="gobblinCluster"
-topologySpecFactory.localGobblinCluster.specExecutorInstance.class="org.apache.gobblin.service.SimpleKafkaSpecProducer"
-topologySpecFactory.localGobblinCluster.specExecInstance.capabilities="externalSource:InternalSink"
-topologySpecFactory.localGobblinCluster.writer.kafka.topics="SimpleKafkaSpecExecutorInstanceTest"
-topologySpecFactory.localGobblinCluster.writer.kafka.producerConfig.bootstrap.servers="localhost:9092"
-topologySpecFactory.localGobblinCluster.writer.kafka.producerConfig.value.serializer="org.apache.kafka.common.serialization.ByteArraySerializer"
+topologySpecFactory.localGobblinCluster.specExecutorInstance.class="org.apache.gobblin.runtime.spec_executorInstance.LocalFsSpecExecutor"
+topologySpecFactory.localGobblinCluster.specExecInstance.capabilities="source:dest"
+topologySpecFactory.localGobblinCluster.gobblin.cluster.localSpecProducer.dir=${gobblin.service.work.dir}/jobs
 
 # Flow Catalog and Store
 flowSpec.store.dir=${gobblin.service.work.dir}/flowSpecStore
 
 # Template Catalog
-gobblin.service.templateCatalogs.fullyQualifiedPath="file:///tmp/templateCatalog"
+gobblin.service.templateCatalogs.fullyQualifiedPath="file://"
 
 # JobStatusMonitor
 gobblin.service.jobStatusMonitor.enabled=false
@@ -46,5 +43,12 @@ gobblin.service.jobStatusMonitor.enabled=false
 # FsJobStatusRetriever
 fsJobStatusRetriever.state.store.dir=${gobblin.service.work.dir}/state-store
 
+# DagManager
+gobblin.service.dagManager.enabled=true
+gobblin.service.dagManager.jobStatusRetriever.class="org.apache.gobblin.service.monitoring.FsJobStatusRetriever"
+gobblin.service.dagManager.dagStateStoreClass="org.apache.gobblin.service.modules.orchestration.FSDagStateStore"
+gobblin.service.dagManager.dagStateStoreDir=${gobblin.service.work.dir}/dagStateStoreDir
+
 # RestLI
 gobblin.service.port=6956
+

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_executorInstance/LocalFsSpecExecutor.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_executorInstance/LocalFsSpecExecutor.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.runtime.spec_executorInstance;
+
+import com.google.common.base.Optional;
+import com.typesafe.config.Config;
+import java.util.concurrent.Future;
+import org.apache.gobblin.runtime.api.Spec;
+import org.apache.gobblin.runtime.api.JobSpec;
+import org.apache.gobblin.runtime.api.SpecConsumer;
+import org.apache.gobblin.runtime.api.SpecExecutor;
+import org.apache.gobblin.runtime.api.SpecProducer;
+import org.apache.gobblin.util.CompletedFuture;
+import org.slf4j.Logger;
+
+/**
+ * An {@link SpecExecutor} implementation that keep {@link JobSpec} as a file to be consumed up by Gobblin Standalone
+ * Therefore there's no necessity to install {@link SpecConsumer} in this case.
+ */
+public class LocalFsSpecExecutor extends AbstractSpecExecutor {
+  // Communication mechanism components.
+  // Not specifying final for further extension based on this implementation.
+  private SpecProducer<Spec> specProducer;
+
+  public LocalFsSpecExecutor(Config config) {
+    this(config, Optional.absent());
+  }
+
+  public LocalFsSpecExecutor(Config config, Optional<Logger> log) {
+    super(config, log);
+    specProducer = new LocalFsSpecProducer(config);
+  }
+
+  @Override
+  public Future<String> getDescription() {
+    return new CompletedFuture("Local File System SpecExecutor", null);
+  }
+
+  @Override
+  public Future<? extends SpecProducer> getProducer(){
+    return new CompletedFuture(this.specProducer, null);
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    // Nothing to do in the abstract implementation.
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    // Nothing to do in the abstract implementation.
+  }
+
+}

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_executorInstance/LocalFsSpecProducer.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_executorInstance/LocalFsSpecProducer.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.runtime.spec_executorInstance;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.typesafe.config.Config;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.Future;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.gobblin.runtime.api.JobSpec;
+import org.apache.gobblin.runtime.api.Spec;
+import org.apache.gobblin.runtime.api.SpecExecutor;
+import org.apache.gobblin.runtime.api.SpecProducer;
+import org.apache.gobblin.util.CompletedFuture;
+import org.apache.gobblin.util.ConfigUtils;
+
+
+/**
+ * An implementation of {@link SpecProducer} that produces {@link JobSpec}s to the {@value #LOCAL_FS_PRODUCER_PATH_KEY}
+ */
+@Slf4j
+public class LocalFsSpecProducer implements SpecProducer<Spec> {
+  private String specProducerPath;
+  public static final String LOCAL_FS_PRODUCER_PATH_KEY = "gobblin.cluster.localSpecProducer.dir";
+
+  public LocalFsSpecProducer(Config config) {
+    this.specProducerPath = ConfigUtils.getString(config, LOCAL_FS_PRODUCER_PATH_KEY, "");
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(this.specProducerPath), "Missing argument: " + LOCAL_FS_PRODUCER_PATH_KEY);
+    File parentDir = new File(specProducerPath);
+    if (!parentDir.exists()) {
+      if (parentDir.mkdirs()) {
+        log.info("Creating directory path at {}", this.specProducerPath);
+      }
+    }
+  }
+
+  /** Add a {@link Spec} for execution on {@link org.apache.gobblin.runtime.api.SpecExecutor}.
+   * @param addedSpec*/
+  @Override
+  public Future<?> addSpec(Spec addedSpec) {
+    return writeSpec(addedSpec, SpecExecutor.Verb.ADD);
+  }
+
+  /** Update a {@link Spec} being executed on {@link org.apache.gobblin.runtime.api.SpecExecutor}.
+   * @param updatedSpec*/
+  @Override
+  public Future<?> updateSpec(Spec updatedSpec) {
+    return writeSpec(updatedSpec, SpecExecutor.Verb.UPDATE);
+  }
+
+  private Future<?> writeSpec(Spec spec, SpecExecutor.Verb verb) {
+    if (spec instanceof JobSpec) {
+      String specString = spec.toString();
+      // format the JobSpec to have file of <flowGroup>_<flowName>.job
+      String jobFileName = specString.replace('/', '_').substring(specString.lastIndexOf(':')+2, specString.length()-1) + ".job";
+      try (
+        FileOutputStream fStream = new FileOutputStream(this.specProducerPath + File.separatorChar + jobFileName);
+      ) {
+        ((JobSpec) spec).getConfigAsProperties().store(fStream, null);
+        log.info("Writing job {} to {}", jobFileName, this.specProducerPath);
+        return new CompletedFuture<>(Boolean.TRUE, null);
+      } catch (IOException e) {
+        log.error("Exception encountered when adding Spec {}", spec);
+        return new CompletedFuture<>(Boolean.TRUE, e);
+      }
+    } else {
+      throw new RuntimeException("Unsupported spec type " + spec.getClass());
+    }
+  }
+
+  /** Delete a {@link Spec} being executed on {@link org.apache.gobblin.runtime.api.SpecExecutor}.
+   * @param deletedSpecURI
+   * @param headers*/
+  @Override
+  public Future<?> deleteSpec(URI deletedSpecURI, Properties headers) {
+    return new CompletedFuture<>(Boolean.TRUE, null);
+  }
+
+  /** List all {@link Spec} being executed on {@link org.apache.gobblin.runtime.api.SpecExecutor}. */
+  @Override
+  public Future<? extends List<Spec>> listSpecs() {
+    throw new UnsupportedOperationException();
+  }
+
+}

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_executorInstance/LocalFsSpecProducer.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_executorInstance/LocalFsSpecProducer.java
@@ -74,8 +74,7 @@ public class LocalFsSpecProducer implements SpecProducer<Spec> {
     if (spec instanceof JobSpec) {
       URI specUri = spec.getUri();
       // format the JobSpec to have file of <flowGroup>_<flowName>.job
-      String[] uriTokens = specUri.getPath().split("/");
-      String jobFileName = String.join("_", uriTokens) + ".job";
+      String jobFileName = getJobFileName(specUri);
       try (
         FileOutputStream fStream = new FileOutputStream(this.specProducerPath + File.separatorChar + jobFileName);
       ) {
@@ -96,8 +95,7 @@ public class LocalFsSpecProducer implements SpecProducer<Spec> {
    * @param headers*/
   @Override
   public Future<?> deleteSpec(URI deletedSpecURI, Properties headers) {
-    String[] uriTokens = deletedSpecURI.getPath().split("/");
-    String jobFileName = String.join("_", uriTokens) + ".job";
+    String jobFileName = getJobFileName(deletedSpecURI);
     File file = new File(jobFileName);
     if (file.delete()) {
       log.info("Deleted spec: {}", jobFileName);
@@ -110,6 +108,11 @@ public class LocalFsSpecProducer implements SpecProducer<Spec> {
   @Override
   public Future<? extends List<Spec>> listSpecs() {
     throw new UnsupportedOperationException();
+  }
+
+  private String getJobFileName(URI specUri) {
+    String[] uriTokens = specUri.getPath().split("/");
+    return String.join("_", uriTokens) + ".job";
   }
 
 }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-897


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

Writes JobSpecs to a local folder, where presumably an instance of Gobblin-standalone can pick up the job to execute them. This is primarily designed for onboarding new users of GaaS.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

