### PR TITLE
[GOBBLIN-980] Fix AzkabanClient always throwing exception when cancelling flow

### DIFF
--- a/gobblin-modules/gobblin-azkaban/src/main/java/org/apache/gobblin/service/modules/orchestration/AzkabanClient.java
+++ b/gobblin-modules/gobblin-azkaban/src/main/java/org/apache/gobblin/service/modules/orchestration/AzkabanClient.java
@@ -425,8 +425,10 @@ public class AzkabanClient implements Closeable {
   private <T> T runWithRetry(Callable callable, Class<T> cls) throws AzkabanClientException {
     try {
       AzkabanClientStatus status = this.retryer.call(callable);
-      if (status.getClass().equals(cls)) {
+      if (cls.isAssignableFrom(status.getClass())) {
         return ((T)status);
+      } else {
+        throw new AzkabanClientException(String.format("Unexpected response type, expected: %s actual: %s", cls, status.getClass()));
       }
     } catch (ExecutionException e) {
       Throwables.propagateIfPossible(e.getCause(), AzkabanClientException.class);


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-980


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

`CancelFlowCallable` returns an `AzkabanSuccess`, which fails the equals check, causing it to throw an exception even though cancel was successful. This changes it to instead use `isAssignableFrom` to allow subclasses as well. 

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Trivial change

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

