### PR TITLE
GOBBLIN-1002: Set state id when deserializing state from Gobblin stat…

### DIFF
--- a/gobblin-metastore/src/main/java/org/apache/gobblin/metastore/FsStateStore.java
+++ b/gobblin-metastore/src/main/java/org/apache/gobblin/metastore/FsStateStore.java
@@ -238,6 +238,7 @@ public class FsStateStore<T extends State> implements StateStore<T> {
         while (reader.next(key)) {
           state = (T)reader.getCurrentValue(state);
           if (key.toString().equals(stateId)) {
+            state.setId(stateId);
             return state;
           }
         }
@@ -272,6 +273,7 @@ public class FsStateStore<T extends State> implements StateStore<T> {
         T state = this.stateClass.newInstance();
         while (reader.next(key)) {
           state = (T)reader.getCurrentValue(state);
+          state.setId(key.toString());
           states.add(state);
           // We need a new object for each read state
           state = this.stateClass.newInstance();

--- a/gobblin-metastore/src/main/java/org/apache/gobblin/metastore/MysqlStateStore.java
+++ b/gobblin-metastore/src/main/java/org/apache/gobblin/metastore/MysqlStateStore.java
@@ -47,6 +47,8 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.typesafe.config.Config;
 
+import javax.sql.DataSource;
+
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.metastore.metadata.StateStoreEntryManager;
@@ -55,8 +57,6 @@ import org.apache.gobblin.metastore.predicates.StoreNamePredicate;
 import org.apache.gobblin.password.PasswordManager;
 import org.apache.gobblin.util.ConfigUtils;
 import org.apache.gobblin.util.io.StreamUtils;
-
-import javax.sql.DataSource;
 
 /**
  * An implementation of {@link StateStore} backed by MySQL.
@@ -312,7 +312,7 @@ public class MysqlStateStore<T extends State> implements StateStore<T> {
 
               key.readFields(dis);
               state.readFields(dis);
-
+              state.setId(key.toString());
               if (key.toString().equals(stateId)) {
                 return state;
               }
@@ -395,8 +395,9 @@ public class MysqlStateStore<T extends State> implements StateStore<T> {
           // keep deserializing while we have data
           while (dis.available() > 0) {
             T state = this.stateClass.newInstance();
-            key.readString(dis);
+            String stateId = key.readString(dis);
             state.readFields(dis);
+            state.setId(stateId);
             states.add(state);
           }
         } catch (EOFException e) {

--- a/gobblin-metastore/src/test/java/org/apache/gobblin/metastore/FsStateStoreTest.java
+++ b/gobblin-metastore/src/test/java/org/apache/gobblin/metastore/FsStateStoreTest.java
@@ -103,8 +103,11 @@ public class FsStateStoreTest {
     Assert.assertEquals(states.size(), 3);
 
     Assert.assertEquals(states.get(0).getProp("k1"), "v1");
+    Assert.assertEquals(states.get(0).getId(),  "s1");
     Assert.assertEquals(states.get(1).getProp("k2"), "v2");
+    Assert.assertEquals(states.get(1).getId(),  "s2");
     Assert.assertEquals(states.get(2).getProp("k3"), "v3");
+    Assert.assertEquals(states.get(2).getId(),  "s3");
   }
 
   @Test(dependsOnMethods = { "testPut" })
@@ -119,8 +122,11 @@ public class FsStateStoreTest {
     Assert.assertEquals(states.size(), 3);
 
     Assert.assertEquals(states.get(0).getProp("k1"), "v1");
+    Assert.assertEquals(states.get(0).getId(),  "s1");
     Assert.assertEquals(states.get(1).getProp("k2"), "v2");
+    Assert.assertEquals(states.get(1).getId(),  "s2");
     Assert.assertEquals(states.get(2).getProp("k3"), "v3");
+    Assert.assertEquals(states.get(2).getId(),  "s3");
   }
 
   @Test(dependsOnMethods = { "testGetAlias" })
@@ -152,8 +158,11 @@ public class FsStateStoreTest {
     Assert.assertEquals(states.size(), 3);
 
     Assert.assertEquals(states.get(0).getProp("k1"), "v1");
+    Assert.assertEquals(states.get(0).getId(),  "s1");
     Assert.assertEquals(states.get(1).getProp("k2"), "v2");
+    Assert.assertEquals(states.get(1).getId(),  "s2");
     Assert.assertEquals(states.get(2).getProp("k3"), "v3");
+    Assert.assertEquals(states.get(2).getId(),  "s3");
   }
 
   @AfterClass

--- a/gobblin-modules/gobblin-helix/src/main/java/org/apache/gobblin/metastore/ZkStateStore.java
+++ b/gobblin-modules/gobblin-helix/src/main/java/org/apache/gobblin/metastore/ZkStateStore.java
@@ -322,6 +322,7 @@ public class ZkStateStore<T extends State> implements StateStore<T> {
 
           key.readFields(dis);
           state.readFields(dis);
+          state.setId(key.toString());
           states.add(state);
 
           if (stateId != null && key.toString().equals(stateId)) {

--- a/gobblin-modules/gobblin-helix/src/test/java/org/apache/gobblin/runtime/ZkDatasetStateStoreTest.java
+++ b/gobblin-modules/gobblin-helix/src/test/java/org/apache/gobblin/runtime/ZkDatasetStateStoreTest.java
@@ -121,6 +121,7 @@ public class ZkDatasetStateStoreTest {
         zkDatasetStateStore.CURRENT_DATASET_STATE_FILE_SUFFIX + zkDatasetStateStore.DATASET_STATE_STORE_TABLE_SUFFIX,
         TEST_JOB_ID);
 
+    Assert.assertEquals(jobState.getId(), TEST_JOB_ID);
     Assert.assertEquals(jobState.getJobName(), TEST_JOB_NAME);
     Assert.assertEquals(jobState.getJobId(), TEST_JOB_ID);
     Assert.assertEquals(jobState.getState(), JobState.RunningState.COMMITTED);
@@ -184,6 +185,7 @@ public class ZkDatasetStateStoreTest {
     Assert.assertEquals(datasetState.getStartTime(), this.startTime);
     Assert.assertEquals(datasetState.getEndTime(), this.startTime + 1000);
     Assert.assertEquals(datasetState.getDuration(), 1000);
+    Assert.assertEquals(datasetState.getId(), TEST_DATASET_URN);
 
     Assert.assertEquals(datasetState.getCompletedTasks(), 3);
     for (int i = 0; i < datasetState.getCompletedTasks(); i++) {
@@ -219,6 +221,7 @@ public class ZkDatasetStateStoreTest {
     Assert.assertEquals(datasetStatesByUrns.size(), 2);
 
     JobState.DatasetState datasetState = datasetStatesByUrns.get(TEST_DATASET_URN);
+    Assert.assertEquals(datasetState.getId(), TEST_DATASET_URN);
     Assert.assertEquals(datasetState.getDatasetUrn(), TEST_DATASET_URN);
     Assert.assertEquals(datasetState.getJobName(), TEST_JOB_NAME);
     Assert.assertEquals(datasetState.getJobId(), TEST_JOB_ID);
@@ -228,6 +231,7 @@ public class ZkDatasetStateStoreTest {
     Assert.assertEquals(datasetState.getDuration(), 1000);
 
     datasetState = datasetStatesByUrns.get(TEST_DATASET_URN2);
+    Assert.assertEquals(datasetState.getId(), TEST_DATASET_URN2);
     Assert.assertEquals(datasetState.getDatasetUrn(), TEST_DATASET_URN2);
     Assert.assertEquals(datasetState.getJobName(), TEST_JOB_NAME);
     Assert.assertEquals(datasetState.getJobId(), TEST_JOB_ID);

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/CheckpointableWatermarkState.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/CheckpointableWatermarkState.java
@@ -39,6 +39,10 @@ public class CheckpointableWatermarkState extends State {
     super.setId(watermark.getSource());
   }
 
+  public String getSource() {
+    return getId();
+  }
+
   /**
    * Needed for reflection based construction.
    */

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/MysqlDatasetStateStoreTest.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/MysqlDatasetStateStoreTest.java
@@ -141,6 +141,7 @@ public class MysqlDatasetStateStoreTest {
         dbDatasetStateStore.CURRENT_DATASET_STATE_FILE_SUFFIX + dbDatasetStateStore.DATASET_STATE_STORE_TABLE_SUFFIX,
         TEST_JOB_ID);
 
+    Assert.assertEquals(jobState.getId(), TEST_JOB_ID);
     Assert.assertEquals(jobState.getJobName(), TEST_JOB_NAME);
     Assert.assertEquals(jobState.getJobId(), TEST_JOB_ID);
     Assert.assertEquals(jobState.getProp("foo"), "bar");
@@ -163,6 +164,7 @@ public class MysqlDatasetStateStoreTest {
         dbDatasetStateStore.CURRENT_DATASET_STATE_FILE_SUFFIX + dbDatasetStateStore.DATASET_STATE_STORE_TABLE_SUFFIX,
         TEST_JOB_ID);
 
+    Assert.assertEquals(jobState.getId(), TEST_JOB_ID);
     Assert.assertEquals(jobState.getJobName(), TEST_JOB_NAME_LOWER);
     Assert.assertEquals(jobState.getJobId(), TEST_JOB_ID);
     Assert.assertEquals(jobState.getProp("foo"), "bar");
@@ -200,7 +202,7 @@ public class MysqlDatasetStateStoreTest {
 
     // persist a colliding lowercase dataset state to test that retrieval is case sensitive
     datasetState.setDatasetUrn(TEST_DATASET_URN_LOWER);
-    datasetState.setId(TEST_DATASET_URN_LOWER );
+    datasetState.setId(TEST_DATASET_URN_LOWER);
     datasetState.setDuration(3000);
 
     dbDatasetStateStore.persistDatasetState(TEST_DATASET_URN_LOWER, datasetState);
@@ -215,6 +217,7 @@ public class MysqlDatasetStateStoreTest {
     JobState.DatasetState datasetState =
         dbDatasetStateStore.getLatestDatasetState(TEST_JOB_NAME, TEST_DATASET_URN);
 
+    Assert.assertEquals(datasetState.getId(), TEST_DATASET_URN);
     Assert.assertEquals(datasetState.getDatasetUrn(), TEST_DATASET_URN);
     Assert.assertEquals(datasetState.getJobName(), TEST_JOB_NAME);
     Assert.assertEquals(datasetState.getJobId(), TEST_JOB_ID);
@@ -259,6 +262,7 @@ public class MysqlDatasetStateStoreTest {
     Assert.assertEquals(datasetStatesByUrns.size(), 3);
 
     JobState.DatasetState datasetState = datasetStatesByUrns.get(TEST_DATASET_URN);
+    Assert.assertEquals(datasetState.getId(), TEST_DATASET_URN);
     Assert.assertEquals(datasetState.getDatasetUrn(), TEST_DATASET_URN);
     Assert.assertEquals(datasetState.getJobName(), TEST_JOB_NAME);
     Assert.assertEquals(datasetState.getJobId(), TEST_JOB_ID);
@@ -268,6 +272,7 @@ public class MysqlDatasetStateStoreTest {
     Assert.assertEquals(datasetState.getDuration(), 1000);
 
     datasetState = datasetStatesByUrns.get(TEST_DATASET_URN2);
+    Assert.assertEquals(datasetState.getId(), TEST_DATASET_URN2);
     Assert.assertEquals(datasetState.getDatasetUrn(), TEST_DATASET_URN2);
     Assert.assertEquals(datasetState.getJobName(), TEST_JOB_NAME);
     Assert.assertEquals(datasetState.getJobId(), TEST_JOB_ID);
@@ -277,6 +282,7 @@ public class MysqlDatasetStateStoreTest {
     Assert.assertEquals(datasetState.getDuration(), 2000);
 
     datasetState = datasetStatesByUrns.get(TEST_DATASET_URN_LOWER);
+    Assert.assertEquals(datasetState.getId(), TEST_DATASET_URN_LOWER);
     Assert.assertEquals(datasetState.getDatasetUrn(), TEST_DATASET_URN_LOWER);
     Assert.assertEquals(datasetState.getJobName(), TEST_JOB_NAME);
     Assert.assertEquals(datasetState.getJobId(), TEST_JOB_ID);


### PR DESCRIPTION
…e store

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1002


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Current behavior returns the deserialized state without setting the state id member field. 



### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Enhanced unit tests for all state store implementations to validate the returned state id.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

