### PR TITLE
[GOBBLIN-1004] Downgrade Helix version at compile time to fix slf4j dependency

### DIFF
--- a/gobblin-cluster/build.gradle
+++ b/gobblin-cluster/build.gradle
@@ -51,7 +51,6 @@ dependencies {
   compile externalDependency.helix
 
   runtime project(":gobblin-modules:gobblin-service-kafka")
-  runtime "org.apache.helix:helix-core:0.9.1"
 
   testCompile project(":gobblin-example")
 

--- a/gobblin-cluster/build.gradle
+++ b/gobblin-cluster/build.gradle
@@ -51,6 +51,7 @@ dependencies {
   compile externalDependency.helix
 
   runtime project(":gobblin-modules:gobblin-service-kafka")
+  runtime "org.apache.helix:helix-core:0.9.1"
 
   testCompile project(":gobblin-example")
 

--- a/gradle/scripts/dependencyDefinitions.gradle
+++ b/gradle/scripts/dependencyDefinitions.gradle
@@ -62,7 +62,7 @@ ext.externalDependency = [
     "hadoopYarnMiniCluster": "org.apache.hadoop:hadoop-minicluster:" + hadoopVersion,
     "hadoopAnnotations": "org.apache.hadoop:hadoop-annotations:" + hadoopVersion,
     "hadoopAws": "org.apache.hadoop:hadoop-aws:2.6.0",
-    "helix": "org.apache.helix:helix-core:0.9.1",
+    "helix": "org.apache.helix:helix-core:0.8.2",
     "hiveCommon": "org.apache.hive:hive-common:" + hiveVersion,
     "hiveService": "org.apache.hive:hive-service:" + hiveVersion,
     "hiveJdbc": "org.apache.hive:hive-jdbc:" + hiveVersion,


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

The current version of Helix introduces a transitive dependency of slf4j (1.7.25) that is not backwards compatible with the current slf4j that is used (1.7.21).

The PR bumps down Apache Helix from 0.9.1 to 0.8.2
### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-XXX


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

