### PR TITLE
[GOBBLIN-925] Create option to log outputs to console, fix docker-com…

### DIFF
--- a/conf/standalone/log4j.xml
+++ b/conf/standalone/log4j.xml
@@ -16,6 +16,13 @@
     </layout>
   </appender>
 
+
+  <appender name="console" class="org.apache.log4j.ConsoleAppender">
+    <layout class="org.apache.log4j.PatternLayout">
+      <param name="ConversionPattern" value="%d{yyyy-MM-dd HH:mm:ss z} %-5p [%t] %C %X{tableName} %L - %m%n"/>
+    </layout>
+  </appender>
+
   <logger name="org.apache.commons.httpclient">
     <level value="DEBUG"/>
   </logger>
@@ -27,6 +34,7 @@
   <root>
     <priority value ="INFO" />
     <appender-ref ref="FileRoll" />
+    <appender-ref ref="console" />
   </root>
 
 </log4j:configuration>

--- a/gobblin-docker/gobblin-service/alpine-gaas-latest/entrypoint.sh
+++ b/gobblin-docker/gobblin-service/alpine-gaas-latest/entrypoint.sh
@@ -17,6 +17,5 @@
 #
 GOBBLIN_HOME="$(cd `dirname $0`/..; pwd)"
 
-./bin/gobblin.sh service gobblin-as-service start alpine-gaas-latest_gobblin-standalone
-busybox tail -F $GOBBLIN_HOME/logs/gobblin-as-service.out
+./bin/gobblin.sh service gobblin-as-service start --log-to-stdout $@
 

--- a/gobblin-docker/gobblin-standalone/alpine-gobblin-latest/entrypoint.sh
+++ b/gobblin-docker/gobblin-standalone/alpine-gobblin-latest/entrypoint.sh
@@ -17,5 +17,4 @@
 #
 GOBBLIN_HOME="$(cd `dirname $0`/..; pwd)"
 
-./bin/gobblin.sh service standalone start
-busybox tail -F ${GOBBLIN_HOME}/logs/standalone.out
+./bin/gobblin.sh service standalone start --log-to-stdout $@


### PR DESCRIPTION
…pose

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-925


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

Currently, Gobblin containers `tail -F` a file to output logs.
While this works, this means that the container will not stop execution if the java process is terminated. This becomes problematic when Kubernetes uses container status to restart pods.

This patch adds a flag variable to the startup script so that containers can read console directly by running the gobblin executable in the foreground 

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
scripts change

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

