### PR TITLE
[GOBBLIN-988] Implement LocalFSJobStatusRetriever

### DIFF
--- a/conf/gobblin-as-service/application.conf
+++ b/conf/gobblin-as-service/application.conf
@@ -29,7 +29,7 @@ topologySpecFactory.localGobblinCluster.version="1"
 topologySpecFactory.localGobblinCluster.uri="gobblinCluster"
 topologySpecFactory.localGobblinCluster.specExecutorInstance.class="org.apache.gobblin.runtime.spec_executorInstance.LocalFsSpecExecutor"
 topologySpecFactory.localGobblinCluster.specExecInstance.capabilities="source:dest"
-topologySpecFactory.localGobblinCluster.gobblin.cluster.localSpecProducer.dir=${gobblin.service.work.dir}/jobs
+topologySpecFactory.localGobblinCluster.localFsSpecProducer.dir=${gobblin.service.work.dir}/jobs
 
 # Flow Catalog and Store
 flowSpec.store.dir=${gobblin.service.work.dir}/flowSpecStore
@@ -40,12 +40,13 @@ gobblin.service.templateCatalogs.fullyQualifiedPath="file://"
 # JobStatusMonitor
 gobblin.service.jobStatusMonitor.enabled=false
 
-# FsJobStatusRetriever
-fsJobStatusRetriever.state.store.dir=${gobblin.service.work.dir}/state-store
+# JobStatusRetriever
+jobStatusRetriever.class="org.apache.gobblin.service.monitoring.LocalFsJobStatusRetriever"
+localFsJobStatusRetriever.localFsSpecProducer.dir=${gobblin.service.work.dir}/jobs
 
 # DagManager
 gobblin.service.dagManager.enabled=true
-gobblin.service.dagManager.jobStatusRetriever.class="org.apache.gobblin.service.monitoring.FsJobStatusRetriever"
+gobblin.service.dagManager.jobStatusRetriever.class="org.apache.gobblin.service.monitoring.LocalFsJobStatusRetriever"
 gobblin.service.dagManager.dagStateStoreClass="org.apache.gobblin.service.modules.orchestration.FSDagStateStore"
 gobblin.service.dagManager.dagStateStoreDir=${gobblin.service.work.dir}/dagStateStoreDir
 

--- a/gobblin-kubernetes/gobblin-service/mysql-cluster/gaas-application.conf
+++ b/gobblin-kubernetes/gobblin-service/mysql-cluster/gaas-application.conf
@@ -44,7 +44,7 @@ fsJobStatusRetriever.state.store.dir=${gobblin.service.work.dir}/state-store
 
 # DagManager
 gobblin.service.dagManager.enabled=true
-gobblin.service.dagManager.jobStatusRetriever.class="org.apache.gobblin.service.monitoring.FsJobStatusRetriever"
+gobblin.service.dagManager.jobStatusRetriever.class="org.apache.gobblin.service.monitoring.LocalFSJobStatusRetriever"
 gobblin.service.dagManager.dagStateStoreClass="org.apache.gobblin.service.modules.orchestration.FSDagStateStore"
 gobblin.service.dagManager.dagStateStoreDir=${gobblin.service.work.dir}/dagStateStoreDir
 

--- a/gobblin-kubernetes/gobblin-service/mysql-cluster/gaas-application.conf
+++ b/gobblin-kubernetes/gobblin-service/mysql-cluster/gaas-application.conf
@@ -28,7 +28,7 @@ topologySpecFactory.localGobblinCluster.version="1"
 topologySpecFactory.localGobblinCluster.uri="gobblinCluster"
 topologySpecFactory.localGobblinCluster.specExecutorInstance.class="org.apache.gobblin.runtime.spec_executorInstance.LocalFsSpecExecutor"
 topologySpecFactory.localGobblinCluster.specExecInstance.capabilities="source:dest"
-topologySpecFactory.localGobblinCluster.gobblin.cluster.localSpecProducer.dir=${gobblin.service.work.dir}/jobs
+topologySpecFactory.localGobblinCluster.localFsSpecProducer.dir=${gobblin.service.work.dir}/jobs
 
 # Flow Catalog and Store
 flowSpec.store.dir=${gobblin.service.work.dir}/flowSpecStore
@@ -39,12 +39,13 @@ gobblin.service.templateCatalogs.fullyQualifiedPath="file://"
 # JobStatusMonitor
 gobblin.service.jobStatusMonitor.enabled=false
 
-# FsJobStatusRetriever
-fsJobStatusRetriever.state.store.dir=${gobblin.service.work.dir}/state-store
+# JobStatusRetriever
+jobStatusRetriever.class="org.apache.gobblin.service.monitoring.LocalFsJobStatusRetriever"
+localFsJobStatusRetriever.localFsSpecProducer.dir=${gobblin.service.work.dir}/jobs
 
 # DagManager
 gobblin.service.dagManager.enabled=true
-gobblin.service.dagManager.jobStatusRetriever.class="org.apache.gobblin.service.monitoring.LocalFSJobStatusRetriever"
+gobblin.service.dagManager.jobStatusRetriever.class="org.apache.gobblin.service.monitoring.LocalFsJobStatusRetriever"
 gobblin.service.dagManager.dagStateStoreClass="org.apache.gobblin.service.modules.orchestration.FSDagStateStore"
 gobblin.service.dagManager.dagStateStoreDir=${gobblin.service.work.dir}/dagStateStoreDir
 
@@ -62,12 +63,3 @@ mysqlSpecStore.state.store.db.table="flow_spec_store"
 mysqlSpecStore.state.store.db.url="jdbc:mysql://mysql.default.svc.cluster.local:3306/gaas_db"
 mysqlSpecStore.state.store.db.user=${mysqlCredentials.user}
 mysqlSpecStore.state.store.db.password=${mysqlCredentials.password}
-
-# MySQL Job Status Retriever
-jobStatusRetriever.class="org.apache.gobblin.service.monitoring.MysqlJobStatusRetriever"
-mysqlJobStatusRetriever.state.store.db.table="gaas_job_status"
-
-# Assuming default namespace. URL of the service takes the form of <service>.<namespace>.cluster.local
-mysqlJobStatusRetriever.state.store.db.url="jdbc:mysql://mysql.default.svc.cluster.local:3306/gaas_db"
-mysqlJobStatusRetriever.state.store.db.user=${mysqlCredentials.user}
-mysqlJobStatusRetriever.state.store.db.password=${mysqlCredentials.password}

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_executorInstance/LocalFsSpecProducer.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_executorInstance/LocalFsSpecProducer.java
@@ -16,9 +16,6 @@
  */
 
 package org.apache.gobblin.runtime.spec_executorInstance;
-
-import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
 import com.typesafe.config.Config;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -33,7 +30,6 @@ import org.apache.gobblin.runtime.api.Spec;
 import org.apache.gobblin.runtime.api.SpecExecutor;
 import org.apache.gobblin.runtime.api.SpecProducer;
 import org.apache.gobblin.util.CompletedFuture;
-import org.apache.gobblin.util.ConfigUtils;
 
 
 /**

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_executorInstance/LocalFsSpecProducer.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_executorInstance/LocalFsSpecProducer.java
@@ -71,6 +71,7 @@ public class LocalFsSpecProducer implements SpecProducer<Spec> {
   private Future<?> writeSpec(Spec spec, SpecExecutor.Verb verb) {
     if (spec instanceof JobSpec) {
       URI specUri = spec.getUri();
+      ((JobSpec) spec).getMetadata().get()
       // format the JobSpec to have file of <flowGroup>_<flowName>.job
       String jobFileName = getJobFileName(specUri);
       try (
@@ -109,7 +110,7 @@ public class LocalFsSpecProducer implements SpecProducer<Spec> {
     throw new UnsupportedOperationException();
   }
 
-  private String getJobFileName(URI specUri) {
+  public static String getJobFileName(URI specUri) {
     String[] uriTokens = specUri.getPath().split("/");
     return String.join("_", uriTokens) + ".job";
   }

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_executorInstance/LocalFsSpecProducer.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_executorInstance/LocalFsSpecProducer.java
@@ -54,16 +54,14 @@ public class LocalFsSpecProducer implements SpecProducer<Spec> {
   }
 
   /** Add a {@link Spec} for execution on {@link org.apache.gobblin.runtime.api.SpecExecutor}.
-   * @param addedSpec
-   */
+   * @param addedSpec*/
   @Override
   public Future<?> addSpec(Spec addedSpec) {
     return writeSpec(addedSpec, SpecExecutor.Verb.ADD);
   }
 
   /** Update a {@link Spec} being executed on {@link org.apache.gobblin.runtime.api.SpecExecutor}.
-   * @param updatedSpec
-   */
+   * @param updatedSpec*/
   @Override
   public Future<?> updateSpec(Spec updatedSpec) {
     return writeSpec(updatedSpec, SpecExecutor.Verb.UPDATE);

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_executorInstance/LocalFsSpecProducer.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_executorInstance/LocalFsSpecProducer.java
@@ -102,10 +102,13 @@ public class LocalFsSpecProducer implements SpecProducer<Spec> {
     });
 
     for (int i = 0; i < foundFiles.length; i++) {
-        foundFiles[i].delete();
+        Boolean didDelete = foundFiles[i].delete();
+        if (!didDelete) {
+          return new CompletedFuture<>(Boolean.TRUE, new RuntimeException(String.format("Failed to delete file with uri %s", deletedSpecURI)));
+        }
     }
 
-    throw new RuntimeException(String.format("Failed to delete file with uri %s", deletedSpecURI));
+    return new CompletedFuture<>(Boolean.TRUE, null);
   }
 
   /** List all {@link Spec} being executed on {@link org.apache.gobblin.runtime.api.SpecExecutor}. */

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_executorInstance/LocalFsSpecProducer.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_executorInstance/LocalFsSpecProducer.java
@@ -57,14 +57,16 @@ public class LocalFsSpecProducer implements SpecProducer<Spec> {
   }
 
   /** Add a {@link Spec} for execution on {@link org.apache.gobblin.runtime.api.SpecExecutor}.
-   * @param addedSpec*/
+   * @param addedSpec
+   */
   @Override
   public Future<?> addSpec(Spec addedSpec) {
     return writeSpec(addedSpec, SpecExecutor.Verb.ADD);
   }
 
   /** Update a {@link Spec} being executed on {@link org.apache.gobblin.runtime.api.SpecExecutor}.
-   * @param updatedSpec*/
+   * @param updatedSpec
+   */
   @Override
   public Future<?> updateSpec(Spec updatedSpec) {
     return writeSpec(updatedSpec, SpecExecutor.Verb.UPDATE);
@@ -92,7 +94,8 @@ public class LocalFsSpecProducer implements SpecProducer<Spec> {
 
   /** Delete a {@link Spec} being executed on {@link org.apache.gobblin.runtime.api.SpecExecutor}.
    * @param deletedSpecURI
-   * @param headers*/
+   * @param headers
+   */
   @Override
   public Future<?> deleteSpec(URI deletedSpecURI, Properties headers) {
     String jobFileName = getJobFileName(deletedSpecURI);

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_executorInstance/LocalFsSpecProducer.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_executorInstance/LocalFsSpecProducer.java
@@ -39,7 +39,7 @@ import org.apache.gobblin.util.CompletedFuture;
 @Slf4j
 public class LocalFsSpecProducer implements SpecProducer<Spec> {
   private String specProducerPath;
-  public static final String LOCAL_FS_PRODUCER_PATH_KEY = "gobblin.cluster.localSpecProducer.dir";
+  public static final String LOCAL_FS_PRODUCER_PATH_KEY = "localFsSpecProducer.dir";
 
   public LocalFsSpecProducer(Config config) {
     this.specProducerPath = config.getString(LOCAL_FS_PRODUCER_PATH_KEY);

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_executorInstance/LocalFsSpecProducer.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_executorInstance/LocalFsSpecProducer.java
@@ -72,7 +72,8 @@ public class LocalFsSpecProducer implements SpecProducer<Spec> {
   private Future<?> writeSpec(Spec spec, SpecExecutor.Verb verb) {
     if (spec instanceof JobSpec) {
       // format the JobSpec to have file of <flowGroup>_<flowName>.job
-      String jobFileName = getJobFileName(spec);
+      String flowExecutionId = ((JobSpec) spec).getConfigAsProperties().getProperty(ConfigurationKeys.FLOW_EXECUTION_ID_KEY);
+      String jobFileName = getJobFileName(spec.getUri(), flowExecutionId);
       try (
         FileOutputStream fStream = new FileOutputStream(this.specProducerPath + File.separatorChar + jobFileName);
       ) {
@@ -115,9 +116,8 @@ public class LocalFsSpecProducer implements SpecProducer<Spec> {
     throw new UnsupportedOperationException();
   }
 
-  public static String getJobFileName(Spec spec) {
-    String[] uriTokens = spec.getUri().getPath().split("/");
-    String flowExecutionId = ((JobSpec) spec).getConfigAsProperties().getProperty(ConfigurationKeys.FLOW_EXECUTION_ID_KEY);
+  public static String getJobFileName(URI specUri, String flowExecutionId) {
+    String[] uriTokens = specUri.getPath().split("/");
     return String.join("_", uriTokens) + "_" + flowExecutionId + ".job";
   }
 

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
@@ -694,7 +694,6 @@ public class DagManager extends AbstractIdleService {
         // The SpecProducer implementations submit the job to the underlying executor and return when the submission is complete,
         // either successfully or unsuccessfully. To catch any exceptions in the job submission, the DagManagerThread
         // blocks (by calling Future#get()) until the submission is completed.
-        dagNode.getValue().getExecutionStatus();
         Future addSpecFuture = producer.addSpec(jobSpec);
         dagNode.getValue().setJobFuture(Optional.of(addSpecFuture));
         //Persist the dag

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
@@ -694,6 +694,7 @@ public class DagManager extends AbstractIdleService {
         // The SpecProducer implementations submit the job to the underlying executor and return when the submission is complete,
         // either successfully or unsuccessfully. To catch any exceptions in the job submission, the DagManagerThread
         // blocks (by calling Future#get()) until the submission is completed.
+        dagNode.getValue().getExecutionStatus();
         Future addSpecFuture = producer.addSpec(jobSpec);
         dagNode.getValue().setJobFuture(Optional.of(addSpecFuture));
         //Persist the dag

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/LocalFsJobStatusRetriever.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/LocalFsJobStatusRetriever.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.service.monitoring;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
+import com.typesafe.config.Config;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import org.apache.gobblin.configuration.State;
+import org.apache.gobblin.metastore.FileContextBasedFsStateStore;
+import org.apache.gobblin.metastore.FileContextBasedFsStateStoreFactory;
+import org.apache.gobblin.runtime.spec_executorInstance.LocalFsSpecProducer;
+import org.apache.gobblin.service.ExecutionStatus;
+
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class LocalFsJobStatusRetriever extends JobStatusRetriever {
+
+  public static final String CONF_PREFIX = "localFsJobStatusRetriever";
+  private String specProducerPath;
+
+  @Getter
+  private final FileContextBasedFsStateStore<State> stateStore;
+
+
+  public LocalFsJobStatusRetriever(Config config) {
+    this.specProducerPath = config.getString(LocalFsSpecProducer.LOCAL_FS_PRODUCER_PATH_KEY);
+    this.stateStore = (FileContextBasedFsStateStore<State>) new FileContextBasedFsStateStoreFactory().
+        createStateStore(config.getConfig(CONF_PREFIX), State.class);
+  }
+
+  private boolean isJobDone(String flowName, String flowGroup) {
+    // Local FS has no monitor to update job state yet, for now check if standalone is completed with job, and mark as done
+    // Otherwise the job is pending
+    try {
+      String jobName = LocalFsSpecProducer.getJobFileName(new URI(flowGroup + File.separatorChar + flowName));
+      File jobDone = new File(this.specProducerPath + File.separatorChar + jobName + ".done");
+      return jobDone.exists();
+    } catch (URISyntaxException e) {
+      log.error("URISyntaxException occurred when retrieving job status for flow: {},{}", flowGroup, flowName, e);
+    }
+    return false;
+  }
+
+  @Override
+  public Iterator<JobStatus> getJobStatusesForFlowExecution(String flowName, String flowGroup, long flowExecutionId) {
+    Preconditions.checkArgument(flowName != null, "FlowName cannot be null");
+    Preconditions.checkArgument(flowGroup != null, "FlowGroup cannot be null");
+    List<JobStatus> jobStatuses = new ArrayList<>();
+
+    // Instead of looking directly at state store, first check the local FS job workspace to determine if the job is finished
+    // Then update the state store with the correct state, instead of having a monitor watch the file system
+    // Finally, return the corresponding job state
+
+    Predicate<String> flowExecutionIdPredicate = input -> input.startsWith(String.valueOf(flowExecutionId) + ".");
+    String storeName = KafkaJobStatusMonitor.jobStatusStoreName(flowGroup, flowName);
+    try {
+      List<JobStatus> jobStatuses = new ArrayList<>();
+      List<String> tableNames = this.stateStore.getTableNames(storeName, flowExecutionIdPredicate);
+      for (String tableName : tableNames) {
+        List<State> jobStates = this.stateStore.getAll(storeName, tableName);
+        if (jobStates.isEmpty()) {
+          return Iterators.emptyIterator();
+        }
+        // this is gobblin-standalone's indicator that the job is completed
+        if (isJobDone(flowName, flowGroup)) {
+          jobStates.get(0).setProp(JobStatusRetriever.EVENT_NAME_FIELD, ExecutionStatus.COMPLETE.name());
+        }
+        jobStatuses.add(getJobStatus(jobStates.get(0)));
+      }
+    } catch (IOException e) {
+      log.error("IOException encountered when retrieving job statuses for flow: {},{},{}", flowGroup, flowName, flowExecutionId, e);
+      return Iterators.emptyIterator();
+    }
+
+  }
+
+  @Override
+  public Iterator<JobStatus> getJobStatusesForFlowExecution(String flowName, String flowGroup, long flowExecutionId,
+      String jobName, String jobGroup) {
+    Preconditions.checkArgument(flowName != null, "flowName cannot be null");
+    Preconditions.checkArgument(flowGroup != null, "flowGroup cannot be null");
+    Preconditions.checkArgument(jobName != null, "jobName cannot be null");
+    Preconditions.checkArgument(jobGroup != null, "jobGroup cannot be null");
+
+    try {
+      String storeName = KafkaJobStatusMonitor.jobStatusStoreName(flowGroup, flowName);
+      String tableName = KafkaJobStatusMonitor.jobStatusTableName(flowExecutionId, jobGroup, jobName);
+      List<State> jobStates = this.stateStore.getAll(storeName, tableName);
+      if (jobStates.isEmpty()) {
+        return Iterators.emptyIterator();
+      } else {
+        if (isJobDone(flowName, flowGroup)) {
+          jobStates.get(0).setProp(JobStatusRetriever.EVENT_NAME_FIELD, ExecutionStatus.COMPLETE.name());
+        }
+        return Iterators.singletonIterator(getJobStatus(jobStates.get(0)));
+      }
+    } catch (IOException e) {
+      log.error("Exception encountered when listing files", e);
+      return Iterators.emptyIterator();
+    }
+  }
+
+  /**
+   * @param flowName
+   * @param flowGroup
+   * @return the last <code>count</code> flow execution ids with the given flowName and flowGroup. -1 will be returned if no such execution found.
+   */
+  @Override
+  public List<Long> getLatestExecutionIdsForFlow(String flowName, String flowGroup, int count) {
+    Preconditions.checkArgument(flowName != null, "flowName cannot be null");
+    Preconditions.checkArgument(flowGroup != null, "flowGroup cannot be null");
+    Preconditions.checkArgument(count > 0, "Number of execution ids must be at least 1.");
+    try {
+      String storeName = KafkaJobStatusMonitor.jobStatusStoreName(flowGroup, flowName);
+      List<String> tableNames = this.stateStore.getTableNames(storeName, input -> true);
+      Set<Long> flowExecutionIds = new TreeSet<>(tableNames.stream()
+          .map(KafkaJobStatusMonitor::getExecutionIdFromTableName)
+          .collect(Collectors.toList())).descendingSet();
+      return ImmutableList.copyOf(Iterables.limit(flowExecutionIds, count));
+    } catch (Exception e) {
+      return null;
+    }
+  }
+}

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/LocalFsJobStatusRetriever.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/LocalFsJobStatusRetriever.java
@@ -33,8 +33,6 @@ import org.apache.gobblin.metastore.StateStore;
 import org.apache.gobblin.runtime.spec_executorInstance.LocalFsSpecProducer;
 import org.apache.gobblin.service.ExecutionStatus;
 
-import java.net.URISyntaxException;
-
 import lombok.extern.slf4j.Slf4j;
 
 

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/LocalFsJobStatusRetriever.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/LocalFsJobStatusRetriever.java
@@ -33,6 +33,8 @@ import org.apache.gobblin.metastore.StateStore;
 import org.apache.gobblin.runtime.spec_executorInstance.LocalFsSpecProducer;
 import org.apache.gobblin.service.ExecutionStatus;
 
+import java.net.URISyntaxException;
+
 import lombok.extern.slf4j.Slf4j;
 
 
@@ -51,7 +53,7 @@ public class LocalFsJobStatusRetriever extends JobStatusRetriever {
     // Local FS has no monitor to update job state yet, for now check if standalone is completed with job, and mark as done
     // Otherwise the job is pending
     try {
-      String fileName = LocalFsSpecProducer.getJobFileName(new URI(flowGroup + File.separatorChar + flowName), String.valueOf(flowExecutionId));
+      String fileName = LocalFsSpecProducer.getJobFileName(new URI(File.separatorChar + flowGroup + File.separatorChar + flowName), String.valueOf(flowExecutionId));
       return new File(this.specProducerPath + File.separatorChar + fileName).exists();
     } catch (URISyntaxException e) {
       log.error("URISyntaxException occurred when retrieving job status for flow: {},{}", flowGroup, flowName, e);
@@ -63,7 +65,7 @@ public class LocalFsJobStatusRetriever extends JobStatusRetriever {
     // Local FS has no monitor to update job state yet, for now check if standalone is completed with job, and mark as done
     // Otherwise the job is pending
     try {
-      String fileName = LocalFsSpecProducer.getJobFileName(new URI(flowGroup + File.separatorChar + flowName), String.valueOf(flowExecutionId));
+      String fileName = LocalFsSpecProducer.getJobFileName(new URI(File.separatorChar + flowGroup + File.separatorChar + flowName), String.valueOf(flowExecutionId));
       return new File(this.specProducerPath + File.separatorChar + fileName + ".done").exists();
     } catch (URISyntaxException e) {
       log.error("URISyntaxException occurred when retrieving job status for flow: {},{}", flowGroup, flowName, e);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/LocalFsJobStatusRetriever.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/LocalFsJobStatusRetriever.java
@@ -48,9 +48,6 @@ public class LocalFsJobStatusRetriever extends JobStatusRetriever {
     this.specProducerPath = config.getString(LocalFsSpecProducer.LOCAL_FS_PRODUCER_PATH_KEY);
   }
 
-  private String
-
-
   private Boolean doesJobExist(String flowName, String flowGroup, long flowExecutionId, String suffix) {
     // Local FS has no monitor to update job state yet, for now check if standalone is completed with job, and mark as done
     // Otherwise the job is pending

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/LocalFsJobStatusRetriever.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/LocalFsJobStatusRetriever.java
@@ -18,30 +18,23 @@
 package org.apache.gobblin.service.monitoring;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
+
 import com.google.common.collect.Iterators;
 import com.typesafe.config.Config;
 import java.io.File;
-import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
-import java.util.TreeSet;
-import java.util.stream.Collectors;
+
 import org.apache.gobblin.configuration.State;
-import org.apache.gobblin.metastore.FileContextBasedFsStateStore;
-import org.apache.gobblin.metastore.FileContextBasedFsStateStoreFactory;
+import org.apache.gobblin.metastore.StateStore;
 import org.apache.gobblin.runtime.spec_executorInstance.LocalFsSpecProducer;
 import org.apache.gobblin.service.ExecutionStatus;
 
-
-import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+
 
 @Slf4j
 public class LocalFsJobStatusRetriever extends JobStatusRetriever {
@@ -49,22 +42,29 @@ public class LocalFsJobStatusRetriever extends JobStatusRetriever {
   public static final String CONF_PREFIX = "localFsJobStatusRetriever";
   private String specProducerPath;
 
-  @Getter
-  private final FileContextBasedFsStateStore<State> stateStore;
-
-
   // Do not use a state store for this implementation, just look at the job folder that @LocalFsSpecProducer writes to
   public LocalFsJobStatusRetriever(Config config) {
     this.specProducerPath = config.getString(LocalFsSpecProducer.LOCAL_FS_PRODUCER_PATH_KEY);
   }
 
-  private boolean isJobDone(String flowName, String flowGroup) {
+  private Boolean isJobPending(String flowName, String flowGroup, long flowExecutionId) {
     // Local FS has no monitor to update job state yet, for now check if standalone is completed with job, and mark as done
     // Otherwise the job is pending
     try {
-      String jobName = LocalFsSpecProducer.getJobFileName(new URI(flowGroup + File.separatorChar + flowName));
-      File jobDone = new File(this.specProducerPath + File.separatorChar + jobName + ".done");
-      return jobDone.exists();
+      String fileName = LocalFsSpecProducer.getJobFileName(new URI(flowGroup + File.separatorChar + flowName), String.valueOf(flowExecutionId));
+      return new File(this.specProducerPath + File.separatorChar + fileName).exists();
+    } catch (URISyntaxException e) {
+      log.error("URISyntaxException occurred when retrieving job status for flow: {},{}", flowGroup, flowName, e);
+    }
+    return false;
+  }
+
+  private Boolean isJobDone(String flowName, String flowGroup, long flowExecutionId) {
+    // Local FS has no monitor to update job state yet, for now check if standalone is completed with job, and mark as done
+    // Otherwise the job is pending
+    try {
+      String fileName = LocalFsSpecProducer.getJobFileName(new URI(flowGroup + File.separatorChar + flowName), String.valueOf(flowExecutionId));
+      return new File(this.specProducerPath + File.separatorChar + fileName + ".done").exists();
     } catch (URISyntaxException e) {
       log.error("URISyntaxException occurred when retrieving job status for flow: {},{}", flowGroup, flowName, e);
     }
@@ -76,31 +76,21 @@ public class LocalFsJobStatusRetriever extends JobStatusRetriever {
     Preconditions.checkArgument(flowName != null, "FlowName cannot be null");
     Preconditions.checkArgument(flowGroup != null, "FlowGroup cannot be null");
 
-    // Instead of looking directly at state store, first check the local FS job workspace to determine if the job is finished
-    // Then update the state store with the correct state, instead of having a monitor watch the file system
-    // Finally, return the corresponding job state
+    // For the FS use case, JobExecutionID == FlowExecutionID
 
-    Predicate<String> flowExecutionIdPredicate = input -> input.startsWith(String.valueOf(flowExecutionId) + ".");
-    String storeName = KafkaJobStatusMonitor.jobStatusStoreName(flowGroup, flowName);
-    try {
-      List<JobStatus> jobStatuses = new ArrayList<>();
-      List<String> tableNames = this.stateStore.getTableNames(storeName, flowExecutionIdPredicate);
-      for (String tableName : tableNames) {
-        List<State> jobStates = this.stateStore.getAll(storeName, tableName);
-        if (jobStates.isEmpty()) {
-          return Iterators.emptyIterator();
-        }
-        // this is gobblin-standalone's indicator that the job is completed
-        if (isJobDone(flowName, flowGroup)) {
-          jobStates.get(0).setProp(JobStatusRetriever.EVENT_NAME_FIELD, ExecutionStatus.COMPLETE.name());
-        }
-        jobStatuses.add(getJobStatus(jobStates.get(0)));
-      }
-      return jobStatuses.iterator();
-    } catch (IOException e) {
-      log.error("IOException encountered when retrieving job statuses for flow: {},{},{}", flowGroup, flowName, flowExecutionId, e);
+    List<JobStatus> jobStatuses = new ArrayList<>();
+    JobStatus jobStatus;
+
+    if (this.isJobDone(flowName, flowGroup, flowExecutionId)) {
+      jobStatus = JobStatus.builder().flowName(flowName).flowGroup(flowGroup).flowExecutionId(flowExecutionId).jobExecutionId(flowExecutionId).eventName(ExecutionStatus.COMPLETE.name()).build();
+    } else if (this.isJobPending(flowName, flowGroup, flowExecutionId)) {
+      jobStatus = JobStatus.builder().flowName(flowName).flowGroup(flowGroup).flowExecutionId(flowExecutionId).jobExecutionId(flowExecutionId).eventName(ExecutionStatus.PENDING.name()).build();
+    } else {
       return Iterators.emptyIterator();
     }
+
+    jobStatuses.add(jobStatus);
+    return jobStatuses.iterator();
 
   }
 
@@ -111,26 +101,21 @@ public class LocalFsJobStatusRetriever extends JobStatusRetriever {
     Preconditions.checkArgument(flowGroup != null, "flowGroup cannot be null");
     Preconditions.checkArgument(jobName != null, "jobName cannot be null");
     Preconditions.checkArgument(jobGroup != null, "jobGroup cannot be null");
+    List<JobStatus> jobStatuses = new ArrayList<>();
+    JobStatus jobStatus;
 
-    try {
-      String storeName = KafkaJobStatusMonitor.jobStatusStoreName(flowGroup, flowName);
-      String tableName = KafkaJobStatusMonitor.jobStatusTableName(flowExecutionId, jobGroup, jobName);
-      log.info(storeName);
-      log.info(tableName);
-      List<State> jobStates = this.stateStore.getAll(storeName, tableName);
-      if (jobStates.isEmpty()) {
-        log.info("I AM EMPTY");
-        return Iterators.emptyIterator();
-      } else {
-        if (isJobDone(flowName, flowGroup)) {
-          jobStates.get(0).setProp(JobStatusRetriever.EVENT_NAME_FIELD, ExecutionStatus.COMPLETE.name());
-        }
-        return Iterators.singletonIterator(getJobStatus(jobStates.get(0)));
-      }
-    } catch (IOException e) {
-      log.error("Exception encountered when listing files", e);
+    if (this.isJobDone(flowName, flowGroup, flowExecutionId)) {
+      jobStatus = JobStatus.builder().flowName(flowName).flowGroup(flowGroup).flowExecutionId(flowExecutionId).
+          jobName(jobName).jobGroup(jobGroup).jobExecutionId(flowExecutionId).eventName(ExecutionStatus.COMPLETE.name()).build();
+    } else if (this.isJobPending(flowName, flowGroup, flowExecutionId)) {
+      jobStatus = JobStatus.builder().flowName(flowName).flowGroup(flowGroup).flowExecutionId(flowExecutionId).
+          jobName(jobName).jobGroup(jobGroup).jobExecutionId(flowExecutionId).eventName(ExecutionStatus.PENDING.name()).build();
+    } else {
       return Iterators.emptyIterator();
     }
+
+    jobStatuses.add(jobStatus);
+    return jobStatuses.iterator();
   }
 
   /**
@@ -143,15 +128,15 @@ public class LocalFsJobStatusRetriever extends JobStatusRetriever {
     Preconditions.checkArgument(flowName != null, "flowName cannot be null");
     Preconditions.checkArgument(flowGroup != null, "flowGroup cannot be null");
     Preconditions.checkArgument(count > 0, "Number of execution ids must be at least 1.");
-    try {
-      String storeName = KafkaJobStatusMonitor.jobStatusStoreName(flowGroup, flowName);
-      List<String> tableNames = this.stateStore.getTableNames(storeName, input -> true);
-      Set<Long> flowExecutionIds = new TreeSet<>(tableNames.stream()
-          .map(KafkaJobStatusMonitor::getExecutionIdFromTableName)
-          .collect(Collectors.toList())).descendingSet();
-      return ImmutableList.copyOf(Iterables.limit(flowExecutionIds, count));
-    } catch (Exception e) {
-      return null;
-    }
+
+    //TODO: implement this
+
+    return null;
+  }
+
+  public StateStore<State> getStateStore() {
+    // this jobstatus retriever does not have a state store
+    // only used in tests so this is okay
+    return null;
   }
 }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/LocalFsJobStatusRetriever.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/LocalFsJobStatusRetriever.java
@@ -35,7 +35,10 @@ import org.apache.gobblin.service.ExecutionStatus;
 
 import lombok.extern.slf4j.Slf4j;
 
-
+/**
+ * A job status monitor for jobs completed by a Gobblin Standalone instance running on the same machine. Mainly used for sandboxing/testing
+ * Considers a job done when Gobblin standalone appends ".done" to the job. Otherwise it will assume the job is in progress
+ */
 @Slf4j
 public class LocalFsJobStatusRetriever extends JobStatusRetriever {
 

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/LocalFsJobStatusRetriever.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/LocalFsJobStatusRetriever.java
@@ -76,7 +76,6 @@ public class LocalFsJobStatusRetriever extends JobStatusRetriever {
   public Iterator<JobStatus> getJobStatusesForFlowExecution(String flowName, String flowGroup, long flowExecutionId) {
     Preconditions.checkArgument(flowName != null, "FlowName cannot be null");
     Preconditions.checkArgument(flowGroup != null, "FlowGroup cannot be null");
-    List<JobStatus> jobStatuses = new ArrayList<>();
 
     // Instead of looking directly at state store, first check the local FS job workspace to determine if the job is finished
     // Then update the state store with the correct state, instead of having a monitor watch the file system
@@ -98,6 +97,7 @@ public class LocalFsJobStatusRetriever extends JobStatusRetriever {
         }
         jobStatuses.add(getJobStatus(jobStates.get(0)));
       }
+      return jobStatuses.iterator();
     } catch (IOException e) {
       log.error("IOException encountered when retrieving job statuses for flow: {},{},{}", flowGroup, flowName, flowExecutionId, e);
       return Iterators.emptyIterator();

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/LocalFsJobStatusRetriever.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/LocalFsJobStatusRetriever.java
@@ -53,10 +53,9 @@ public class LocalFsJobStatusRetriever extends JobStatusRetriever {
   private final FileContextBasedFsStateStore<State> stateStore;
 
 
+  // Do not use a state store for this implementation, just look at the job folder that @LocalFsSpecProducer writes to
   public LocalFsJobStatusRetriever(Config config) {
     this.specProducerPath = config.getString(LocalFsSpecProducer.LOCAL_FS_PRODUCER_PATH_KEY);
-    this.stateStore = (FileContextBasedFsStateStore<State>) new FileContextBasedFsStateStoreFactory().
-        createStateStore(config.getConfig(CONF_PREFIX), State.class);
   }
 
   private boolean isJobDone(String flowName, String flowGroup) {
@@ -116,8 +115,11 @@ public class LocalFsJobStatusRetriever extends JobStatusRetriever {
     try {
       String storeName = KafkaJobStatusMonitor.jobStatusStoreName(flowGroup, flowName);
       String tableName = KafkaJobStatusMonitor.jobStatusTableName(flowExecutionId, jobGroup, jobName);
+      log.info(storeName);
+      log.info(tableName);
       List<State> jobStates = this.stateStore.getAll(storeName, tableName);
       if (jobStates.isEmpty()) {
+        log.info("I AM EMPTY");
         return Iterators.emptyIterator();
       } else {
         if (isJobDone(flowName, flowGroup)) {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/LocalFsJobStatusRetriever.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/LocalFsJobStatusRetriever.java
@@ -39,13 +39,13 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class LocalFsJobStatusRetriever extends JobStatusRetriever {
 
-  public static final String CONF_PREFIX = "localFsJobStatusRetriever";
+  public static final String CONF_PREFIX = "localFsJobStatusRetriever.";
   private String JOB_DONE_SUFFIX = ".done";
   private String specProducerPath;
 
   // Do not use a state store for this implementation, just look at the job folder that @LocalFsSpecProducer writes to
   public LocalFsJobStatusRetriever(Config config) {
-    this.specProducerPath = config.getString(LocalFsSpecProducer.LOCAL_FS_PRODUCER_PATH_KEY);
+    this.specProducerPath = config.getString(CONF_PREFIX + LocalFsSpecProducer.LOCAL_FS_PRODUCER_PATH_KEY);
   }
 
   private Boolean doesJobExist(String flowName, String flowGroup, long flowExecutionId, String suffix) {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-988


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

Currently GaaS only supports job statuses being emitted from Kafka
Create a simple mechanism to track job statuses that are completed in gobblin standalone. This is to be used in the GaaS K8s cluster as a sample.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

