### PR TITLE
ability to start admin server as separate process

### DIFF
--- a/bin/gobblin.sh
+++ b/bin/gobblin.sh
@@ -63,8 +63,9 @@ AWS_MODE='aws'
 YARN_MODE='yarn'
 MAPREDUCE_MODE='mapreduce'
 GOBBLIN_AS_SERVICE_MODE='gobblin-as-service'
+GOBBLIN_UI_MODE='gobblin-ui'
 
-GOBBLIN_EXEC_MODE_LIST="$STANDALONE_MODE $CLUSTER_MASTER_MODE $CLUSTER_WORKER_MODE $AWS_MODE $YARN_MODE $MAPREDUCE_MODE $GOBBLIN_AS_SERVICE_MODE"
+GOBBLIN_EXEC_MODE_LIST="$STANDALONE_MODE $CLUSTER_MASTER_MODE $CLUSTER_WORKER_MODE $AWS_MODE $YARN_MODE $MAPREDUCE_MODE $GOBBLIN_AS_SERVICE_MODE $GOBBLIN_UI_MODE"
 
 # CLI Command class
 CLI_CLASS='org.apache.gobblin.runtime.cli.GobblinCli'
@@ -77,6 +78,7 @@ AWS_CLASS='org.apache.gobblin.aws.GobblinAWSClusterLauncher'
 YARN_CLASS='org.apache.gobblin.yarn.GobblinYarnAppLauncher'
 MAPREDUCE_CLASS='org.apache.gobblin.runtime.mapreduce.CliMRJobLauncher'
 SERVICE_MANAGER_CLASS='org.apache.gobblin.service.modules.core.GobblinServiceManager'
+GOBBLIN_UI_CLASS='org.apache.gobblin.admin.AdminWebServer'
 
 function print_gobblin_usage() {
     echo "Usage:"
@@ -447,7 +449,10 @@ function start() {
                 CLASS_N_ARGS="$CLUSTER_MASTER_CLASS --standalone_cluster true --app_name $CLUSTER_NAME "
 
             elif [[ "$GOBBLIN_MODE" = "$GOBBLIN_AS_SERVICE_MODE" ]]; then
-                CLASS_N_ARGS="$SERVICE_MANAGER_CLASS --service_name Gobblin-$GOBBLIN_AS_SERVICE_MODE --service_id GAAS-1"
+                CLASS_N_ARGS="$SERVICE_MANAGER_CLASS --service_name $GOBBLIN_AS_SERVICE_MODE --service_id GAAS-1"
+
+            elif [[ "$GOBBLIN_MODE" = "$GOBBLIN_UI_MODE" ]]; then
+                CLASS_N_ARGS="$GOBBLIN_UI_CLASS"
 
             elif [[ "$GOBBLIN_MODE" = "$CLUSTER_WORKER_MODE" ]]; then
                 #Find largest worker id and use next one to start worker in incremental order, starts with 1
@@ -508,6 +513,8 @@ function stop() {
                         class_to_search="$YARN_CLASS"
                     elif [[ "$GOBBLIN_MODE" = "$GOBBLIN_AS_SERVICE_MODE" ]]; then
                         class_to_search="$SERVICE_MANAGER_CLASS"
+                    elif [[ "$GOBBLIN_MODE" = "$GOBBLIN_UI_MODE" ]]; then
+                        class_to_search="$GOBBLIN_UI_CLASS"
                     elif [[ "$GOBBLIN_MODE" = "$CLUSTER_MASTER_MODE" ]]; then
                         class_to_search="$CLUSTER_MASTER_CLASS"
                     elif [[ "$GOBBLIN_MODE" = "$CLUSTER_WORKER_MODE" ]]; then

--- a/gobblin-admin/build.gradle
+++ b/gobblin-admin/build.gradle
@@ -26,6 +26,7 @@ repositories {
 
 dependencies {
     compile project(":gobblin-rest-service:gobblin-rest-client")
+    compile project(":gobblin-rest-service:gobblin-rest-server")
     compile project(":gobblin-core")
 
     compile externalDependency.jetty

--- a/gobblin-rest-service/gobblin-rest-server/src/main/java/org/apache/gobblin/rest/JobExecutionInfoServer.java
+++ b/gobblin-rest-service/gobblin-rest-server/src/main/java/org/apache/gobblin/rest/JobExecutionInfoServer.java
@@ -72,7 +72,7 @@ public class JobExecutionInfoServer extends AbstractIdleService {
   }
 
   @Override
-  protected void startUp()
+  public void startUp()
       throws Exception {
     // Server configuration
     RestLiConfig config = new RestLiConfig();


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-843


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
currently, the admin UI & rest server starts and clubbed within the master process ( standalone, or cluster master/worker process ).

If we can have ability to start the rest server and admin UI separately, it would help manage it better and decouple the deployment modes and admin/rest services.

the gobblin service command should facilitate starting stopping admin/rest services.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: adding more way to start admin server, no new code functionality.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

