### PR TITLE
[GOBBLIN-944] Provide the flexibility of deriving platform field in a different way for subclasses of BaseDatasetDescriptor

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/dataset/BaseDatasetDescriptor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/dataset/BaseDatasetDescriptor.java
@@ -51,12 +51,21 @@ public abstract class BaseDatasetDescriptor implements DatasetDescriptor {
           .build());
 
   public BaseDatasetDescriptor(Config config) throws IOException {
-    Preconditions.checkArgument(config.hasPath(DatasetDescriptorConfigKeys.PLATFORM_KEY), "Dataset descriptor config must specify platform");
-    this.platform = config.getString(DatasetDescriptorConfigKeys.PLATFORM_KEY).toLowerCase();
+    this.platform = extractPlatform(config);
     this.formatConfig = new FormatConfig(config);
     this.isRetentionApplied = ConfigUtils.getBoolean(config, DatasetDescriptorConfigKeys.IS_RETENTION_APPLIED_KEY, false);
     this.description = ConfigUtils.getString(config, DatasetDescriptorConfigKeys.DESCRIPTION_KEY, "");
     this.rawConfig = config.withFallback(this.formatConfig.getRawConfig()).withFallback(DEFAULT_FALLBACK);
+  }
+
+  /**
+   * Provide the default way of extracting the platform field from a {@code config} parameter
+   * @param config the configuration for current DatasetDescriptor
+   * @return the platform extracted
+   */
+  protected String extractPlatform(Config config) {
+    Preconditions.checkArgument(config.hasPath(DatasetDescriptorConfigKeys.PLATFORM_KEY), "Dataset descriptor config must specify platform");
+    return config.getString(DatasetDescriptorConfigKeys.PLATFORM_KEY).toLowerCase();
   }
 
   /**


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA]
    - https://issues.apache.org/jira/browse/GOBBLIN-944


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
Move two lines of code to a protected method for subclasses to override.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

