### PR TITLE
[GOBBLIN-971]Enable speculative execution awareness for RowQualityChecker

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/qualitychecker/row/RowLevelPolicyChecker.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/qualitychecker/row/RowLevelPolicyChecker.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.apache.gobblin.commit.SpeculativeAttemptAwareConstruct;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
@@ -45,7 +46,17 @@ import javax.annotation.concurrent.ThreadSafe;
 import lombok.Getter;
 
 
-public class RowLevelPolicyChecker<S, D> implements Closeable, FinalState, RecordStreamProcessor<S, S, D, D> {
+public class RowLevelPolicyChecker<S, D> implements Closeable, FinalState, RecordStreamProcessor<S, S, D, D>,
+                                                    SpeculativeAttemptAwareConstruct {
+
+  /**
+   * Given the existence of writer object when the policy is set to {@link RowLevelPolicy.Type#ERR_FILE}, objects of
+   * this class needs to be speculative-attempt-aware.
+   */
+  @Override
+  public boolean isSpeculativeAttemptSafe() {
+    return !this.list.stream().allMatch(x -> x.getType().equals(RowLevelPolicy.Type.ERR_FILE)) || this.allowSpeculativeExecWhenWriteErrFile;
+  }
 
   private final List<RowLevelPolicy> list;
   private final String stateId;
@@ -56,6 +67,17 @@ public class RowLevelPolicyChecker<S, D> implements Closeable, FinalState, Recor
   private RowLevelErrFileWriter writer;
   @Getter
   private final RowLevelPolicyCheckResults results;
+  /** Flag to determine if it is safe to enable speculative execution when policy is set to ERR_FILE
+   * Users are suggested to turn this off since it could potentially run into HDFS file lease contention if multiple
+   * speculative execution are appending to the same ERR_FILE.
+   *
+   * When there are ERR_FILE policy appears and users are enforcing to set it to true, RowPolicyChecker will created
+   * different ERR_FILE with timestamp in name to avoid contention but there's no guarantee as
+   * different containers' clock is hard to coordinate.
+   * */
+  private boolean allowSpeculativeExecWhenWriteErrFile;
+
+  private static final String ALLOW_SPECULATIVE_EXECUTION_WITH_ERR_FILE_POLICY = "allowSpeculativeExecutionWithErrFilePolicy";
 
   public RowLevelPolicyChecker(List<RowLevelPolicy> list, String stateId, FileSystem fs) {
     this(list, stateId, fs, new State());
@@ -71,6 +93,9 @@ public class RowLevelPolicyChecker<S, D> implements Closeable, FinalState, Recor
     this.results = new RowLevelPolicyCheckResults();
     this.sampler = new FrontLoadedSampler(state.getPropAsLong(ConfigurationKeys.ROW_LEVEL_ERR_FILE_RECORDS_PER_TASK,
         ConfigurationKeys.DEFAULT_ROW_LEVEL_ERR_FILE_RECORDS_PER_TASK), 1.5);
+
+    /** By default set to true as to maintain backward-compatibility */
+    this.allowSpeculativeExecWhenWriteErrFile = state.getPropAsBoolean(ALLOW_SPECULATIVE_EXECUTION_WITH_ERR_FILE_POLICY, true);
   }
 
   public boolean executePolicies(Object record, RowLevelPolicyCheckResults results) throws IOException {
@@ -98,11 +123,15 @@ public class RowLevelPolicyChecker<S, D> implements Closeable, FinalState, Recor
     return true;
   }
 
-  private Path getErrFilePath(RowLevelPolicy policy) {
+  Path getErrFilePath(RowLevelPolicy policy) {
     String errFileName = HadoopUtils.sanitizePath(policy.toString(), "-");
     if (!Strings.isNullOrEmpty(this.stateId)) {
       errFileName += "-" + this.stateId;
     }
+    if (allowSpeculativeExecWhenWriteErrFile) {
+      errFileName += "-" + System.currentTimeMillis();
+    }
+
     errFileName += ".err";
     return new Path(policy.getErrFileLocation(), errFileName);
   }

--- a/gobblin-core/src/main/java/org/apache/gobblin/qualitychecker/row/RowLevelPolicyChecker.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/qualitychecker/row/RowLevelPolicyChecker.java
@@ -55,7 +55,7 @@ public class RowLevelPolicyChecker<S, D> implements Closeable, FinalState, Recor
    */
   @Override
   public boolean isSpeculativeAttemptSafe() {
-    return !this.list.stream().allMatch(x -> x.getType().equals(RowLevelPolicy.Type.ERR_FILE)) || this.allowSpeculativeExecWhenWriteErrFile;
+    return this.list.stream().noneMatch(x -> x.getType().equals(RowLevelPolicy.Type.ERR_FILE)) || this.allowSpeculativeExecWhenWriteErrFile;
   }
 
   private final List<RowLevelPolicy> list;

--- a/gobblin-core/src/main/java/org/apache/gobblin/qualitychecker/row/RowLevelPolicyChecker.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/qualitychecker/row/RowLevelPolicyChecker.java
@@ -77,7 +77,7 @@ public class RowLevelPolicyChecker<S, D> implements Closeable, FinalState, Recor
    * */
   private boolean allowSpeculativeExecWhenWriteErrFile;
 
-  private static final String ALLOW_SPECULATIVE_EXECUTION_WITH_ERR_FILE_POLICY = "allowSpeculativeExecutionWithErrFilePolicy";
+  static final String ALLOW_SPECULATIVE_EXECUTION_WITH_ERR_FILE_POLICY = "allowSpeculativeExecutionWithErrFilePolicy";
 
   public RowLevelPolicyChecker(List<RowLevelPolicy> list, String stateId, FileSystem fs) {
     this(list, stateId, fs, new State());

--- a/gobblin-core/src/test/java/org/apache/gobblin/qualitychecker/row/RowLevelQualityCheckerTest.java
+++ b/gobblin-core/src/test/java/org/apache/gobblin/qualitychecker/row/RowLevelQualityCheckerTest.java
@@ -15,15 +15,16 @@
  * limitations under the License.
  */
 
-package org.apache.gobblin.qualitychecker;
+package org.apache.gobblin.qualitychecker.row;
 
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.State;
-import org.apache.gobblin.qualitychecker.row.RowLevelPolicyCheckResults;
-import org.apache.gobblin.qualitychecker.row.RowLevelPolicyChecker;
-import org.apache.gobblin.qualitychecker.row.RowLevelPolicyCheckerBuilderFactory;
+import org.apache.gobblin.qualitychecker.TestConstants;
+import org.apache.gobblin.qualitychecker.TestRowLevelPolicy;
 import java.io.File;
 import java.net.URI;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.apache.avro.file.DataFileReader;
 import org.apache.avro.file.FileReader;
@@ -55,6 +56,20 @@ public class RowLevelQualityCheckerTest {
     for (GenericRecord datum : fileReader) {
       Assert.assertTrue(checker.executePolicies(datum, results));
     }
+  }
+
+  public void testFileNameWithTimestamp() throws Exception {
+    State state = new State();
+    state.setProp(ConfigurationKeys.ROW_LEVEL_POLICY_LIST_TYPE, "ERR_FILE");
+    state.setProp(ConfigurationKeys.ROW_LEVEL_ERR_FILE, TestConstants.TEST_ERR_FILE);
+    RowLevelPolicyChecker checker =
+        new RowLevelPolicyCheckerBuilderFactory().newPolicyCheckerBuilder(state, -1).build();
+    Path path = checker.getErrFilePath(new TestRowLevelPolicy(state, RowLevelPolicy.Type.ERR_FILE));
+
+    // Verify that path follows the structure which contains timestamp.
+    Pattern pattern = Pattern.compile("test\\/org.apache.gobblin.qualitychecker.TestRowLevelPolicy-\\d+\\.err");
+    Matcher matcher = pattern.matcher(path.toString());
+    Assert.assertTrue(matcher.matches());
   }
 
   @Test(groups = {"ignore"})

--- a/gobblin-core/src/test/java/org/apache/gobblin/qualitychecker/row/RowLevelQualityCheckerTest.java
+++ b/gobblin-core/src/test/java/org/apache/gobblin/qualitychecker/row/RowLevelQualityCheckerTest.java
@@ -37,6 +37,8 @@ import org.apache.hadoop.fs.Path;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import static org.apache.gobblin.qualitychecker.row.RowLevelPolicyChecker.ALLOW_SPECULATIVE_EXECUTION_WITH_ERR_FILE_POLICY;
+
 
 @Test(groups = {"gobblin.qualitychecker"})
 public class RowLevelQualityCheckerTest {
@@ -70,6 +72,13 @@ public class RowLevelQualityCheckerTest {
     Pattern pattern = Pattern.compile("test\\/org.apache.gobblin.qualitychecker.TestRowLevelPolicy-\\d+\\.err");
     Matcher matcher = pattern.matcher(path.toString());
     Assert.assertTrue(matcher.matches());
+
+    // Negative case
+    state.setProp(ConfigurationKeys.ROW_LEVEL_POLICY_LIST_TYPE, "FAIL");
+    state.setProp(ALLOW_SPECULATIVE_EXECUTION_WITH_ERR_FILE_POLICY, false);
+    checker =
+        new RowLevelPolicyCheckerBuilderFactory().newPolicyCheckerBuilder(state, -1).build();
+    Assert.assertFalse(checker.isSpeculativeAttemptSafe());
   }
 
   @Test(groups = {"ignore"})

--- a/gobblin-core/src/test/java/org/apache/gobblin/qualitychecker/row/RowLevelQualityCheckerTest.java
+++ b/gobblin-core/src/test/java/org/apache/gobblin/qualitychecker/row/RowLevelQualityCheckerTest.java
@@ -62,6 +62,7 @@ public class RowLevelQualityCheckerTest {
 
   public void testFileNameWithTimestamp() throws Exception {
     State state = new State();
+    state.setProp(ConfigurationKeys.ROW_LEVEL_POLICY_LIST, "org.apache.gobblin.qualitychecker.TestRowLevelPolicy");
     state.setProp(ConfigurationKeys.ROW_LEVEL_POLICY_LIST_TYPE, "ERR_FILE");
     state.setProp(ConfigurationKeys.ROW_LEVEL_ERR_FILE, TestConstants.TEST_ERR_FILE);
     RowLevelPolicyChecker checker =
@@ -73,9 +74,16 @@ public class RowLevelQualityCheckerTest {
     Matcher matcher = pattern.matcher(path.toString());
     Assert.assertTrue(matcher.matches());
 
-    // Negative case
-    state.setProp(ConfigurationKeys.ROW_LEVEL_POLICY_LIST_TYPE, "FAIL");
+    // Positive case with multiple non-err_file policy specified.
+    state.setProp(ConfigurationKeys.ROW_LEVEL_POLICY_LIST, "org.apache.gobblin.qualitychecker.TestRowLevelPolicy,org.apache.gobblin.qualitychecker.TestRowLevelPolicy");
+    state.setProp(ConfigurationKeys.ROW_LEVEL_POLICY_LIST_TYPE, "FAIL,OPTIONAL");
     state.setProp(ALLOW_SPECULATIVE_EXECUTION_WITH_ERR_FILE_POLICY, false);
+    checker =
+        new RowLevelPolicyCheckerBuilderFactory().newPolicyCheckerBuilder(state, -1).build();
+    Assert.assertTrue(checker.isSpeculativeAttemptSafe());
+
+    // Negative case with multiple policy containing err_file
+    state.setProp(ConfigurationKeys.ROW_LEVEL_POLICY_LIST_TYPE, "FAIL,ERR_FILE");
     checker =
         new RowLevelPolicyCheckerBuilderFactory().newPolicyCheckerBuilder(state, -1).build();
     Assert.assertFalse(checker.isSpeculativeAttemptSafe());


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] https://issues.apache.org/jira/browse/GOBBLIN-971


### Description
- [x] 
Problem: 
When speculative execution is enabled with ERR_FILE set as the policy when encountering records that failed rowPolicy, we will run into HDFS file lease contention since the file name are only depends on `state.getId()`. 

Solution: To maintain backward-compatibility we allow speculative-execution to happen by default, but whenever the policy is set to `ERR_FILE` , we created different file name for speculative execution. This won't guarantee contention-free as different execution environment could coincidentally give identical timestamp, but the chances are pretty low. 

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

