### PR TITLE
[GOBBLIN-986]Persist the existing property of table when doing hive registration

### DIFF
--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/metastore/HiveMetaStoreUtils.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/metastore/HiveMetaStoreUtils.java
@@ -253,7 +253,7 @@ public class HiveMetaStoreUtils {
     return si;
   }
 
-  private static State getTableProps(Table table) {
+  public static State getTableProps(Table table) {
     State tableProps = new State();
     for (Map.Entry<String, String> entry : table.getParameters().entrySet()) {
       tableProps.setProp(entry.getKey(), entry.getValue());


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-986


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Persist the existing property of table when doing hive registration, so the property of iceberg will not be overwritten

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Local test

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

