### PR TITLE
add missing dep. for simple json example

### DIFF
--- a/gobblin-example/build.gradle
+++ b/gobblin-example/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     compile externalDependency.httpclient
     compile externalDependency.commonsCli
     compile externalDependency.hiveJdbc
+    implementation externalDependency.commonsVfs
 
     testCompile externalDependency.testng
 }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-920


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
when you run simple json example from gobblin-example module in mapreduce mode, it reports error of missing apache common vfs dependency.
solution is to include the dependency in gobblin-example so that it created in lib to be used when running the example.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: no new code or functionality


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

