### PR TITLE
[GOBBLIN-921]Make pull/push mode when registering partition to be configurable

### DIFF
--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/metastore/HiveMetaStoreBasedRegister.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/metastore/HiveMetaStoreBasedRegister.java
@@ -103,6 +103,9 @@ public class HiveMetaStoreBasedRegister extends HiveRegister {
   public static final String PATH_REGISTER_TIMER = HIVE_REGISTER_METRICS_PREFIX + "pathRegisterTimer";
   public static final String SKIP_PARTITION_DIFF_COMPUTATION = HIVE_REGISTER_METRICS_PREFIX + "skip.partition.diff.computation";
   public static final String FETCH_LATEST_SCHEMA = HIVE_REGISTER_METRICS_PREFIX + "fetchLatestSchemaFromSchemaRegistry";
+  //A config which when enabled checks for the existence of a partition in Hive before adding the partition.
+  // This is done to minimize the add_partition calls sent to Hive.
+  public static final String REGISTER_PARTITION_WITH_PULL_MODE = HIVE_REGISTER_METRICS_PREFIX + "registerPartitionWithPullMode";
   /**
    * To reduce lock aquisition and RPC to metaStoreClient, we cache the result of query regarding to
    * the existence of databases and tables in {@link #tableAndDbExistenceCache},
@@ -117,6 +120,7 @@ public class HiveMetaStoreBasedRegister extends HiveRegister {
   private final EventSubmitter eventSubmitter;
   private final MetricContext metricContext;
   private final boolean shouldUpdateLatestSchema;
+  private final boolean registerPartitionWithPullMode;
 
   /**
    * Local cache that contains records for both databases and tables.
@@ -128,7 +132,7 @@ public class HiveMetaStoreBasedRegister extends HiveRegister {
    * when the first time a table/database is loaded into the cache, whether they existed on the remote hiveMetaStore side.
    */
   CacheLoader<String, Boolean> cacheLoader = new CacheLoader<String, Boolean>() {
-  @Override
+    @Override
     public Boolean load(String key) throws Exception {
       return true;
     }
@@ -151,6 +155,7 @@ public class HiveMetaStoreBasedRegister extends HiveRegister {
     this.optimizedChecks = state.getPropAsBoolean(this.OPTIMIZED_CHECK_ENABLED, true);
     this.skipDiffComputation = state.getPropAsBoolean(this.SKIP_PARTITION_DIFF_COMPUTATION, false);
     this.shouldUpdateLatestSchema = state.getPropAsBoolean(this.FETCH_LATEST_SCHEMA, false);
+    this.registerPartitionWithPullMode = state.getPropAsBoolean(this.REGISTER_PARTITION_WITH_PULL_MODE, false);
     if(state.getPropAsBoolean(this.FETCH_LATEST_SCHEMA, false)) {
       this.schemaRegistry = Optional.of(KafkaSchemaRegistryFactory.getSchemaRegistry(state.getProperties()));
       topicName = state.getProp(KafkaSource.TOPIC_NAME);
@@ -200,6 +205,8 @@ public class HiveMetaStoreBasedRegister extends HiveRegister {
       }
     }
   }
+
+
 
   /**
    * If table existed on Hive side will return false;
@@ -492,7 +499,7 @@ public class HiveMetaStoreBasedRegister extends HiveRegister {
     }
   }
 
-  private void addOrAlterPartition(IMetaStoreClient client, Table table, HivePartition partition)
+  private void addOrAlterPartitionWithPushMode(IMetaStoreClient client, Table table, HivePartition partition)
       throws TException, IOException {
     Partition nativePartition = HiveMetaStoreUtils.getPartition(partition);
 
@@ -514,7 +521,7 @@ public class HiveMetaStoreBasedRegister extends HiveRegister {
           if (this.skipDiffComputation) {
             onPartitionExistWithoutComputingDiff(table, nativePartition, e);
           } else {
-            onPartitionExist(client, table, partition, nativePartition);
+            onPartitionExist(client, table, partition, nativePartition, null);
           }
         } catch (Throwable e2) {
           log.error(String.format(
@@ -526,11 +533,60 @@ public class HiveMetaStoreBasedRegister extends HiveRegister {
     }
   }
 
-  private void onPartitionExist(IMetaStoreClient client, Table table, HivePartition partition, Partition nativePartition) throws TException {
+  private void addOrAlterPartition(IMetaStoreClient client, Table table, HivePartition partition)
+      throws TException, IOException {
+    if(!registerPartitionWithPullMode) {
+      addOrAlterPartitionWithPushMode(client, table, partition);
+    } else {
+      addOrAlterPartitionWithPullMode(client, table, partition);
+    }
+  }
+  private void addOrAlterPartitionWithPullMode(IMetaStoreClient client, Table table, HivePartition partition)
+      throws TException, IOException {
+    Partition nativePartition = HiveMetaStoreUtils.getPartition(partition);
+
+    Preconditions.checkArgument(table.getPartitionKeysSize() == nativePartition.getValues().size(),
+        String.format("Partition key size is %s but partition value size is %s", table.getPartitionKeys().size(),
+            nativePartition.getValues().size()));
+
+    try (AutoCloseableHiveLock lock =
+        this.locks.getPartitionLock(table.getDbName(), table.getTableName(), nativePartition.getValues())) {
+
+      Partition existedPartition;
+      try {
+        try (Timer.Context context = this.metricContext.timer(GET_HIVE_PARTITION).time()) {
+          existedPartition =  client.getPartition(table.getDbName(), table.getTableName(), nativePartition.getValues());
+          if (this.skipDiffComputation) {
+            onPartitionExistWithoutComputingDiff(table, nativePartition, null);
+          } else {
+            onPartitionExist(client, table, partition, nativePartition, existedPartition);
+          }
+        }
+      } catch (TException e) {
+        try (Timer.Context context = this.metricContext.timer(ADD_PARTITION_TIMER).time()) {
+          client.add_partition(getPartitionWithCreateTimeNow(nativePartition));
+        }
+        catch (Throwable e2) {
+          log.error(String.format(
+              "Unable to add or alter partition %s in table %s with location %s: " + e2.getMessage(),
+              stringifyPartitionVerbose(nativePartition), table.getTableName(), nativePartition.getSd().getLocation()), e2);
+          throw e2;
+        }
+        log.info(String.format("Added partition %s to table %s with location %s", stringifyPartition(nativePartition),
+            table.getTableName(), nativePartition.getSd().getLocation()));
+      }
+    }
+  }
+
+  private void onPartitionExist(IMetaStoreClient client, Table table, HivePartition partition, Partition nativePartition, Partition existedPartition) throws TException {
     HivePartition existingPartition;
-    try (Timer.Context context = this.metricContext.timer(GET_HIVE_PARTITION).time()) {
-      existingPartition = HiveMetaStoreUtils.getHivePartition(
-          client.getPartition(table.getDbName(), table.getTableName(), nativePartition.getValues()));
+    if(existedPartition == null) {
+      try (Timer.Context context = this.metricContext.timer(GET_HIVE_PARTITION).time()) {
+        existingPartition = HiveMetaStoreUtils.getHivePartition(
+            client.getPartition(table.getDbName(), table.getTableName(), nativePartition.getValues()));
+      }
+    } else {
+      existingPartition = HiveMetaStoreUtils.getHivePartition(existedPartition);
     }
 
     if (needToUpdatePartition(existingPartition, partition)) {
@@ -550,6 +606,9 @@ public class HiveMetaStoreBasedRegister extends HiveRegister {
   }
 
   private void onPartitionExistWithoutComputingDiff(Table table, Partition nativePartition, TException e) throws TException {
+    if(e == null) {
+      return;
+    }
     if (e instanceof AlreadyExistsException) {
       log.debug(String.format("Partition %s in table %s with location %s already exists and no need to update",
           stringifyPartition(nativePartition), table.getTableName(), nativePartition.getSd().getLocation()));

--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/metastore/HiveMetaStoreBasedRegister.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/metastore/HiveMetaStoreBasedRegister.java
@@ -132,7 +132,7 @@ public class HiveMetaStoreBasedRegister extends HiveRegister {
    * when the first time a table/database is loaded into the cache, whether they existed on the remote hiveMetaStore side.
    */
   CacheLoader<String, Boolean> cacheLoader = new CacheLoader<String, Boolean>() {
-    @Override
+  @Override
     public Boolean load(String key) throws Exception {
       return true;
     }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-921] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-921


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
In pull mode, register will first try to check if the partition has already existed to reduce the call to add_partition. In push mode, register will try to call add_partition directly and relying on the exception to determine whether existed which mode should be used when most of the partition the HiveRegister try to register is not existed to reduce the call to HiveMetaStore.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Test on cluster

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

