### PR TITLE
[GOBBLIN-912]Enable TTL caching on Hive Metastore client connection

### DIFF
--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/HiveMetastoreClientPool.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/HiveMetastoreClientPool.java
@@ -60,7 +60,9 @@ public class HiveMetastoreClientPool {
 
   public static final String POOL_CACHE_TTL_MINUTES_KEY = "hive.metaStorePoolCache.ttl";
 
-  public static final String POOL_EVICTION_POLICY_CLASS_NAME = "org.apache.commons.pool2.impl.DefaultEvictionPolicy";
+  public static final String POOL_EVICTION_POLICY_CLASS_NAME = "pool.eviction.policy.class.name";
+
+  public static final String DEFAULT_POOL_EVICTION_POLICY_CLASS_NAME = "org.apache.commons.pool2.impl.DefaultEvictionPolicy";
 
   public static final String POOL_MIN_EVICTABLE_IDLE_TIME_MILLIS = "pool.min.evictable.idle.time.millis";
 
@@ -119,6 +121,14 @@ public class HiveMetastoreClientPool {
 
   /**
    * Constructor for {@link HiveMetastoreClientPool}.
+   * By default we will using the default eviction strategy for the client pool. Client will be evicted if the following conditions are met:
+   *  * <ul>
+   *  * <li>the object has been idle longer than
+   *  *     {@link GenericObjectPool#getMinEvictableIdleTimeMillis()}</li>
+   *  * <li>there are more than {@link GenericObjectPool#getMinIdle()} idle objects in
+   *  *     the pool and the object has been idle for longer than
+   *  *     {@link GenericObjectPool#getSoftMinEvictableIdleTimeMillis()} </li>
+   *  * </ul>
    * @deprecated It is recommended to use the static {@link #get} method instead. Use this constructor only if you
    *             different pool configurations are required.
    */
@@ -132,7 +142,7 @@ public class HiveMetastoreClientPool {
     this.factory = new HiveMetaStoreClientFactory(metastoreURI);
     this.pool = new GenericObjectPool<>(this.factory, config);
     //Set the eviction policy for the client pool
-    this.pool.setEvictionPolicyClassName(POOL_EVICTION_POLICY_CLASS_NAME);
+    this.pool.setEvictionPolicyClassName(properties.getProperty(POOL_EVICTION_POLICY_CLASS_NAME, DEFAULT_POOL_EVICTION_POLICY_CLASS_NAME));
     this.pool.setMinEvictableIdleTimeMillis(PropertiesUtils.getPropAsLong(properties, POOL_MIN_EVICTABLE_IDLE_TIME_MILLIS, DEFAULT_POOL_MIN_EVICTABLE_IDLE_TIME_MILLIS));
     this.pool.setTimeBetweenEvictionRunsMillis(PropertiesUtils.getPropAsLong(properties, POOL_TIME_BETWEEN_EVICTION_MILLIS, DEFAULT_POOL_TIME_BETWEEN_EVICTION_MILLIS));
     this.hiveConf = this.factory.getHiveConf();

--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/HiveMetastoreClientPool.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/HiveMetastoreClientPool.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+import org.apache.gobblin.util.PropertiesUtils;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 
@@ -58,6 +59,17 @@ public class HiveMetastoreClientPool {
   private static final long DEFAULT_POOL_CACHE_TTL_MINUTES = 30;
 
   public static final String POOL_CACHE_TTL_MINUTES_KEY = "hive.metaStorePoolCache.ttl";
+
+  public static final String POOL_EVICTION_POLICY_CLASS_NAME = "org.apache.commons.pool2.impl.DefaultEvictionPolicy";
+
+  public static final String POOL_MIN_EVICTABLE_IDLE_TIME_MILLIS = "pool.min.evictable.idle.time.millis";
+
+  public static final long DEFAULT_POOL_MIN_EVICTABLE_IDLE_TIME_MILLIS = 600000L;
+
+  public static final String POOL_TIME_BETWEEN_EVICTION_MILLIS = "pool.time.between eviction.millis";
+
+  public static final long DEFAULT_POOL_TIME_BETWEEN_EVICTION_MILLIS = 60000L;
+
 
   private static Cache<Optional<String>, HiveMetastoreClientPool> poolCache = null;
 
@@ -119,6 +131,10 @@ public class HiveMetastoreClientPool {
 
     this.factory = new HiveMetaStoreClientFactory(metastoreURI);
     this.pool = new GenericObjectPool<>(this.factory, config);
+    //Set the eviction policy for the client pool
+    this.pool.setEvictionPolicyClassName(POOL_EVICTION_POLICY_CLASS_NAME);
+    this.pool.setMinEvictableIdleTimeMillis(PropertiesUtils.getPropAsLong(properties, POOL_MIN_EVICTABLE_IDLE_TIME_MILLIS, DEFAULT_POOL_MIN_EVICTABLE_IDLE_TIME_MILLIS));
+    this.pool.setTimeBetweenEvictionRunsMillis(PropertiesUtils.getPropAsLong(properties, POOL_TIME_BETWEEN_EVICTION_MILLIS, DEFAULT_POOL_TIME_BETWEEN_EVICTION_MILLIS));
     this.hiveConf = this.factory.getHiveConf();
   }
 

--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/metastore/HiveMetaStoreBasedRegister.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/metastore/HiveMetaStoreBasedRegister.java
@@ -230,7 +230,7 @@ public class HiveMetaStoreBasedRegister extends HiveRegister {
         if(shouldUpdateLatestSchema) {
           updateSchema(spec, table);
         }
-        if (needToUpdateTable(existingTable, spec.getTable())) {
+        if (needToUpdateTable(existingTable, HiveMetaStoreUtils.getHiveTable(table))) {
           try (Timer.Context context = this.metricContext.timer(ALTER_TABLE).time()) {
             client.alter_table(dbName, tableName, getNewTblByMergingExistingTblProps(table, existingTable));
           }


### PR DESCRIPTION

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-912] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-912


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Enable TTL catche for HMS client and change one logic to determine whether need update table in hive to reduce one call to update table

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Test on parallel pipeline to make sure the connect will be destroyed after being idle for some time.

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

