### PR TITLE
[GOBBLIN-959] add missing junit dependency for gobblin-http

### DIFF
--- a/gobblin-modules/gobblin-http/build.gradle
+++ b/gobblin-modules/gobblin-http/build.gradle
@@ -44,6 +44,7 @@ dependencies {
   testCompile externalDependency.curatorClient
   testCompile externalDependency.curatorTest
   testCompile externalDependency.testng
+  testCompile externalDependency.junit
   testCompile externalDependency.mockito
 }
 


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-959


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
missing the junit dependency in gradle file

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: compilation bugfix


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

