### PR TITLE
[GOBBLIN-946] Add HttpDatasetDescriptor and HttpDataNode to Gobblin Service

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/dataset/HttpDatasetDescriptor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/dataset/HttpDatasetDescriptor.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.service.modules.dataset;
+
+import com.google.common.base.Enums;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigValueFactory;
+import java.io.IOException;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.gobblin.service.modules.flowgraph.DatasetDescriptorConfigKeys;
+import org.apache.gobblin.util.ConfigUtils;
+
+
+/**
+ * Describes a dataset behind a HTTP scheme.
+ * path refers to the HTTP path of a given dataset.
+ * e.g, https://some-api:443/user/123/names, where /user/123/names is the path
+ * query string is not supported
+ */
+@Slf4j
+@ToString (exclude = {"rawConfig"})
+@EqualsAndHashCode (exclude = {"rawConfig"}, callSuper = true)
+public class HttpDatasetDescriptor extends BaseDatasetDescriptor implements DatasetDescriptor {
+
+  @Getter
+  private final String path;
+  @Getter
+  private final Config rawConfig;
+
+  public enum Platform {
+    HTTP("http"),
+    HTTPS("https");
+
+    private final String platform;
+
+    Platform(final String platform) {
+      this.platform = platform;
+    }
+
+    @Override
+    public String toString() {
+      return this.platform;
+    }
+  }
+
+  public HttpDatasetDescriptor(Config config) throws IOException {
+    super(config);
+    if (!isPlatformValid()) {
+      throw new IOException("Invalid platform specified for HttpDatasetDescriptor: " + getPlatform());
+    }
+    // refers to the full HTTP url
+    this.path = ConfigUtils.getString(config, DatasetDescriptorConfigKeys.PATH_KEY, "");
+    this.rawConfig = config.withValue(DatasetDescriptorConfigKeys.PATH_KEY, ConfigValueFactory.fromAnyRef(this.path)).withFallback(super.getRawConfig());
+  }
+
+  /**
+   * @return true if the platform is valid, false otherwise
+   */
+  private boolean isPlatformValid() {
+    return Enums.getIfPresent(HttpDatasetDescriptor.Platform.class, getPlatform().toUpperCase()).isPresent();
+  }
+
+  /**
+   * Check if this HTTP path equals the other HTTP path
+   *
+   * @param other whose path should be in the format of a HTTP path
+   */
+  @Override
+  protected boolean isPathContaining(DatasetDescriptor other) {
+    // Might be null
+    String otherPath = other.getPath();
+    return this.path.equals(otherPath);
+  }
+}

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/dataset/SqlDatasetDescriptor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/dataset/SqlDatasetDescriptor.java
@@ -51,7 +51,7 @@ public class SqlDatasetDescriptor extends BaseDatasetDescriptor implements Datas
   @Getter
   private final Config rawConfig;
 
-  public enum  Platform {
+  public enum Platform {
     SQLSERVER("sqlserver"),
     MYSQL("mysql"),
     ORACLE("oracle"),

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/FlowGraphConfigurationKeys.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/FlowGraphConfigurationKeys.java
@@ -30,6 +30,12 @@ public class FlowGraphConfigurationKeys {
   public static final String DATA_NODE_IS_ACTIVE_KEY = DATA_NODE_PREFIX + "isActive";
 
   /**
+   *   {@link org.apache.gobblin.service.modules.flowgraph.datanodes.HttpDataNode} related configuration keys.
+   */
+  public static final String DATA_NODE_HTTP_DOMAIN_KEY = DATA_NODE_PREFIX + "http.domain";
+  public static final String DATA_NODE_HTTP_AUTHENTICATION_TYPE_KEY = DATA_NODE_PREFIX + "http.authentication.type";
+
+  /**
    * {@link FlowEdge} related configuration keys.
    */
   public static final String FLOW_EDGE_FACTORY_CLASS = FLOW_EDGE_PREFIX + "factory.class";

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/datanodes/HttpDataNode.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/datanodes/HttpDataNode.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.service.modules.flowgraph.datanodes;
+
+import com.google.common.base.Preconditions;
+import com.typesafe.config.Config;
+
+import joptsimple.internal.Strings;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+import org.apache.gobblin.service.modules.flowgraph.BaseDataNode;
+import org.apache.gobblin.service.modules.flowgraph.DataNode;
+import org.apache.gobblin.service.modules.flowgraph.FlowGraphConfigurationKeys;
+import org.apache.gobblin.util.ConfigUtils;
+
+
+/**
+ * Represents a HTTP source. Whether the source provides a REST complied API is not enforced.
+ * Currently supports HTTPS with port default to 443
+ */
+@EqualsAndHashCode (callSuper = true)
+public class HttpDataNode extends BaseDataNode  {
+
+  @Getter
+  private String httpDomain;
+  @Getter
+  private String authenticationType;
+
+  public HttpDataNode(Config nodeProps) throws DataNode.DataNodeCreationException {
+    super(nodeProps);
+    try {
+      this.httpDomain = ConfigUtils.getString(nodeProps, FlowGraphConfigurationKeys.DATA_NODE_HTTP_DOMAIN_KEY, "");
+      // Authentication details and credentials should reside in the Gobblin job payload
+      this.authenticationType = ConfigUtils.getString(
+          nodeProps, FlowGraphConfigurationKeys.DATA_NODE_HTTP_AUTHENTICATION_TYPE_KEY, "");
+
+      Preconditions.checkArgument(!Strings.isNullOrEmpty(httpDomain),
+          FlowGraphConfigurationKeys.DATA_NODE_HTTP_DOMAIN_KEY + " cannot be null or empty.");
+      Preconditions.checkArgument(!Strings.isNullOrEmpty(authenticationType),
+          FlowGraphConfigurationKeys.DATA_NODE_HTTP_AUTHENTICATION_TYPE_KEY + " cannot be null or empty.");
+    } catch (Exception e) {
+      throw new DataNode.DataNodeCreationException(e);
+    }
+  }
+}

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/dataset/HttpDatasetDescriptorTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/dataset/HttpDatasetDescriptorTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.service.modules.dataset;
+
+import java.io.IOException;
+
+import org.junit.Assert;
+import org.testng.annotations.Test;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigValueFactory;
+
+import org.apache.gobblin.service.modules.flowgraph.DatasetDescriptorConfigKeys;
+
+public class HttpDatasetDescriptorTest {
+
+  @Test
+  public void testContains() throws IOException {
+    Config config1 = ConfigFactory.empty()
+        .withValue(DatasetDescriptorConfigKeys.PLATFORM_KEY, ConfigValueFactory.fromAnyRef("https"))
+        .withValue(DatasetDescriptorConfigKeys.PATH_KEY, ConfigValueFactory.fromAnyRef("https://a.com/b"));
+    HttpDatasetDescriptor descriptor1 = new HttpDatasetDescriptor(config1);
+
+    // Verify that same path points to same dataset
+    Config config2 = ConfigFactory.empty()
+        .withValue(DatasetDescriptorConfigKeys.PLATFORM_KEY, ConfigValueFactory.fromAnyRef("https"))
+        .withValue(DatasetDescriptorConfigKeys.PATH_KEY, ConfigValueFactory.fromAnyRef("https://a.com/b"));
+    HttpDatasetDescriptor descriptor2 = new HttpDatasetDescriptor(config2);
+    Assert.assertTrue(descriptor2.contains(descriptor1));
+
+    // Verify that same path but different platform points to different dataset
+    Config config3 = ConfigFactory.empty()
+        .withValue(DatasetDescriptorConfigKeys.PLATFORM_KEY, ConfigValueFactory.fromAnyRef("http"))
+        .withValue(DatasetDescriptorConfigKeys.PATH_KEY, ConfigValueFactory.fromAnyRef("https://a.com/b"));
+    HttpDatasetDescriptor descriptor3 = new HttpDatasetDescriptor(config3);
+    Assert.assertFalse(descriptor3.contains(descriptor1));
+
+  }
+}

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/flowgraph/datanodes/HttpDataNodeTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/flowgraph/datanodes/HttpDataNodeTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.service.modules.flowgraph.datanodes;
+
+import org.apache.gobblin.service.modules.flowgraph.DataNode;
+import org.apache.gobblin.service.modules.flowgraph.FlowGraphConfigurationKeys;
+import org.apache.gobblin.util.ConfigUtils;
+import org.junit.Assert;
+import org.testng.annotations.Test;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigValueFactory;
+
+import org.apache.gobblin.service.modules.flowgraph.DatasetDescriptorConfigKeys;
+
+public class HttpDataNodeTest {
+
+  @Test
+  public void testConfig() throws DataNode.DataNodeCreationException {
+    String expectedNodeId = "some-node-id";
+    String expectedHttpDomain = "https://a.b.c";
+    String expectedHttpAuthType = "oauth";
+
+    Config config = ConfigFactory.empty()
+        .withValue(FlowGraphConfigurationKeys.DATA_NODE_ID_KEY, ConfigValueFactory.fromAnyRef(expectedNodeId))
+        .withValue(FlowGraphConfigurationKeys.DATA_NODE_HTTP_DOMAIN_KEY, ConfigValueFactory.fromAnyRef(expectedHttpDomain))
+        .withValue(FlowGraphConfigurationKeys.DATA_NODE_HTTP_AUTHENTICATION_TYPE_KEY, ConfigValueFactory.fromAnyRef(expectedHttpAuthType));
+    HttpDataNode node = new HttpDataNode(config);
+
+    // Verify the node id
+    String id = node.getId();
+    Assert.assertTrue(id.equals(expectedNodeId));
+
+    Config rawConfig = node.getRawConfig();
+    String httpDomain = ConfigUtils.getString(rawConfig, FlowGraphConfigurationKeys.DATA_NODE_HTTP_DOMAIN_KEY, "");
+    String httpAuthType = ConfigUtils.getString(rawConfig, FlowGraphConfigurationKeys.DATA_NODE_HTTP_AUTHENTICATION_TYPE_KEY, "");
+    // Verify config saved to the node successfully
+    Assert.assertTrue(httpDomain.equals(expectedHttpDomain));
+    Assert.assertTrue(httpAuthType.equals(expectedHttpAuthType));
+
+  }
+}


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

@arjun4084346 @sv2000 @jack-moseley 

### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-946


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

Adding support for transmitting data from a http/https source. This is the first effort and minimum number of attributes were introduced.

A HttpDataNode will specify two attributes:

1. domain - This is the domain component of a http url
2. authentication type - This is the authentication protocol supported for a given domain

A HttpDatasetDescriptor will specify one attribute:

1. path - This is the full url of the data source's endpoint, e.g, https://a.b.c.com/api/dataset_abc

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Custom logics are covered by unit tests

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

