### PR TITLE
[GOBBLIN-964] Add the enum JOB_SUCCEEDED to org.apache.gobblin.metrics.event.EventName

### DIFF
--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/EventName.java
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/EventName.java
@@ -34,6 +34,7 @@ public enum EventName {
   JOB_CLEANUP("JobCleanupTimer"),
   JOB_CANCEL("JobCancelTimer"),
   JOB_COMPLETE("JobCompleteTimer"),
+  JOB_SUCCEEDED("JobSucceededTimer"),
   JOB_FAILED("JobFailedTimer"),
   MR_STAGING_DATA_CLEAN("JobMrStagingDataCleanTimer"),
   UNKNOWN("Unknown");


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-964]] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-964


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
In the notifyListeners method of AbstractJobLauncher, it is unable to convert the TimingEvent.LauncherTimings.JOB_SUCCEEDED successfully into a valid EventName with this line below

EventName.getEnumFromEventId(timerEventName)
We miss an enum for JobSucceededTimer in org.apache.gobblin.metrics.event.EventName 

Without this enum, EventMetadataGenerator cannot work correctly to generate additionalMetadata for the event

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

