### PR TITLE
[GOBBLIN-938] Make job-template resolution available in all JobLaunchers

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobLauncher.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobLauncher.java
@@ -151,7 +151,6 @@ public class GobblinHelixJobLauncher extends AbstractJobLauncher {
 
     this.stateSerDeRunnerThreads = Integer.parseInt(jobProps.getProperty(ParallelRunner.PARALLEL_RUNNER_THREADS_KEY,
         Integer.toString(ParallelRunner.DEFAULT_PARALLEL_RUNNER_THREADS)));
-
     jobConfig = ConfigUtils.propertiesToConfig(jobProps);
 
     this.workFlowExpiryTimeSeconds = ConfigUtils.getLong(jobConfig,

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/spec/JobExecutionPlan.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/spec/JobExecutionPlan.java
@@ -49,6 +49,8 @@ import org.apache.gobblin.service.modules.orchestration.DagManager;
 import org.apache.gobblin.service.modules.template_catalog.FSFlowTemplateCatalog;
 import org.apache.gobblin.util.ConfigUtils;
 
+import static org.apache.gobblin.service.modules.template_catalog.FSFlowTemplateCatalog.JOB_TEMPLATE_KEY;
+
 
 /**
  * A data class that encapsulates information for executing a job. This includes a {@link JobSpec} and a {@link SpecExecutor}
@@ -120,7 +122,7 @@ public class JobExecutionPlan {
       jobSpec.setConfig(jobSpec.getConfig().withoutPath(ConfigurationKeys.JOB_SCHEDULE_KEY));
 
       //Remove template uri
-      jobSpec.setConfig(jobSpec.getConfig().withoutPath(FSFlowTemplateCatalog.JOB_TEMPLATE_KEY));
+      jobSpec.setConfig(jobSpec.getConfig().withoutPath(JOB_TEMPLATE_KEY));
 
       // Add job.name and job.group
       jobSpec.setConfig(jobSpec.getConfig().withValue(ConfigurationKeys.JOB_NAME_KEY, ConfigValueFactory.fromAnyRef(jobName)));

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/template_catalog/FSFlowTemplateCatalog.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/template_catalog/FSFlowTemplateCatalog.java
@@ -47,6 +47,8 @@ import org.apache.gobblin.service.modules.template.FlowTemplate;
 import org.apache.gobblin.service.modules.template.HOCONInputStreamFlowTemplate;
 import org.apache.gobblin.util.PathUtils;
 
+import static org.apache.gobblin.runtime.AbstractJobLauncher.GOBBLIN_JOB_TEMPLATE_KEY;
+
 
 /**
  * An implementation of a catalog for {@link FlowTemplate}s. Provides basic API for retrieving a {@link FlowTemplate}
@@ -67,7 +69,6 @@ public class FSFlowTemplateCatalog extends FSJobCatalog implements FlowCatalogWi
   public static final String JOBS_DIR_NAME = "jobs";
   public static final String FLOW_CONF_FILE_NAME = "flow.conf";
   public static final List<String> JOB_FILE_EXTENSIONS = Arrays.asList(".job", ".template");
-  public static final String JOB_TEMPLATE_KEY = "gobblin.template.uri";
 
   protected static final String FS_SCHEME = "FS";
 
@@ -145,8 +146,8 @@ public class FSFlowTemplateCatalog extends FSJobCatalog implements FlowCatalogWi
     for (FileStatus fileStatus : fs.listStatus(jobFilePath, extensionFilter)) {
       Config jobConfig = loadHoconFileAtPath(fileStatus.getPath());
       //Check if the .job file has an underlying job template
-      if (jobConfig.hasPath(JOB_TEMPLATE_KEY)) {
-        URI jobTemplateRelativeUri = new URI(jobConfig.getString(JOB_TEMPLATE_KEY));
+      if (jobConfig.hasPath(GOBBLIN_JOB_TEMPLATE_KEY)) {
+        URI jobTemplateRelativeUri = new URI(jobConfig.getString(GOBBLIN_JOB_TEMPLATE_KEY));
         if (!jobTemplateRelativeUri.getScheme().equals(FS_SCHEME)) {
           throw new RuntimeException(
               "Expected scheme " + FS_SCHEME + " got unsupported scheme " + flowTemplateDirURI.getScheme());


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] https://issues.apache.org/jira/browse/GOBBLIN-938


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
- Getting rid of duplicated `gobblin.job.templates` in GaaS code
- Making the job-template resolution available in `AbstractJobLauncher` so that all its extensions will be able to resolve the template, including Helix JobLauncher. Once it is being resolved and added as part of `JobContext`, the `Source` will be added with this job properties so as passing-down to each workunits. 


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: Unit tested in `LocalJobLauncher`


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

