### PR TITLE
adds worker id param to set taskrunnner id explicitly

### DIFF
--- a/bin/gobblin.sh
+++ b/bin/gobblin.sh
@@ -455,7 +455,7 @@ function start() {
                 WORKER_ID=$((LAST_WORKER_ID+1))
                 LOG_OUT_FILE="${GOBBLIN_LOGS}/${GOBBLIN_MODE}.$WORKER_ID.out"
                 LOG_ERR_FILE="${GOBBLIN_LOGS}/${GOBBLIN_MODE}.$WORKER_ID.err"
-                CLASS_N_ARGS="$CLUSTER_WORKER_CLASS --app_name $CLUSTER_NAME --helix_instance_name ${GOBBLIN_MODE}.$WORKER_ID "
+                CLASS_N_ARGS="$CLUSTER_WORKER_CLASS --app_name $CLUSTER_NAME --helix_instance_name ${GOBBLIN_MODE}.$WORKER_ID --worker.id $WORKER_ID"
             else
                 echo "Invalid gobblin command or execution mode... [EXITING]"
                 exit 1

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
@@ -66,6 +66,7 @@ public class GobblinClusterConfigurationKeys {
   public static final String ZK_CONNECTION_STRING_KEY = GOBBLIN_CLUSTER_PREFIX + "zk.connection.string";
   public static final String WORK_UNIT_FILE_PATH = GOBBLIN_CLUSTER_PREFIX + "work.unit.file.path";
   public static final String HELIX_INSTANCE_NAME_OPTION_NAME = "helix_instance_name";
+  public static final String TASK_RUNNER_WORKERID = "worker.id";
   public static final String HELIX_INSTANCE_NAME_KEY = GOBBLIN_CLUSTER_PREFIX + "helixInstanceName";
   // The number of tasks that can be running concurrently in the same worker process
   public static final String HELIX_CLUSTER_TASK_CONCURRENCY = GOBBLIN_CLUSTER_PREFIX + "helix.taskConcurrency";

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinTaskRunner.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinTaskRunner.java
@@ -35,6 +35,7 @@ import java.util.concurrent.TimeoutException;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.hadoop.conf.Configuration;
@@ -198,8 +199,10 @@ public class GobblinTaskRunner implements StandardMetricsBridge {
     this.services.addAll(getServices());
 
     if (this.services.isEmpty()) {
+      logger.debug("There are no services defined, setting serviceManager to null");
       this.serviceManager = null;
     } else {
+      logger.debug("adding services: {}.", this.services);
       this.serviceManager = new ServiceManager(services);
     }
 
@@ -594,16 +597,15 @@ public class GobblinTaskRunner implements StandardMetricsBridge {
     return "1";
   }
 
-  private static String getTaskRunnerId() {
-    return UUID.randomUUID().toString();
-  }
-
   public static Options buildOptions() {
     Options options = new Options();
     options.addOption("a", GobblinClusterConfigurationKeys.APPLICATION_NAME_OPTION_NAME, true,
         "Application name");
     options.addOption("i", GobblinClusterConfigurationKeys.HELIX_INSTANCE_NAME_OPTION_NAME, true,
         "Helix instance name");
+    Option workerIdOption = Option.builder("w").longOpt(GobblinClusterConfigurationKeys.TASK_RUNNER_WORKERID)
+            .hasArg().desc("Id of the task runner(worker) process").required().build();
+    options.addOption(workerIdOption);
     return options;
   }
 
@@ -617,8 +619,9 @@ public class GobblinTaskRunner implements StandardMetricsBridge {
     Options options = buildOptions();
     try {
       CommandLine cmd = new DefaultParser().parse(options, args);
-      if (!cmd.hasOption(GobblinClusterConfigurationKeys.APPLICATION_NAME_OPTION_NAME) || !cmd
-          .hasOption(GobblinClusterConfigurationKeys.HELIX_INSTANCE_NAME_OPTION_NAME)) {
+      if (!cmd.hasOption(GobblinClusterConfigurationKeys.APPLICATION_NAME_OPTION_NAME) ||
+              !cmd.hasOption(GobblinClusterConfigurationKeys.HELIX_INSTANCE_NAME_OPTION_NAME)) {
+        logger.info(String.format("Missing required parameters: %s, %s", GobblinClusterConfigurationKeys.APPLICATION_NAME_OPTION_NAME,  GobblinClusterConfigurationKeys.HELIX_INSTANCE_NAME_OPTION_NAME) );
         printUsage(options);
         System.exit(1);
       }
@@ -630,9 +633,16 @@ public class GobblinTaskRunner implements StandardMetricsBridge {
       String helixInstanceName =
           cmd.getOptionValue(GobblinClusterConfigurationKeys.HELIX_INSTANCE_NAME_OPTION_NAME);
 
+      String workerId = null;
+      if (cmd.hasOption(GobblinClusterConfigurationKeys.TASK_RUNNER_WORKERID)){
+        workerId = cmd.getOptionValue(GobblinClusterConfigurationKeys.TASK_RUNNER_WORKERID);
+      }else{
+        workerId = UUID.randomUUID().toString();
+      }
+
       GobblinTaskRunner gobblinWorkUnitRunner =
           new GobblinTaskRunner(applicationName, helixInstanceName, getApplicationId(),
-              getTaskRunnerId(), ConfigFactory.load(), Optional.<Path>absent());
+              workerId, ConfigFactory.load(), Optional.<Path>absent());
       gobblinWorkUnitRunner.start();
     } catch (ParseException pe) {
       printUsage(options);


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-812


### Description
- [x] Here are some details about my PR, including screenshots (if applicable): 
GobblinTaskRunner can take and use worker id from command line if specified while starting the worker.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: no functional code change


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

