### PR TITLE
[GOBBLIN-963] Remove duplicated copies of TaskContext/TaskState when constructing TaskIFaceWrapper

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/GobblinMultiTaskAttempt.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/GobblinMultiTaskAttempt.java
@@ -38,6 +38,9 @@ import com.google.common.base.Optional;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 
+import javax.annotation.Nullable;
+import lombok.Setter;
+
 import org.apache.gobblin.annotation.Alpha;
 import org.apache.gobblin.broker.gobblin_scopes.GobblinScopeTypes;
 import org.apache.gobblin.broker.gobblin_scopes.TaskScopeInstance;
@@ -60,9 +63,6 @@ import org.apache.gobblin.util.Either;
 import org.apache.gobblin.util.ExecutorsUtils;
 import org.apache.gobblin.util.executors.IteratorExecutor;
 
-import javax.annotation.Nullable;
-import lombok.Setter;
-
 
 /**
  * Attempt of running multiple {@link Task}s generated from a list of{@link WorkUnit}s.
@@ -78,8 +78,7 @@ public class GobblinMultiTaskAttempt {
     /**
      * Commit {@link GobblinMultiTaskAttempt} immediately after running is done.
      */
-    IMMEDIATE,
-    /**
+    IMMEDIATE, /**
      * Not committing {@link GobblinMultiTaskAttempt} but leaving it to user customized launcher.
      */
     CUSTOMIZED
@@ -129,7 +128,8 @@ public class GobblinMultiTaskAttempt {
    * @throws IOException
    * @throws InterruptedException
    */
-  public void run() throws IOException, InterruptedException {
+  public void run()
+      throws IOException, InterruptedException {
     if (!this.workUnits.hasNext()) {
       log.warn("No work units to run in container " + containerIdOptional.or(""));
       return;
@@ -158,7 +158,8 @@ public class GobblinMultiTaskAttempt {
     log.info("All assigned tasks of job {} have completed in container {}", jobId, containerIdOptional.or(""));
   }
 
-  private void interruptTaskExecution(CountDownLatch countDownLatch) throws InterruptedException {
+  private void interruptTaskExecution(CountDownLatch countDownLatch)
+      throws InterruptedException {
     log.info("Job interrupted. Attempting a graceful shutdown of the job.");
     this.tasks.forEach(Task::shutdown);
     if (!countDownLatch.await(5, TimeUnit.SECONDS)) {
@@ -176,7 +177,8 @@ public class GobblinMultiTaskAttempt {
    * 3. persist task statestore.
    * @throws IOException
    */
-  public void commit() throws IOException {
+  public void commit()
+      throws IOException {
     if (this.tasks == null || this.tasks.isEmpty()) {
       log.warn("No tasks to be committed in container " + containerIdOptional.or(""));
       return;
@@ -188,7 +190,8 @@ public class GobblinMultiTaskAttempt {
             return new Callable<Void>() {
               @Nullable
               @Override
-              public Void call() throws Exception {
+              public Void call()
+                  throws Exception {
                 task.commit();
                 return null;
               }
@@ -199,8 +202,8 @@ public class GobblinMultiTaskAttempt {
     try {
       List<Either<Void, ExecutionException>> executionResults =
           new IteratorExecutor<>(callableIterator, this.getTaskCommitThreadPoolSize(),
-              ExecutorsUtils.newDaemonThreadFactory(Optional.of(log),
-                  Optional.of("Task-committing-pool-%d"))).executeAndGetResults();
+              ExecutorsUtils.newDaemonThreadFactory(Optional.of(log), Optional.of("Task-committing-pool-%d")))
+              .executeAndGetResults();
       IteratorExecutor.logFailures(executionResults, log, 10);
     } catch (InterruptedException ie) {
       log.error("Committing of tasks interrupted. Aborting.");
@@ -220,7 +223,8 @@ public class GobblinMultiTaskAttempt {
    * A method that shuts down all running tasks managed by this instance.
    * TODO: Call this from the right place.
    */
-  public void shutdownTasks() throws InterruptedException {
+  public void shutdownTasks()
+      throws InterruptedException {
     log.info("Shutting down tasks");
     for (Task task : this.tasks) {
       task.shutdown();
@@ -239,7 +243,8 @@ public class GobblinMultiTaskAttempt {
     }
   }
 
-  private void persistTaskStateStore() throws IOException {
+  private void persistTaskStateStore()
+      throws IOException {
     if (!this.taskStateStoreOptional.isPresent()) {
       log.info("Task state store does not exist.");
       return;
@@ -277,8 +282,8 @@ public class GobblinMultiTaskAttempt {
         // to filter out successful tasks on subsequent attempts.
         if (task.getTaskState().getWorkingState() == WorkUnitState.WorkingState.SUCCESSFUL
             || task.getTaskState().getWorkingState() == WorkUnitState.WorkingState.COMMITTED) {
-          taskStateStore.put(task.getJobId(), task.getTaskId() + TASK_STATE_STORE_SUCCESS_MARKER_SUFFIX,
-              task.getTaskState());
+          taskStateStore
+              .put(task.getJobId(), task.getTaskId() + TASK_STATE_STORE_SUCCESS_MARKER_SUFFIX, task.getTaskState());
         }
       }
 
@@ -421,8 +426,8 @@ public class GobblinMultiTaskAttempt {
 
     this.log.info("Heap Memory");
     this.log.info(String.format(format, "init", "used", "Committed", "max"));
-    this.log.info(String.format(format, heapMemory.getInit(), heapMemory.getUsed(), heapMemory.getCommitted(),
-        heapMemory.getMax()));
+    this.log.info(String
+        .format(format, heapMemory.getInit(), heapMemory.getUsed(), heapMemory.getCommitted(), heapMemory.getMax()));
 
     this.log.info("Non-heap Memory");
     this.log.info(String.format(format, "init", "used", "Committed", "max"));
@@ -432,12 +437,12 @@ public class GobblinMultiTaskAttempt {
 
   private Task createTaskRunnable(WorkUnitState workUnitState, CountDownLatch countDownLatch) {
     Optional<TaskFactory> taskFactoryOpt = TaskUtils.getTaskFactory(workUnitState);
+    final TaskContext taskContext = new TaskContext(workUnitState);
     if (taskFactoryOpt.isPresent()) {
-      return new TaskIFaceWrapper(taskFactoryOpt.get().createTask(new TaskContext(workUnitState)),
-          new TaskContext(workUnitState), countDownLatch, this.taskStateTracker);
+      return new TaskIFaceWrapper(taskFactoryOpt.get().createTask(taskContext), taskContext, countDownLatch,
+          this.taskStateTracker);
     } else {
-      return new Task(new TaskContext(workUnitState), this.taskStateTracker, this.taskExecutor,
-          Optional.of(countDownLatch));
+      return new Task(taskContext, this.taskStateTracker, this.taskExecutor, Optional.of(countDownLatch));
     }
   }
 

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/GobblinMultiTaskAttempt.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/GobblinMultiTaskAttempt.java
@@ -78,7 +78,9 @@ public class GobblinMultiTaskAttempt {
     /**
      * Commit {@link GobblinMultiTaskAttempt} immediately after running is done.
      */
-    IMMEDIATE, /**
+    IMMEDIATE,
+
+    /**
      * Not committing {@link GobblinMultiTaskAttempt} but leaving it to user customized launcher.
      */
     CUSTOMIZED


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-963] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-963


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
Currently in GobblinMultiTaskAttempt, when we call createTaskRunnable, we rely on a TaskFactory to create a task and return a wrapper for that task. However, when we create the wrapper, we initialized the TaskContext twice. 

For the task creation
For the task wrapper creation
These two TaskContexts, which generate two copies of TaskState, will cause inconsistency in the following operation. The task state update within the task won't be reflected in TaskWrapper.

 

Specifically, this is the buggy line of code
```java
return new TaskIFaceWrapper(taskFactoryOpt.get().createTask(new TaskContext(workUnitState)),
 new TaskContext(workUnitState), countDownLatch, this.taskStateTracker);
```
Ideally, we should create the TaskContext once, and reuse the same TaskContext.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

