### PR TITLE
[GOBBLIN-909] Return error message for unresolved substitutions in explain query

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -899,6 +899,7 @@ public class ConfigurationKeys {
   public static final String DATASET_BASE_INPUT_PATH_KEY = "gobblin.flow.dataset.baseInputPath";
   public static final String DATASET_BASE_OUTPUT_PATH_KEY = "gobblin.flow.dataset.baseOutputPath";
   public static final String DATASET_COMBINE_KEY = "gobblin.flow.dataset.combine";
+  public static final String WHITELISTED_EDGE_IDS = "gobblin.flow.whitelistedEdgeIds";
 
   /***
    * Configuration properties related to TopologySpec Store

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowConfigV2ResourceLocalHandler.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowConfigV2ResourceLocalHandler.java
@@ -69,7 +69,7 @@ public class FlowConfigV2ResourceLocalHandler extends FlowConfigResourceLocalHan
       StringMap props = flowConfig.getProperties();
       AddSpecResponse<String> addSpecResponse = responseMap.getOrDefault(GOBBLIN_SERVICE_JOB_SCHEDULER_LISTENER_CLASS, null);
       props.put("gobblin.flow.compiled",
-          addSpecResponse != null ? StringEscapeUtils.escapeJson(addSpecResponse.getValue()) : "");
+          addSpecResponse != null && addSpecResponse.getValue() != null ? StringEscapeUtils.escapeJson(addSpecResponse.getValue()) : "");
       flowConfig.setProperties(props);
       //Return response with 200 status code, since no resource is actually created.
       httpStatus = HttpStatus.S_200_OK;

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/FlowSpec.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/FlowSpec.java
@@ -20,6 +20,7 @@ package org.apache.gobblin.runtime.api;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
@@ -73,6 +74,9 @@ public class FlowSpec implements Configurable, Spec {
   /** Child {@link Spec}s to this {@link FlowSpec} **/
   // Note that a FlowSpec can be materialized into multiple FlowSpec or JobSpec hierarchy
   final Optional<List<Spec>> childSpecs;
+
+  /** List of exceptions that occurred during compilation of this FlowSpec **/
+  final Set<String> compilationErrors = new HashSet<>();
 
   public static FlowSpec.Builder builder(URI flowSpecUri) {
     return new FlowSpec.Builder(flowSpecUri);

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/FlowSpec.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/FlowSpec.java
@@ -39,6 +39,7 @@ import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.util.ConfigUtils;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 
 /**
@@ -50,6 +51,7 @@ import lombok.Data;
  */
 @Alpha
 @Data
+@EqualsAndHashCode(exclude={"compilationErrors"})
 public class FlowSpec implements Configurable, Spec {
   /** An URI identifying the flow. */
   final URI uri;

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/pathfinder/AbstractPathFinder.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/pathfinder/AbstractPathFinder.java
@@ -31,6 +31,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.typesafe.config.Config;
+import com.typesafe.config.ConfigException;
 import com.typesafe.config.ConfigValue;
 import com.typesafe.config.ConfigValueFactory;
 
@@ -192,8 +193,9 @@ public abstract class AbstractPathFinder implements PathFinder {
             DatasetDescriptor inputDatasetDescriptor = datasetDescriptorPair.getLeft();
             DatasetDescriptor outputDatasetDescriptor = datasetDescriptorPair.getRight();
 
-            Exception e = flowEdge.getFlowTemplate().isResolvable(mergedConfig, datasetDescriptorPair.getLeft(), datasetDescriptorPair.getRight());
-            if (e != null) {
+            try {
+              flowEdge.getFlowTemplate().tryResolving(mergedConfig, datasetDescriptorPair.getLeft(), datasetDescriptorPair.getRight());
+            } catch (JobTemplate.TemplateException | ConfigException | SpecNotFoundException e) {
               this.flowSpec.getCompilationErrors().add(e.toString());
               continue;
             }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobScheduler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobScheduler.java
@@ -300,11 +300,6 @@ public class GobblinServiceJobScheduler extends JobScheduler implements SpecCata
           }
         } else {
           //Return a compiled flow.
-          try {
-            this.orchestrator.getSpecCompiler().awaitHealthy();
-          } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-          }
           Dag<JobExecutionPlan> dag = this.orchestrator.getSpecCompiler().compileFlow(flowSpec);
           if (dag != null && !dag.isEmpty()) {
             response = dag.toString();

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobScheduler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobScheduler.java
@@ -19,6 +19,7 @@ package org.apache.gobblin.service.modules.scheduler;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Properties;
@@ -282,7 +283,7 @@ public class GobblinServiceJobScheduler extends JobScheduler implements SpecCata
               flowSpecProperties.getProperty(ConfigurationKeys.JOB_SCHEDULE_KEY));
         }
         boolean isExplain = ConfigUtils.getBoolean(flowSpec.getConfig(), ConfigurationKeys.FLOW_EXPLAIN_KEY, false);
-        String compiledFlow = null;
+        String response = null;
         if (!isExplain) {
           this.scheduledFlowSpecs.put(addedSpec.getUri().toString(), addedSpec);
 
@@ -306,7 +307,9 @@ public class GobblinServiceJobScheduler extends JobScheduler implements SpecCata
           }
           Dag<JobExecutionPlan> dag = this.orchestrator.getSpecCompiler().compileFlow(flowSpec);
           if (dag != null && !dag.isEmpty()) {
-            compiledFlow = dag.toString();
+            response = dag.toString();
+          } else if (!flowSpec.getCompilationErrors().isEmpty()) {
+            response = Arrays.toString(flowSpec.getCompilationErrors().toArray());
           }
           _log.info("{} Skipping adding flow spec: {}, since it is an EXPLAIN request", this.serviceName, addedSpec);
 
@@ -315,7 +318,7 @@ public class GobblinServiceJobScheduler extends JobScheduler implements SpecCata
             this.flowCatalog.get().remove(flowSpec.getUri(), new Properties(), false);
           }
         }
-        return new AddSpecResponse(compiledFlow);
+        return new AddSpecResponse(response);
       } catch (JobException je) {
         _log.error("{} Failed to schedule or run FlowSpec {}", serviceName, addedSpec, je);
       }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/template/FlowTemplate.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/template/FlowTemplate.java
@@ -51,10 +51,10 @@ public interface FlowTemplate extends Spec {
 
   /**
    * @param userConfig a list of user customized attributes.
-   * @return list of input/output {@link DatasetDescriptor}s that fully resolve the {@link FlowTemplate} using the
-   * provided userConfig.
+   * @param resolvable if true, only return descriptors that resolve the {@link FlowTemplate}
+   * @return list of input/output {@link DatasetDescriptor}s corresponding to the provied userConfig.
    */
-  List<Pair<DatasetDescriptor, DatasetDescriptor>> getResolvingDatasetDescriptors(Config userConfig)
+  List<Pair<DatasetDescriptor, DatasetDescriptor>> getDatasetDescriptors(Config userConfig, boolean resolvable)
       throws IOException, ReflectiveOperationException, SpecNotFoundException, JobTemplate.TemplateException;
 
   /**
@@ -65,7 +65,7 @@ public interface FlowTemplate extends Spec {
    * @param outputDescriptor output {@link DatasetDescriptor}
    * @return true if the {@link FlowTemplate} is resolvable
    */
-  boolean isResolvable(Config userConfig, DatasetDescriptor inputDescriptor, DatasetDescriptor outputDescriptor)
+  Exception isResolvable(Config userConfig, DatasetDescriptor inputDescriptor, DatasetDescriptor outputDescriptor)
       throws SpecNotFoundException, JobTemplate.TemplateException;
 
   /**

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/template/FlowTemplate.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/template/FlowTemplate.java
@@ -63,7 +63,7 @@ public interface FlowTemplate extends Spec {
    * @param userConfig User supplied Config
    * @param inputDescriptor input {@link DatasetDescriptor}
    * @param outputDescriptor output {@link DatasetDescriptor}
-   * @return true if the {@link FlowTemplate} is resolvable
+   * @return any exception that occurred when resolving or null if the {@link FlowTemplate} is resolvable
    */
   Exception isResolvable(Config userConfig, DatasetDescriptor inputDescriptor, DatasetDescriptor outputDescriptor)
       throws SpecNotFoundException, JobTemplate.TemplateException;

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/template/FlowTemplate.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/template/FlowTemplate.java
@@ -58,14 +58,14 @@ public interface FlowTemplate extends Spec {
       throws IOException, ReflectiveOperationException, SpecNotFoundException, JobTemplate.TemplateException;
 
   /**
-   * Checks if the {@link FlowTemplate} is resolvable using the provided {@link Config} object. A {@link FlowTemplate}
-   * is resolvable only if each of the {@link JobTemplate}s in the flow is resolvable
+   * Try to resolve the {@link FlowTemplate} using the provided {@link Config} object. A {@link FlowTemplate}
+   * is resolvable only if each of the {@link JobTemplate}s in the flow is resolvable. Throws an exception if the flow is
+   * not resolvable.
    * @param userConfig User supplied Config
    * @param inputDescriptor input {@link DatasetDescriptor}
    * @param outputDescriptor output {@link DatasetDescriptor}
-   * @return any exception that occurred when resolving or null if the {@link FlowTemplate} is resolvable
    */
-  Exception isResolvable(Config userConfig, DatasetDescriptor inputDescriptor, DatasetDescriptor outputDescriptor)
+  void tryResolving(Config userConfig, DatasetDescriptor inputDescriptor, DatasetDescriptor outputDescriptor)
       throws SpecNotFoundException, JobTemplate.TemplateException;
 
   /**

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/template/StaticFlowTemplate.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/template/StaticFlowTemplate.java
@@ -102,8 +102,8 @@ public class StaticFlowTemplate implements FlowTemplate {
 
   /**
    * Generate the input/output dataset descriptors for the {@link FlowTemplate}.
-   * @param userConfig
-   * @param resolvable
+   * @param userConfig User supplied Config
+   * @param resolvable Whether to return only resolvable dataset descriptors
    * @return a List of Input/Output DatasetDescriptors that correspond to this {@link FlowTemplate}. If resolvable is true,
    * only return descriptors that fully resolve it.
    */
@@ -164,7 +164,7 @@ public class StaticFlowTemplate implements FlowTemplate {
    * Checks if the {@link FlowTemplate} is resolvable using the provided {@link Config} object. A {@link FlowTemplate}
    * is resolvable only if each of the {@link JobTemplate}s in the flow is resolvable
    * @param userConfig User supplied Config
-   * @return true if the {@link FlowTemplate} is resolvable
+   * @return any exception that occurred when resolving or null if the {@link FlowTemplate} is resolvable
    */
   @Override
   public Exception isResolvable(Config userConfig, DatasetDescriptor inputDescriptor, DatasetDescriptor outputDescriptor) {

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/flow/MultiHopFlowCompilerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/flow/MultiHopFlowCompilerTest.java
@@ -641,7 +641,7 @@ public class MultiHopFlowCompilerTest {
   }
 
   @Test (dependsOnMethods = "testCompileCombinedDatasetFlow")
-  public void testUnresovedFlow() throws Exception {
+  public void testUnresolvedFlow() throws Exception {
     FlowSpec spec = createFlowSpec("flow/flow5.conf", "HDFS-1", "HDFS-3", false, false);
 
     Dag<JobExecutionPlan> dag = specCompiler.compileFlow(spec);
@@ -651,7 +651,7 @@ public class MultiHopFlowCompilerTest {
     Assert.assertTrue(spec.getCompilationErrors().iterator().next().contains("user.to.proxy"));
   }
 
-  @Test (dependsOnMethods = "testUnresovedFlow")
+  @Test (dependsOnMethods = "testUnresolvedFlow")
   public void testGitFlowGraphMonitorService()
       throws IOException, GitAPIException, URISyntaxException, InterruptedException {
     File remoteDir = new File(TESTDIR + "/remote");

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/flow/MultiHopFlowCompilerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/flow/MultiHopFlowCompilerTest.java
@@ -640,7 +640,18 @@ public class MultiHopFlowCompilerTest {
     Assert.assertTrue(jobConfig2.getString(ConfigurableGlobDatasetFinder.DATASET_FINDER_PATTERN_KEY).endsWith("{dataset0,dataset1,dataset2}"));
   }
 
-  @Test (dependsOnMethods = "testCompileMultiDatasetFlow")
+  @Test (dependsOnMethods = "testCompileCombinedDatasetFlow")
+  public void testUnresovedFlow() throws Exception {
+    FlowSpec spec = createFlowSpec("flow/flow5.conf", "HDFS-1", "HDFS-3", false, false);
+
+    Dag<JobExecutionPlan> dag = specCompiler.compileFlow(spec);
+
+    Assert.assertTrue(dag.isEmpty());
+    Assert.assertEquals(spec.getCompilationErrors().size(), 1);
+    Assert.assertTrue(spec.getCompilationErrors().iterator().next().contains("user.to.proxy"));
+  }
+
+  @Test (dependsOnMethods = "testUnresovedFlow")
   public void testGitFlowGraphMonitorService()
       throws IOException, GitAPIException, URISyntaxException, InterruptedException {
     File remoteDir = new File(TESTDIR + "/remote");

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/template_catalog/FSFlowTemplateCatalogTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/template_catalog/FSFlowTemplateCatalogTest.java
@@ -77,7 +77,7 @@ public class FSFlowTemplateCatalogTest {
     Config flowConfig = ConfigFactory.empty().withValue("team.name", ConfigValueFactory.fromAnyRef("test-team"))
         .withValue("dataset.name", ConfigValueFactory.fromAnyRef("test-dataset"));
 
-    List<Pair<DatasetDescriptor, DatasetDescriptor>> inputOutputDescriptors = flowTemplate.getResolvingDatasetDescriptors(flowConfig);
+    List<Pair<DatasetDescriptor, DatasetDescriptor>> inputOutputDescriptors = flowTemplate.getDatasetDescriptors(flowConfig, true);
     Assert.assertTrue(inputOutputDescriptors.size() == 2);
     List<String> dirs = Lists.newArrayList("inbound", "outbound");
     for (int i = 0; i < 2; i++) {

--- a/gobblin-service/src/test/resources/flow/flow5.conf
+++ b/gobblin-service/src/test/resources/flow/flow5.conf
@@ -1,0 +1,9 @@
+// Leaving user.to.proxy unresolved
+
+gobblin.flow.input.dataset.descriptor.class=org.apache.gobblin.service.modules.dataset.FSDatasetDescriptor
+gobblin.flow.input.dataset.descriptor.platform=hdfs
+gobblin.flow.input.dataset.descriptor.path=/data/input/dataset1
+
+gobblin.flow.output.dataset.descriptor.class=${gobblin.flow.input.dataset.descriptor.class}
+gobblin.flow.output.dataset.descriptor.platform=${gobblin.flow.input.dataset.descriptor.platform}
+gobblin.flow.output.dataset.descriptor.path=/data/output/dataset1


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-909

### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

- If an explain query does not return a compiled flow, instead return a list of error messages from the config that was not successfully resolved
- To make this more useful, added a whitelisted edges property that specifies which edges are allowed (otherwise there may be many unresolved substitutions and it's not clear which one was the issue)

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

