### PR TITLE
[GOBBLIN-911] Make profiling of HiveWritableHdfsDataWriter easier by injecting jobConf

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/writer/HiveWritableHdfsDataWriter.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/writer/HiveWritableHdfsDataWriter.java
@@ -64,7 +64,13 @@ public class HiveWritableHdfsDataWriter extends FsDataWriter<Writable> {
       Class<? extends Writable> writableClass = (Class<? extends Writable>) Class
           .forName(this.properties.getProp(HiveWritableHdfsDataWriterBuilder.WRITER_WRITABLE_CLASS));
 
-      return outputFormat.getHiveRecordWriter(new JobConf(), this.stagingFile, writableClass, true,
+      // Merging Job Properties into JobConf for easy tuning
+      JobConf loadedJobConf = new JobConf();
+      for (Object key : this.properties.getProperties().keySet()) {
+        loadedJobConf.set((String)key, this.properties.getProp((String)key));
+      }
+
+      return outputFormat.getHiveRecordWriter(loadedJobConf, this.stagingFile, writableClass, true,
           this.properties.getProperties(), null);
     } catch (Throwable t) {
       throw new IOException(String.format("Failed to create writer"), t);


### PR DESCRIPTION
Also cache the schema object in `AvroFileExtractor` to avoid loading HDFS file for multiple times


### JIRA
-  https://issues.apache.org/jira/browse/GOBBLIN-911


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

