### PR TITLE
GOBBLIN-966: Check if no partitions have been processed by KafkaExtra…

### DIFF
--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaExtractor.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaExtractor.java
@@ -303,7 +303,7 @@ public abstract class KafkaExtractor<S, D> extends EventBasedExtractor<S, D> {
 
   @Override
   public void close() throws IOException {
-    if (!allPartitionsFinished()) {
+    if (!allPartitionsFinished() && currentPartitionIdx != INITIAL_PARTITION_IDX) {
       this.statsTracker.updateStatisticsForCurrentPartition(currentPartitionIdx, readStartTime, getLastSuccessfulRecordHeaderTimestamp());
     }
     // Add error partition count and error message count to workUnitState


### PR DESCRIPTION
…ctor in close() method to avoid ArrayIndexOutOfBoundsException

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-966


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
When no partitions are processed by KafkaExtractor, the currentPartitionIndex remains at -1. Calling the KafkaExtractorStatsTracker#updateStatisticsForCurrentPartition() method, with a partition index of -1 causes ArrayIndexOutofBoundsException.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Trivial.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

