### PR TITLE
[GOBBLIN-961]Bypass locked directories when calculating src watermark

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/converter/avro/JsonElementConversionWithAvroSchemaFactory.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/converter/avro/JsonElementConversionWithAvroSchemaFactory.java
@@ -19,7 +19,6 @@ package org.apache.gobblin.converter.avro;
 
 import com.sun.javafx.binding.StringFormatter;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/gobblin-core/src/main/java/org/apache/gobblin/converter/avro/JsonElementConversionWithAvroSchemaFactory.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/converter/avro/JsonElementConversionWithAvroSchemaFactory.java
@@ -19,6 +19,7 @@ package org.apache.gobblin.converter.avro;
 
 import com.sun.javafx.binding.StringFormatter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/replication/SourceHadoopFsEndPoint.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/replication/SourceHadoopFsEndPoint.java
@@ -17,7 +17,6 @@
 
 package org.apache.gobblin.data.management.copy.replication;
 
-import com.sun.javafx.binding.StringFormatter;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
@@ -79,7 +78,7 @@ public class SourceHadoopFsEndPoint extends HadoopFsEndPoint {
         try {
           this.allFileStatus.addAll(FileListUtils.listFilesRecursively(fs, p, super.getPathFilter(), super.isApplyFilterToDirectories()));
         } catch (Exception e) {
-          log.error(StringFormatter.format("Error while try read file in directory %s to get watermark", p.toString()).toString());
+          log.error(String.format("Error while try read file in directory %s to get watermark", p.toString()));
         }
       }
 

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/replication/SourceHadoopFsEndPoint.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/replication/SourceHadoopFsEndPoint.java
@@ -75,8 +75,11 @@ public class SourceHadoopFsEndPoint extends HadoopFsEndPoint {
 
       Collection<Path> validPaths = ReplicationDataValidPathPicker.getValidPaths(this);
       for (Path p : validPaths) {
-        this.allFileStatus.addAll(
-            FileListUtils.listFilesRecursively(fs, p, super.getPathFilter(), super.isApplyFilterToDirectories()));
+        try {
+          this.allFileStatus.addAll(FileListUtils.listFilesRecursively(fs, p, super.getPathFilter(), super.isApplyFilterToDirectories()));
+        } catch (Exception e) {
+          log.error("Error while try read file in directory" + p.toString() +" to get watermark");
+        }
       }
 
       for (FileStatus f : this.allFileStatus) {

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/replication/SourceHadoopFsEndPoint.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/replication/SourceHadoopFsEndPoint.java
@@ -17,6 +17,7 @@
 
 package org.apache.gobblin.data.management.copy.replication;
 
+import com.sun.javafx.binding.StringFormatter;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
@@ -78,7 +79,7 @@ public class SourceHadoopFsEndPoint extends HadoopFsEndPoint {
         try {
           this.allFileStatus.addAll(FileListUtils.listFilesRecursively(fs, p, super.getPathFilter(), super.isApplyFilterToDirectories()));
         } catch (Exception e) {
-          log.error("Error while try read file in directory" + p.toString() +" to get watermark");
+          log.error(StringFormatter.format("Error while try read file in directory %s to get watermark", p.toString()).toString());
         }
       }
 


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-961


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Background:
 Found the issue where there are locking directory in place, which gobblin failed to scan through list of files (source) to copy, and the watermark retrieve as NAN.
Therefore, data is not able to copy successfully and possibly causing the delay
Solution:
Simple change to bypass locked partitions when calculating src watermark

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Test on azkaban to make sure when there is locked partition, it can bypass that partition and do copy

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

