### PR TITLE
[GOBBLIN-923] Fix Array and Map JsonElement converters to handle nullable elements

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/converter/avro/JsonElementConversionFactory.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/converter/avro/JsonElementConversionFactory.java
@@ -530,7 +530,7 @@ public class JsonElementConversionFactory {
       List<Object> list = new ArrayList<>();
 
       for (JsonElement elem : (JsonArray) value) {
-        list.add(getElementConverter().convertField(elem));
+        list.add(getElementConverter().convert(elem));
       }
 
       return new GenericData.Array<>(arraySchema(), list);
@@ -566,7 +566,7 @@ public class JsonElementConversionFactory {
       Map<String, Object> map = new HashMap<>();
 
       for (Map.Entry<String, JsonElement> entry : ((JsonObject) value).entrySet()) {
-        map.put(entry.getKey(), getElementConverter().convertField(entry.getValue()));
+        map.put(entry.getKey(), getElementConverter().convert(entry.getValue()));
       }
 
       return map;

--- a/gobblin-core/src/main/java/org/apache/gobblin/converter/avro/JsonElementConversionWithAvroSchemaFactory.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/converter/avro/JsonElementConversionWithAvroSchemaFactory.java
@@ -90,7 +90,7 @@ public class JsonElementConversionWithAvroSchemaFactory extends JsonElementConve
       List<Object> list = new ArrayList<>();
 
       for (JsonElement elem : (JsonArray) value) {
-        list.add(getElementConverter().convertField(elem));
+        list.add(getElementConverter().convert(elem));
       }
 
       return new GenericData.Array<>(schema(), list);
@@ -124,7 +124,7 @@ public class JsonElementConversionWithAvroSchemaFactory extends JsonElementConve
       Map<String, Object> map = new HashMap<>();
 
       for (Map.Entry<String, JsonElement> entry : ((JsonObject) value).entrySet()) {
-        map.put(entry.getKey(), getElementConverter().convertField(entry.getValue()));
+        map.put(entry.getKey(), getElementConverter().convert(entry.getValue()));
       }
 
       return map;


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ GOBBLIN-923] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-923


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
This change fixes the converters below to check if the `JsonElement`
they are invoked with is a `JsonNull` and handle it accordingly.

  - `JsonElementConversionWithAvroSchemaFactory::ArrayConverter`
  - `JsonElementConversionWithAvroSchemaFactory::MapConverter`
  - `JsonElementConversionFactory::ArrayConverter`
  - `JsonElementConversionFactory::MapConverter`

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
No new functionality


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

