### PR TITLE
[GOBBLIN-940]Add synchronization on workunit persistency before Helix job launching

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobLauncher.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobLauncher.java
@@ -219,7 +219,7 @@ public class GobblinHelixJobLauncher extends AbstractJobLauncher {
           if (helixMetrics.isPresent()) {
             helixMetrics.get().submitMeter.mark();
           }
-          submitJobToHelix(createJob(workUnits));
+          submitJobToHelix(createHelixJob(workUnits));
           if (helixMetrics.isPresent()) {
             this.helixMetrics.get().updateTimeForHelixSubmit(submitStart);
           }
@@ -271,7 +271,7 @@ public class GobblinHelixJobLauncher extends AbstractJobLauncher {
   /**
    * Create a job from a given batch of {@link WorkUnit}s.
    */
-  private JobConfig.Builder createJob(List<WorkUnit> workUnits) throws IOException {
+  JobConfig.Builder createHelixJob(List<WorkUnit> workUnits) throws IOException {
     Map<String, TaskConfig> taskConfigMap = Maps.newHashMap();
 
     try (ParallelRunner stateSerDeRunner = new ParallelRunner(this.stateSerDeRunnerThreads, this.fs)) {
@@ -295,23 +295,34 @@ public class GobblinHelixJobLauncher extends AbstractJobLauncher {
         SerializationUtils.serializeState(this.fs, jobStateFilePath, this.jobContext.getJobState());
       }
 
-      LOGGER.debug("GobblinHelixJobLauncher.createJob: jobStateFilePath {}, jobState {} jobProperties {}",
-          jobStateFilePath, this.jobContext.getJobState().toString(), this.jobContext.getJobState().getProperties());
-    }
+      // Block on all persistency of workunits finished
+      // It is necessary when underlying storage being and Helix activate task-execution before the workunit being persisted.
+      stateSerDeRunner.waitForTasks();
 
+      LOGGER.debug("GobblinHelixJobLauncher.createHelixJob: jobStateFilePath {}, jobState {} jobProperties {}",
+          jobStateFilePath, this.jobContext.getJobState().toString(), this.jobContext.getJobState().getProperties());
+
+      return translateGobblinJobConfigToHelixJobConfig(this.jobContext.getJobState(), workUnits, taskConfigMap);
+    }
+  }
+
+  /**
+   * Populate {@link JobConfig.Builder} with relevant gobblin job-configurations.
+   */
+  JobConfig.Builder translateGobblinJobConfigToHelixJobConfig(JobState gobblinJobState, List<WorkUnit> workUnits,
+      Map<String, TaskConfig> taskConfigMap) {
     JobConfig.Builder jobConfigBuilder = new JobConfig.Builder();
 
     // Helix task attempts = retries + 1 (fallback to general task retry for backward compatibility)
-    jobConfigBuilder.setMaxAttemptsPerTask(this.jobContext.getJobState().getPropAsInt(
-        GobblinClusterConfigurationKeys.HELIX_TASK_MAX_ATTEMPTS_KEY,
-        this.jobContext.getJobState().getPropAsInt(
+    jobConfigBuilder.setMaxAttemptsPerTask(gobblinJobState.getPropAsInt(
+        GobblinClusterConfigurationKeys.HELIX_TASK_MAX_ATTEMPTS_KEY, gobblinJobState.getPropAsInt(
             ConfigurationKeys.MAX_TASK_RETRIES_KEY,
             ConfigurationKeys.DEFAULT_MAX_TASK_RETRIES)) + 1);
 
     // Helix task timeout (fallback to general task timeout for backward compatibility)
-    jobConfigBuilder.setTimeoutPerTask(this.jobContext.getJobState().getPropAsLong(
+    jobConfigBuilder.setTimeoutPerTask(gobblinJobState.getPropAsLong(
         GobblinClusterConfigurationKeys.HELIX_TASK_TIMEOUT_SECONDS,
-        this.jobContext.getJobState().getPropAsLong(
+        gobblinJobState.getPropAsLong(
             ConfigurationKeys.TASK_TIMEOUT_SECONDS,
             ConfigurationKeys.DEFAULT_TASK_TIMEOUT_SECONDS)) * 1000);
 
@@ -337,7 +348,7 @@ public class GobblinHelixJobLauncher extends AbstractJobLauncher {
       jobConfigBuilder.setRebalanceRunningTask(true);
     }
 
-    jobConfigBuilder.setExpiry(this.jobContext.getJobState().getPropAsLong(
+    jobConfigBuilder.setExpiry(gobblinJobState.getPropAsLong(
         GobblinClusterConfigurationKeys.HELIX_WORKFLOW_EXPIRY_TIME_SECONDS, GobblinClusterConfigurationKeys.DEFAULT_HELIX_WORKFLOW_EXPIRY_TIME_SECONDS));
 
     return jobConfigBuilder;

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobLauncher.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobLauncher.java
@@ -295,8 +295,8 @@ public class GobblinHelixJobLauncher extends AbstractJobLauncher {
         SerializationUtils.serializeState(this.fs, jobStateFilePath, this.jobContext.getJobState());
       }
 
-      // Block on all persistency of workunits finished
-      // It is necessary when underlying storage being and Helix activate task-execution before the workunit being persisted.
+      // Block on persistence of all workunits to be finished.
+      // It is necessary when underlying storage being slow and Helix activate task-execution before the workunit being persisted.
       stateSerDeRunner.waitForTasks();
 
       LOGGER.debug("GobblinHelixJobLauncher.createHelixJob: jobStateFilePath {}, jobState {} jobProperties {}",

--- a/gobblin-utility/build.gradle
+++ b/gobblin-utility/build.gradle
@@ -59,20 +59,17 @@ dependencies {
 }
 
 configurations {
-    compile {
-        transitive = true
-    }
-    archives
+  compile {
+    transitive = true
+  }
+  archives
 }
 
 test {
-    workingDir rootProject.rootDir
+  workingDir rootProject.rootDir
 }
 
-
-
-ext.classification="library"
-
+ext.classification = "library"
 
 task utilityTar(type: Tar) {
   //there seems to be a bug in the Gradle signing module where X.tar.gz will generate
@@ -83,8 +80,8 @@ task utilityTar(type: Tar) {
   compression = Compression.GZIP
 
   into("lib") { from configurations.runtime }
-  into("lib") { from "${project.rootDir}/build/${project.name}/libs/${project.name}.jar"}
-  into("lib") { from "${project.rootDir}/build/${project.name}/libs/${project.name}-${project.version}.jar"}
+  into("lib") { from "${project.rootDir}/build/${project.name}/libs/${project.name}.jar" }
+  into("lib") { from "${project.rootDir}/build/${project.name}/libs/${project.name}-${project.version}.jar" }
   into("bin") {
     from "src/main/bash"
     fileMode = 0755

--- a/gobblin-utility/src/test/java/org/apache/gobblin/util/ParallelRunnerTest.java
+++ b/gobblin-utility/src/test/java/org/apache/gobblin/util/ParallelRunnerTest.java
@@ -192,9 +192,18 @@ public class ParallelRunnerTest {
     Assert.assertEquals(actual.toString(), expected);
   }
 
-  @Test(groups = { "ignore" })
+  /**
+   * A test verifying when {@link ParallelRunner#close()} is called, everything inside runner has been collected.
+   * Positive case: Both files get mock-deleted and parallelRunner returns.
+   * Negative case: Using countdown-latch to specify causality between two deletion of files and construct a deadlock.
+   * The src2 deletion won't happen as it depends on src1's deletion and vice versa.
+   * {@link ParallelRunner#close()} will finally timeout and expect to catch the {@link java.util.concurrent.TimeoutException}.
+   */
   public void testWaitsForFuturesWhenClosing() throws IOException, InterruptedException {
+
+    // Indicate if deadlock is being constructed.
     final AtomicBoolean flag = new AtomicBoolean();
+    flag.set(true);
     final CountDownLatch latch1 = new CountDownLatch(1);
     final CountDownLatch latch2 = new CountDownLatch(1);
     Path src1 = new Path("/src/file1.txt");
@@ -204,21 +213,23 @@ public class ParallelRunnerTest {
     Mockito.when(fs.delete(src1, true)).thenAnswer(new Answer<Boolean>() {
       @Override
       public Boolean answer(InvocationOnMock invocation) throws Throwable {
+        if (flag.get()) {
+          latch2.await();
+        }
         latch1.countDown();
-        return false;
+        return true;
       }
     });
     Mockito.when(fs.exists(src2)).thenReturn(true);
 
-    final int max_waiting = 70000;
+    /** Will make deletion of files from parallelRunner to be timeout after 5 seconds.*/
+    final int timeout = 5000;
     Mockito.when(fs.delete(src2, true)).thenAnswer(new Answer<Boolean>() {
       @Override
       public Boolean answer(InvocationOnMock invocation) throws Throwable {
-        latch1.await();
-        long end = System.currentTimeMillis() + max_waiting;
-        AssertWithBackoff.create().maxSleepMs(max_waiting).backoffFactor(2).
-            assertTrue(input -> System.currentTimeMillis() < end, "Something wrong with waiting on condition");
-        flag.set(true);
+        if (flag.get()) {
+          latch1.await();
+        }
         latch2.countDown();
         return true;
       }
@@ -227,17 +238,30 @@ public class ParallelRunnerTest {
     boolean caughtException = false;
     ParallelRunner parallelRunner = new ParallelRunner(2, fs);
     try {
-      parallelRunner.deletePath(src1, true);
       parallelRunner.deletePath(src2, true);
-      System.out.println(System.currentTimeMillis() + ": START - ParallelRunner.close()");
-      parallelRunner.close();
+      parallelRunner.deletePath(src1, true);
+      parallelRunner.waitForTasks(timeout);
     } catch (IOException e) {
       caughtException = true;
     }
-    // Close method will wait until all tasks finished.
+    Assert.assertTrue(caughtException);
+    Assert.assertEquals(latch2.getCount(), 1);
+    Assert.assertEquals(latch1.getCount(), 1);
+
+    // Remove deadlock
+    flag.set(false);
+    caughtException = false;
+    parallelRunner = new ParallelRunner(2, fs);
+    try {
+      parallelRunner.deletePath(src2, true);
+      parallelRunner.deletePath(src1, true);
+      parallelRunner.waitForTasks(timeout);
+    } catch (IOException e) {
+      caughtException = true;
+    }
     Assert.assertFalse(caughtException);
     Assert.assertEquals(latch2.getCount(), 0);
-    Assert.assertTrue(flag.get());
+    Assert.assertEquals(latch1.getCount(), 0);
   }
 
   @AfterClass


### PR DESCRIPTION

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] https://issues.apache.org/jira/browse/GOBBLIN-940


### Description
- [x] Did some minor refactoring and unit test fixing, the major part is just adding `waitForTasks ` before Helix job being returned and submitted. This is causing problem when HDFS being very slow / parallel runner hitting CPU bounded on working on workunit persistency that Helix task is activated before WU is showing up.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

