### PR TITLE
[GOBBLIN-968] Honor file split size for HadoopFileInputSource

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/hadoop/HadoopFileInputSource.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/hadoop/HadoopFileInputSource.java
@@ -78,6 +78,8 @@ public abstract class HadoopFileInputSource<S, D, K, V> extends AbstractSource<S
   public static final String FILE_SPLITS_DESIRED_KEY = HADOOP_SOURCE_KEY_PREFIX + "file.splits.desired";
   public static final int DEFAULT_FILE_SPLITS_DESIRED = 1;
   public static final String FILE_INPUT_PATHS_KEY = HADOOP_SOURCE_KEY_PREFIX + "file.input.paths";
+  public static final String FILE_INPUT_SPLIT_MINSIZE = HADOOP_SOURCE_KEY_PREFIX + "file.input.split.minsize";
+  public static final String FILE_INPUT_SPLIT_MAXSIZE = HADOOP_SOURCE_KEY_PREFIX + "file.input.split.maxsize";
   public static final String FILE_INPUT_READ_KEYS_KEY = HADOOP_SOURCE_KEY_PREFIX + "file.read.keys";
   public static final boolean DEFAULT_FILE_INPUT_READ_KEYS = false;
   public static final String FILE_SPLIT_PATH_KEY = HADOOP_SOURCE_KEY_PREFIX + "file.split.path";
@@ -92,6 +94,14 @@ public abstract class HadoopFileInputSource<S, D, K, V> extends AbstractSource<S
         for (String inputPath : state.getPropAsList(FILE_INPUT_PATHS_KEY)) {
           FileInputFormat.addInputPath(job, new Path(inputPath));
         }
+      }
+
+      if (state.contains(FILE_INPUT_SPLIT_MINSIZE)) {
+        FileInputFormat.setMinInputSplitSize(job, state.getPropAsLong(FILE_INPUT_SPLIT_MINSIZE));
+      }
+
+      if (state.contains(FILE_INPUT_SPLIT_MAXSIZE)) {
+        FileInputFormat.setMaxInputSplitSize(job, state.getPropAsLong(FILE_INPUT_SPLIT_MAXSIZE));
       }
 
       FileInputFormat<K, V> fileInputFormat = getFileInputFormat(state, job.getConfiguration());


### PR DESCRIPTION
Set the value of SPLIT_MAXSIZE and SPLIT_MINSIZE in FileInputFormat
class from the configs (source.hadoop.file.input.split.minsize and
source.hadoop.file.input.split.maxsize) passed from .pull file.

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-968


### Description
- [x] Here are some details about my PR, including screenshots (if applicable): NA


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: It is passing configs from .pull to set properties in 'Job' object, no separate unit test case needed. 


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

