### PR TITLE
[GOBBLIN-987] Reject unrecognized Enum symbols in JsonRecordAvroSchemaToAvroConverter

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/converter/avro/JsonElementConversionWithAvroSchemaFactory.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/converter/avro/JsonElementConversionWithAvroSchemaFactory.java
@@ -17,6 +17,7 @@
 
 package org.apache.gobblin.converter.avro;
 
+import com.google.common.base.Preconditions;
 import com.sun.javafx.binding.StringFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -25,7 +26,6 @@ import java.util.Map;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
-import org.apache.commons.lang3.Validate;
 import org.apache.gobblin.configuration.WorkUnitState;
 import org.apache.gobblin.converter.DataConversionException;
 
@@ -159,7 +159,7 @@ public class JsonElementConversionWithAvroSchemaFactory extends JsonElementConve
 
       this.enumSet.addAll(schemaNode.getEnumSymbols());
 
-      this.enumName = schemaNode.getType().getName();
+      this.enumName = schemaNode.getFullName();
 
       this.schema = schemaNode;
     }
@@ -167,8 +167,8 @@ public class JsonElementConversionWithAvroSchemaFactory extends JsonElementConve
     @Override
     Object convertField(JsonElement value) {
       String valueString = value.getAsString();
-      Validate.isTrue(this.enumSet.contains(valueString),
-          String.format("%s is not one of the valid symbols for this enum: %s", valueString, this.enumSet));
+      Preconditions.checkArgument(this.enumSet.contains(valueString),
+          "%s is not one of the valid symbols for the %s enum: %s", valueString, this.enumName, this.enumSet);
       return new GenericData.EnumSymbol(this.schema, valueString);
     }
 

--- a/gobblin-core/src/main/java/org/apache/gobblin/converter/avro/JsonElementConversionWithAvroSchemaFactory.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/converter/avro/JsonElementConversionWithAvroSchemaFactory.java
@@ -25,6 +25,7 @@ import java.util.Map;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
+import org.apache.commons.lang3.Validate;
 import org.apache.gobblin.configuration.WorkUnitState;
 import org.apache.gobblin.converter.DataConversionException;
 
@@ -165,7 +166,10 @@ public class JsonElementConversionWithAvroSchemaFactory extends JsonElementConve
 
     @Override
     Object convertField(JsonElement value) {
-      return new GenericData.EnumSymbol(this.schema, value.getAsString());
+      String valueString = value.getAsString();
+      Validate.isTrue(this.enumSet.contains(valueString),
+          String.format("%s is not one of the valid symbols for this enum: %s", valueString, this.enumSet));
+      return new GenericData.EnumSymbol(this.schema, valueString);
     }
 
     @Override


### PR DESCRIPTION
This change fixes JsonRecordAvroSchemaToAvroConverter by rejecting Enum
symbols not defined in the specified Avro schema. Allowing such values
causes runtime errors when the resulting objects are encoded.

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-987


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
`JsonRecordAvroSchemaToAvroConverter` allows unrecognized Enum symbols not declared in the specified Avro schema. Attempting to write/encode the resulting objects cause runtime errors that are difficult to diagnose or root-cause.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
`org.apache.gobblin.converter.avro.JsonRecordAvroSchemaToAvroConverterTest.testConverterThrowsOnUnrecognizedEnumSymbols()`


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

