### PR TITLE
[GOBBLIN-974] Avoid updating job/flow status if messages arrive out of order

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaJobStatusMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaJobStatusMonitor.java
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeUnit;
 import com.google.common.base.Charsets;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
@@ -73,6 +74,10 @@ public abstract class KafkaJobStatusMonitor extends HighLevelConsumer<byte[], by
   private final ScheduledExecutorService scheduledExecutorService;
   private static final Config DEFAULTS = ConfigFactory.parseMap(ImmutableMap.of(
       KAFKA_AUTO_OFFSET_RESET_KEY, KAFKA_AUTO_OFFSET_RESET_SMALLEST));
+
+  private static final List<ExecutionStatus> ORDERED_EXECUTION_STATUSES = ImmutableList
+      .of(ExecutionStatus.COMPILED, ExecutionStatus.PENDING, ExecutionStatus.ORCHESTRATED, ExecutionStatus.RUNNING,
+          ExecutionStatus.COMPLETE, ExecutionStatus.FAILED, ExecutionStatus.CANCELLED);
 
   public KafkaJobStatusMonitor(String topic, Config config, int numThreads)
       throws ReflectiveOperationException {
@@ -145,6 +150,19 @@ public abstract class KafkaJobStatusMonitor extends HighLevelConsumer<byte[], by
     String jobGroup = jobStatus.getProp(TimingEvent.FlowEventConstants.JOB_GROUP_FIELD);
     String storeName = jobStatusStoreName(flowGroup, flowName);
     String tableName = jobStatusTableName(flowExecutionId, jobGroup, jobName);
+
+    List<org.apache.gobblin.configuration.State> states = stateStore.getAll(storeName, tableName);
+    if (states.size() > 0) {
+      String previousStatus = states.get(states.size() - 1).getProp(JobStatusRetriever.EVENT_NAME_FIELD);
+      String currentStatus = jobStatus.getProp(JobStatusRetriever.EVENT_NAME_FIELD);
+
+      if (previousStatus != null && currentStatus != null && ORDERED_EXECUTION_STATUSES.indexOf(ExecutionStatus.valueOf(currentStatus))
+          < ORDERED_EXECUTION_STATUSES.indexOf(ExecutionStatus.valueOf(previousStatus))) {
+        log.warn(String.format("Received status %s when status is already %s for flow (%s, %s, %s), job (%s, %s)",
+            currentStatus, previousStatus, flowGroup, flowName, flowExecutionId, jobGroup, jobName));
+        return;
+      }
+    }
 
     jobStatus = mergedProperties(storeName, tableName, jobStatus, stateStore);
 

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaJobStatusMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaJobStatusMonitor.java
@@ -164,7 +164,7 @@ public abstract class KafkaJobStatusMonitor extends HighLevelConsumer<byte[], by
       }
     }
 
-    jobStatus = mergedProperties(storeName, tableName, jobStatus, stateStore);
+    jobStatus = mergedProperties(jobStatus, states);
 
     modifyStateIfRetryRequired(jobStatus);
 
@@ -181,17 +181,12 @@ public abstract class KafkaJobStatusMonitor extends HighLevelConsumer<byte[], by
     }
   }
 
-  private static org.apache.gobblin.configuration.State mergedProperties(
-      String storeName, String tableName, org.apache.gobblin.configuration.State jobStatus, StateStore stateStore) {
+  private static org.apache.gobblin.configuration.State mergedProperties(org.apache.gobblin.configuration.State jobStatus,
+      List<org.apache.gobblin.configuration.State> states) {
     Properties mergedProperties = new Properties();
 
-    try {
-      List<org.apache.gobblin.configuration.State> states = stateStore.getAll(storeName, tableName);
-      if (states.size() > 0) {
-        mergedProperties.putAll(states.get(states.size() - 1).getProperties());
-      }
-    } catch (Exception e) {
-      log.warn("Could not get previous state for {} {}", storeName, tableName, e);
+    if (states.size() > 0) {
+      mergedProperties.putAll(states.get(states.size() - 1).getProperties());
     }
     mergedProperties.putAll(jobStatus.getProperties());
 

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/KafkaAvroJobStatusMonitorTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/KafkaAvroJobStatusMonitorTest.java
@@ -106,6 +106,10 @@ public class KafkaAvroJobStatusMonitorTest {
     context.submitEvent(event5);
     kafkaReporter.report();
 
+    GobblinTrackingEvent event6 = createJobStartEvent();
+    context.submitEvent(event6);
+    kafkaReporter.report();
+
     try {
       Thread.sleep(1000);
     } catch(InterruptedException ex) {
@@ -159,6 +163,15 @@ public class KafkaAvroJobStatusMonitorTest {
 
     messageAndMetadata = iterator.next();
     Assert.assertNull(jobStatusMonitor.parseJobStatus(messageAndMetadata.message()));
+
+    // Check that state didn't get set to running since it was already complete
+    messageAndMetadata = iterator.next();
+    jobStatusMonitor.processMessage(messageAndMetadata);
+
+    stateList  = stateStore.getAll(storeName, tableName);
+    Assert.assertEquals(stateList.size(), 1);
+    state = stateList.get(0);
+    Assert.assertEquals(state.getProp(JobStatusRetriever.EVENT_NAME_FIELD), ExecutionStatus.COMPLETE.name());
   }
 
   private GobblinTrackingEvent createFlowCompiledEvent() {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-974


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

Define an order that `ExecutionStatus` are allowed to be updated for a job/flow so that if messages arrive out of order the job/flow status is not set to an incorrect value.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Updated unit test

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

