### PR TITLE
[Gobblin-982] Fix JDBC extraction dependencies issue

### DIFF
--- a/bin/gobblin.sh
+++ b/bin/gobblin.sh
@@ -346,12 +346,16 @@ function get_gobblin_mapreduce_libs() {
         mysql-connector-java-*.jar
         avro-*.jar
         commons-lang3-*.jar
+        commons-dbcp-*.jar
+        commons-pool-*.jar
         config-*.jar
+        calcite-core-*.jar
         data-*.jar
         gson-*.jar
         guava-*.jar
         joda-time-*.jar
         javassist-*.jar
+        jasypt-*.jar
         kafka_2.11-*.jar
         kafka-clients-0.8.2.2.jar
         metrics-core-*.jar

--- a/gobblin-distribution/build.gradle
+++ b/gobblin-distribution/build.gradle
@@ -47,6 +47,8 @@ dependencies {
   compile project(':gobblin-aws')
   compile project(':gobblin-service')
   compile project(':gobblin-runtime-hadoop')
+
+  runtime project(':gobblin-modules:gobblin-sql')
 }
 
 apply from: "${rootProject.rootDir}/gobblin-flavored-build.gradle"


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-982] Dependencies missing for running JDBC extraction job"
    - https://issues.apache.org/jira/browse/GOBBLIN-982


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

Add "gobblin-sql" module into distribution dependencies so that it could be packaged into built tarball, otherwise while running JDBC extraction job, it will pop up `ClassNotFound` exception for all "gobblin-sql" classes.

Add jdbc related libraries into mr libs as jdbc extraction codes are actually running on mappers and need these dependencies (same as above got `ClassNotFound` exception otherwise).

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Gradle config and shell scripts modification.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

