### PR TITLE
[GOBBLIN-933] add support for array of unions in json schema_new

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/converter/avro/JsonElementConversionWithAvroSchemaFactory.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/converter/avro/JsonElementConversionWithAvroSchemaFactory.java
@@ -307,8 +307,7 @@ public class JsonElementConversionWithAvroSchemaFactory extends JsonElementConve
 
     @Override
     public Schema schema() {
-      if(schemas.size() == 2 && isNullable())
-      {
+      if(schemas.size() == 2 && isNullable()) {
         if(schemas.get(0).getType() == Schema.Type.NULL) {
           return schemas.get(1);
         } else {

--- a/gobblin-core/src/main/java/org/apache/gobblin/converter/avro/JsonElementConversionWithAvroSchemaFactory.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/converter/avro/JsonElementConversionWithAvroSchemaFactory.java
@@ -19,14 +19,12 @@ package org.apache.gobblin.converter.avro;
 
 import com.sun.javafx.binding.StringFormatter;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
-import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.WorkUnitState;
 import org.apache.gobblin.converter.DataConversionException;
 
@@ -46,7 +44,7 @@ public class JsonElementConversionWithAvroSchemaFactory extends JsonElementConve
    * Use to create a converter for a single field from a schema.
    */
 
-  public static JsonElementConverter getConvertor(String fieldName, String fieldType, Schema schemaNode,
+  public static JsonElementConverter getConverter(String fieldName, String fieldType, Schema schemaNode,
       WorkUnitState state, boolean nullable, List<String> ignoreFields) throws UnsupportedDateTypeException {
 
     Type type;
@@ -88,7 +86,7 @@ public class JsonElementConversionWithAvroSchemaFactory extends JsonElementConve
         List<String> ignoreFields) throws UnsupportedDateTypeException {
       super(fieldName, nullable, sourceType);
       super.setElementConverter(
-          getConvertor(fieldName, schemaNode.getElementType().getType().getName(), schemaNode.getElementType(), state,
+          getConverter(fieldName, schemaNode.getElementType().getType().getName(), schemaNode.getElementType(), state,
               isNullable(), ignoreFields));
     }
 
@@ -122,7 +120,7 @@ public class JsonElementConversionWithAvroSchemaFactory extends JsonElementConve
         List<String> ignoreFields) throws UnsupportedDateTypeException {
       super(fieldName, nullable, sourceType);
       super.setElementConverter(
-          getConvertor(fieldName, schemaNode.getValueType().getType().getName(), schemaNode.getValueType(), state,
+          getConverter(fieldName, schemaNode.getValueType().getType().getName(), schemaNode.getValueType(), state,
               isNullable(), ignoreFields));
     }
 
@@ -222,8 +220,8 @@ public class JsonElementConversionWithAvroSchemaFactory extends JsonElementConve
    * A converter to convert Union type to avro
    * Here it will try all the possible converters for one type, for example, to convert an int value, it will try all Number converters
    * until meet the first workable one.
-   * So a known bug here is if there are long and double inside the union type, it's possible that all the value will be parse as long
-   * We're doing this since there is no way to determine what exact type it is for a JasonElement
+   * So a known bug here is there's no guarantee on preserving precision from Json to Avro type as the exact type information is clear from JsonElement
+   * We're doing this since there is no way to determine what exact type it is for a JsonElement
    */
   public static class UnionConverter extends ComplexConverter {
     private final List<Schema> schemas;
@@ -236,7 +234,7 @@ public class JsonElementConversionWithAvroSchemaFactory extends JsonElementConve
       this.schemas = schemaNode.getTypes();
       converters = new ArrayList<>();
       for(Schema schema: schemas) {
-        converters.add(getConvertor(fieldName, schema.getType().getName(), schemaNode, state, isNullable(), ignoreFields));
+        converters.add(getConverter(fieldName, schema.getType().getName(), schemaNode, state, isNullable(), ignoreFields));
       }
       this.schemaNode = schemaNode;
     }

--- a/gobblin-core/src/main/java/org/apache/gobblin/converter/avro/JsonRecordAvroSchemaToAvroConverter.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/converter/avro/JsonRecordAvroSchemaToAvroConverter.java
@@ -120,7 +120,7 @@ public class JsonRecordAvroSchemaToAvroConverter<SI> extends ToAvroConverterBase
         }
       } else {
         try {
-          converter = JsonElementConversionWithAvroSchemaFactory.getConvertor(field.name(), type.getName(), schema,
+          converter = JsonElementConversionWithAvroSchemaFactory.getConverter(field.name(), type.getName(), schema,
               workUnit, nullable, ignoreFields);
           avroRecord.put(field.name(), converter.convert(inputRecord.get(field.name())));
         } catch (Exception e) {

--- a/gobblin-core/src/test/java/org/apache/gobblin/converter/avro/JsonRecordAvroSchemaToAvroConverterTest.java
+++ b/gobblin-core/src/test/java/org/apache/gobblin/converter/avro/JsonRecordAvroSchemaToAvroConverterTest.java
@@ -85,5 +85,24 @@ public class JsonRecordAvroSchemaToAvroConverterTest {
     Assert.assertEquals(recordInArray.get("field1").toString(), "test1");
 
     Assert.assertEquals((record.get("enumField")).toString(), "ENUM2");
-  }
+
+    Assert.assertTrue(record.get("arrayFieldWithUnion") instanceof GenericArray);
+    GenericArray arrayWithUnion =  (GenericArray) record.get("arrayFieldWithUnion");
+    Assert.assertEquals(arrayWithUnion.size(), 4);
+    Assert.assertEquals(arrayWithUnion.get(0).toString(), "arrU1");
+    Assert.assertEquals(arrayWithUnion.get(1).toString(), "arrU2");
+    Assert.assertEquals(arrayWithUnion.get(2).toString(), "arrU3");
+    Assert.assertEquals(arrayWithUnion.get(3), 123L);
+
+    Assert.assertTrue(record.get("nullArrayFieldWithUnion") instanceof GenericArray);
+    GenericArray nullArrayWithUnion =  (GenericArray) record.get("nullArrayFieldWithUnion");
+    Assert.assertEquals(nullArrayWithUnion.size(), 1);
+    Assert.assertNull(nullArrayWithUnion.get(0));
+
+    Assert.assertTrue(record.get("arrayFieldWithUnion2") instanceof GenericArray);
+    GenericArray arrayWithUnion2 =  (GenericArray) record.get("arrayFieldWithUnion2");
+    Assert.assertEquals(arrayWithUnion2.size(), 3);
+    Assert.assertEquals(arrayWithUnion2.get(0).toString(), "arrU1");
+    Assert.assertNull(arrayWithUnion2.get(1));
+    Assert.assertEquals(arrayWithUnion2.get(2).toString(), "arrU3");  }
 }

--- a/gobblin-core/src/test/resources/converter/jsonToAvroRecord.json
+++ b/gobblin-core/src/test/resources/converter/jsonToAvroRecord.json
@@ -1,4 +1,8 @@
-{"nullableField": null,
+{
+  "arrayFieldWithUnion2": ["arrU1", null, "arrU3"],
+  "arrayFieldWithUnion": ["arrU1", "arrU2", "arrU3", 123],
+  "nullArrayFieldWithUnion": [null],
+  "nullableField": null,
   "longField": 1234,
   "arrayField": ["arr1", "arr2", "arr3"],
   "mapField": {

--- a/gobblin-core/src/test/resources/converter/jsonToAvroSchema.avsc
+++ b/gobblin-core/src/test/resources/converter/jsonToAvroSchema.avsc
@@ -23,6 +23,27 @@
       }
     },
     {
+      "name": "arrayFieldWithUnion",
+      "type": {
+        "type": "array",
+        "items": ["null","long","string"]
+      }
+    },
+    {
+      "name": "arrayFieldWithUnion2",
+      "type": {
+        "type": "array",
+        "items": ["string","null"]
+      }
+    },
+    {
+      "name": "nullArrayFieldWithUnion",
+      "type": {
+        "type": "array",
+        "items": ["null","string"]
+      }
+    },
+    {
       "name": "mapField",
       "type": {
         "type": "map",

--- a/gobblin-core/src/test/resources/converter/jsonToAvroSchema.avsc
+++ b/gobblin-core/src/test/resources/converter/jsonToAvroSchema.avsc
@@ -26,7 +26,7 @@
       "name": "arrayFieldWithUnion",
       "type": {
         "type": "array",
-        "items": ["null","long","string"]
+        "items": ["null","string","long"]
       }
     },
     {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-933


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
It handles unions inside an array.
But we have a known bug here, if the type in union contains String and other types like int, etc, then it's possible that all the value even int value will be parse as String.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Unit test

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

