### PR TITLE
[GOBBLIN-1006] Enable configurable case-preserving and schema source-of-truth in table level properties

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/converter/AbstractAvroToOrcConverter.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/converter/AbstractAvroToOrcConverter.java
@@ -446,7 +446,7 @@ public abstract class AbstractAvroToOrcConverter extends Converter<Schema, Schem
     }
 
     // Step:
-    // A.2.1: If table pre-exists (destinationTableMeta would be present), evolve table
+    // A.2.1: If table pre-exists (destinationTableMeta would be present), evolve table and update table properties
     // B.2.1: No-op
     List<String> evolutionDDLs = HiveAvroORCQueryGenerator.generateEvolutionDDL(orcStagingTableName,
         orcTableName,
@@ -455,7 +455,8 @@ public abstract class AbstractAvroToOrcConverter extends Converter<Schema, Schem
         outputAvroSchema,
         isEvolutionEnabled,
         hiveColumns,
-        destinationTableMeta);
+        destinationTableMeta,
+        tableProperties);
     log.debug("Evolve final table DDLs: " + evolutionDDLs);
     EventWorkunitUtils.setEvolutionMetadata(workUnit, evolutionDDLs);
 

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/converter/AbstractAvroToOrcConverter.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/converter/AbstractAvroToOrcConverter.java
@@ -222,6 +222,7 @@ public abstract class AbstractAvroToOrcConverter extends Converter<Schema, Schem
     String orcDataLocation = getOrcDataLocation();
     String orcStagingDataLocation = getOrcStagingDataLocation(orcStagingTableName);
     boolean isEvolutionEnabled = getConversionConfig().isEvolutionEnabled();
+    boolean isCasePreserved = getConversionConfig().isCasePreserved();
     Pair<Optional<Table>, Optional<List<Partition>>> destinationMeta = HiveConverterUtils.getDestinationTableMeta(orcTableDatabase,
         orcTableName, workUnit.getProperties());
     Optional<Table> destinationTableMeta = destinationMeta.getLeft();
@@ -346,6 +347,7 @@ public abstract class AbstractAvroToOrcConverter extends Converter<Schema, Schem
             Optional.<String>absent(),
             tableProperties,
             isEvolutionEnabled,
+            isCasePreserved,
             destinationTableMeta,
             hiveColumns);
     conversionEntity.getQueries().add(createStagingTableDDL);
@@ -435,6 +437,7 @@ public abstract class AbstractAvroToOrcConverter extends Converter<Schema, Schem
               Optional.<String>absent(),
               Optional.<String>absent(),
               tableProperties,
+              isCasePreserved,
               isEvolutionEnabled,
               destinationTableMeta,
               new HashMap<String, String>());

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/entities/StageableTableMetadata.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/entities/StageableTableMetadata.java
@@ -100,7 +100,7 @@ public class StageableTableMetadata {
 
   /**
    * Attributes like "avro.schema.literal" are usually used in offline system as the source-of-truth of schema.
-   * This configuration's value should the key name that users expects to preserve to schema string if necessary.
+   * This configuration's value should be the key name that users expects to preserve to schema string if necessary.
    */
   public static final String SCHEMA_SOURCE_OF_TRUTH = "schema.sourceOfTruth";
 

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/entities/StageableTableMetadata.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/entities/StageableTableMetadata.java
@@ -53,6 +53,12 @@ public class StageableTableMetadata {
   public static final String ROW_LIMIT_KEY = "rowLimit";
   public static final String HIVE_VERSION_KEY = "hiveVersion";
   public static final String HIVE_RUNTIME_PROPERTIES_LIST_KEY = "hiveRuntimeProperties";
+
+  /**
+   * The output of Hive-based conversion can preserve casing in ORC-writer if "columns" and "columns.types" are being set
+   * in table-level properties. Turning this off by-default as Hive engine itself doesn't preserve the case.
+   */
+  public static final String OUTPUT_FILE_CASE_PRESERVED = "casePreserved";
   /***
    * Comma separated list of string that should be used as a prefix for destination partition directory name
    * ... (if present in the location path string of source partition)
@@ -92,6 +98,12 @@ public class StageableTableMetadata {
    */
   public static final String SOURCE_DATA_PATH_IDENTIFIER_KEY = "source.dataPathIdentifier";
 
+  /**
+   * Attributes like "avro.schema.literal" are usually used in offline system as the source-of-truth of schema.
+   * This configuration's value should the key name that users expects to preserve to schema string if necessary.
+   */
+  public static final String SCHEMA_SOURCE_OF_TRUTH = "schema.sourceOfTruth";
+
 
   /** Table name of the destination table. */
   private final String destinationTableName;
@@ -109,6 +121,7 @@ public class StageableTableMetadata {
   private final Optional<Integer> numBuckets;
   private final Properties hiveRuntimeProperties;
   private final boolean evolutionEnabled;
+  private final boolean casePreserved;
   private final Optional<Integer> rowLimit;
   private final List<String> sourceDataPathIdentifier;
 
@@ -136,6 +149,7 @@ public class StageableTableMetadata {
     this.hiveRuntimeProperties =
         convertKeyValueListToProperties(ConfigUtils.getStringList(config, HIVE_RUNTIME_PROPERTIES_LIST_KEY));
     this.evolutionEnabled = ConfigUtils.getBoolean(config, EVOLUTION_ENABLED, false);
+    this.casePreserved = ConfigUtils.getBoolean(config, OUTPUT_FILE_CASE_PRESERVED, false);
     this.rowLimit = Optional.fromNullable(ConfigUtils.getInt(config, ROW_LIMIT_KEY, null));
     this.sourceDataPathIdentifier = ConfigUtils.getStringList(config, SOURCE_DATA_PATH_IDENTIFIER_KEY);
   }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/entities/StageableTableMetadata.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/entities/StageableTableMetadata.java
@@ -102,7 +102,7 @@ public class StageableTableMetadata {
    * Attributes like "avro.schema.literal" are usually used in offline system as the source-of-truth of schema.
    * This configuration's value should be the key name that users expects to preserve to schema string if necessary.
    */
-  public static final String SCHEMA_SOURCE_OF_TRUTH = "schema.sourceOfTruth";
+  public static final String SCHEMA_SOURCE_OF_TRUTH = "schema.original";
 
 
   /** Table name of the destination table. */

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/entities/TableLikeStageableTableMetadata.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/entities/TableLikeStageableTableMetadata.java
@@ -34,7 +34,7 @@ public class TableLikeStageableTableMetadata extends StageableTableMetadata {
 
   public TableLikeStageableTableMetadata(Table referenceTable, String destinationDB, String destinationTableName, String targetDataPath) {
     super(destinationTableName, destinationTableName + "_STAGING", destinationDB, targetDataPath,
-        getTableProperties(referenceTable), new ArrayList<>(), Optional.of(referenceTable.getNumBuckets()), new Properties(), false, Optional.absent(),
+        getTableProperties(referenceTable), new ArrayList<>(), Optional.of(referenceTable.getNumBuckets()), new Properties(), false, false, Optional.absent(),
         new ArrayList<>());
   }
 
@@ -44,7 +44,7 @@ public class TableLikeStageableTableMetadata extends StageableTableMetadata {
         HiveDataset.resolveTemplate(config.getString(StageableTableMetadata.DESTINATION_DB_KEY), referenceTable),
         HiveDataset.resolveTemplate(config.getString(DESTINATION_DATA_PATH_KEY), referenceTable),
         getTableProperties(referenceTable), new ArrayList<>(), Optional.of(referenceTable.getNumBuckets()),
-        new Properties(), false, Optional.absent(), new ArrayList<>());
+        new Properties(), false, false, Optional.absent(), new ArrayList<>());
   }
 
   private static Properties getTableProperties(Table table) {

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/conversion/hive/converter/HiveSchemaEvolutionTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/conversion/hive/converter/HiveSchemaEvolutionTest.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -216,10 +217,12 @@ public class HiveSchemaEvolutionTest {
         null, isEvolutionEnabled, true, destinationTableMeta, hiveColumns);
 
     // Destination table exists
+    Properties tableProperties = new Properties();
+    tableProperties.setProperty("random", "value");
     List<String> generateEvolutionDDL = HiveAvroORCQueryGenerator
         .generateEvolutionDDL(orcStagingTableName, orcTableName, Optional.of(hiveDbName), Optional.of(hiveDbName),
-            outputSchema, isEvolutionEnabled, hiveColumns, destinationTableMeta);
-    Assert.assertEquals(generateEvolutionDDL.size(), 2);
+            outputSchema, isEvolutionEnabled, hiveColumns, destinationTableMeta, tableProperties);
+    Assert.assertEquals(generateEvolutionDDL.size(), 4);
     Assert.assertEquals(generateEvolutionDDL.get(1),
         "ALTER TABLE `sourceSchema` ADD COLUMNS (`parentFieldRecord__nestedFieldInt` int "
             + "COMMENT 'from flatten_source parentFieldRecord.nestedFieldInt')",
@@ -229,7 +232,7 @@ public class HiveSchemaEvolutionTest {
     destinationTableMeta = Optional.absent();
     generateEvolutionDDL = HiveAvroORCQueryGenerator
         .generateEvolutionDDL(orcStagingTableName, orcTableName, Optional.of(hiveDbName), Optional.of(hiveDbName),
-            outputSchema, isEvolutionEnabled, hiveColumns, destinationTableMeta);
+            outputSchema, isEvolutionEnabled, hiveColumns, destinationTableMeta, tableProperties);
     // No DDL should be generated, because create table will take care of destination table
     Assert.assertEquals(generateEvolutionDDL.size(), 0,
         "Generated evolution DDL did not match for evolution enabled");
@@ -251,9 +254,11 @@ public class HiveSchemaEvolutionTest {
         null, isEvolutionEnabled, true, destinationTableMeta, hiveColumns);
 
     // Destination table exists
+    Properties tableProperties = new Properties();
+    tableProperties.setProperty("random", "value");
     List<String> generateEvolutionDDL = HiveAvroORCQueryGenerator
         .generateEvolutionDDL(orcStagingTableName, orcTableName, Optional.of(hiveDbName), Optional.of(hiveDbName),
-            outputSchema, isEvolutionEnabled, hiveColumns, destinationTableMeta);
+            outputSchema, isEvolutionEnabled, hiveColumns, destinationTableMeta, tableProperties);
     // No DDL should be generated, because select based on destination table will selectively project columns
     Assert.assertEquals(generateEvolutionDDL.size(), 0,
         "Generated evolution DDL did not match for evolution disabled");
@@ -262,7 +267,7 @@ public class HiveSchemaEvolutionTest {
     destinationTableMeta = Optional.absent();
     generateEvolutionDDL = HiveAvroORCQueryGenerator
         .generateEvolutionDDL(orcStagingTableName, orcTableName, Optional.of(hiveDbName), Optional.of(hiveDbName),
-            outputSchema, isEvolutionEnabled, hiveColumns, destinationTableMeta);
+            outputSchema, isEvolutionEnabled, hiveColumns, destinationTableMeta, tableProperties);
     // No DDL should be generated, because create table will take care of destination table
     Assert.assertEquals(generateEvolutionDDL.size(), 0,
         "Generated evolution DDL did not match for evolution disabled");

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/conversion/hive/converter/HiveSchemaEvolutionTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/conversion/hive/converter/HiveSchemaEvolutionTest.java
@@ -76,7 +76,7 @@ public class HiveSchemaEvolutionTest {
             Optional.<String>absent(), Optional.<Map<String, String>>absent(), Optional.<List<String>>absent(),
             Optional.<Map<String, HiveAvroORCQueryGenerator.COLUMN_SORT_ORDER>>absent(), Optional.<Integer>absent(),
             Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent(),
-            null, isEvolutionEnabled, destinationTableMeta,
+            null, isEvolutionEnabled, true, destinationTableMeta,
             new HashMap<String, String>());
 
     Assert.assertEquals(ddl, ConversionHiveTestUtils.readQueryFromFile(resourceDir,
@@ -101,7 +101,7 @@ public class HiveSchemaEvolutionTest {
             Optional.<String>absent(), Optional.<Map<String, String>>absent(), Optional.<List<String>>absent(),
             Optional.<Map<String, HiveAvroORCQueryGenerator.COLUMN_SORT_ORDER>>absent(), Optional.<Integer>absent(),
             Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent(),
-            null, isEvolutionEnabled, destinationTableMeta,
+            null, isEvolutionEnabled, true, destinationTableMeta,
             new HashMap<String, String>());
 
     Assert.assertEquals(ddl, ConversionHiveTestUtils.readQueryFromFile(resourceDir,
@@ -121,6 +121,7 @@ public class HiveSchemaEvolutionTest {
   @Test
   public void testEvolutionDisabledForExistingTable() throws IOException {
     boolean isEvolutionEnabled = false;
+    boolean casePreserved = true;
     Optional<Table> destinationTableMeta = createEvolvedDestinationTable(schemaName, "default", "", true);
 
     String ddl = HiveAvroORCQueryGenerator
@@ -128,7 +129,7 @@ public class HiveSchemaEvolutionTest {
             Optional.<String>absent(), Optional.<Map<String, String>>absent(), Optional.<List<String>>absent(),
             Optional.<Map<String, HiveAvroORCQueryGenerator.COLUMN_SORT_ORDER>>absent(), Optional.<Integer>absent(),
             Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent(),
-            null, isEvolutionEnabled, destinationTableMeta,
+            null, isEvolutionEnabled, casePreserved, destinationTableMeta,
             new HashMap<String, String>());
 
     Assert.assertEquals(ddl, ConversionHiveTestUtils.readQueryFromFile(resourceDir,
@@ -155,7 +156,7 @@ public class HiveSchemaEvolutionTest {
             Optional.<String>absent(), Optional.<Map<String, String>>absent(), Optional.<List<String>>absent(),
             Optional.<Map<String, HiveAvroORCQueryGenerator.COLUMN_SORT_ORDER>>absent(), Optional.<Integer>absent(),
             Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent(),
-            null, isEvolutionEnabled, destinationTableMeta,
+            null, isEvolutionEnabled, true, destinationTableMeta,
             new HashMap<String, String>());
 
     Assert.assertEquals(ddl, ConversionHiveTestUtils.readQueryFromFile(resourceDir,
@@ -182,7 +183,7 @@ public class HiveSchemaEvolutionTest {
             Optional.<String>absent(), Optional.<Map<String, String>>absent(), Optional.<List<String>>absent(),
             Optional.<Map<String, HiveAvroORCQueryGenerator.COLUMN_SORT_ORDER>>absent(), Optional.<Integer>absent(),
             Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent(),
-            null, isEvolutionEnabled, destinationTableMeta,
+            null, isEvolutionEnabled, true, destinationTableMeta,
             new HashMap<String, String>());
 
     Assert.assertEquals(ddl, ConversionHiveTestUtils.readQueryFromFile(resourceDir,
@@ -212,7 +213,7 @@ public class HiveSchemaEvolutionTest {
         Optional.<Map<String, String>>absent(), Optional.<List<String>>absent(),
         Optional.<Map<String, HiveAvroORCQueryGenerator.COLUMN_SORT_ORDER>>absent(), Optional.<Integer>absent(),
         Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent(),
-        null, isEvolutionEnabled, destinationTableMeta, hiveColumns);
+        null, isEvolutionEnabled, true, destinationTableMeta, hiveColumns);
 
     // Destination table exists
     List<String> generateEvolutionDDL = HiveAvroORCQueryGenerator
@@ -247,7 +248,7 @@ public class HiveSchemaEvolutionTest {
         Optional.<Map<String, String>>absent(), Optional.<List<String>>absent(),
         Optional.<Map<String, HiveAvroORCQueryGenerator.COLUMN_SORT_ORDER>>absent(), Optional.<Integer>absent(),
         Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent(),
-        null, isEvolutionEnabled, destinationTableMeta, hiveColumns);
+        null, isEvolutionEnabled, true, destinationTableMeta, hiveColumns);
 
     // Destination table exists
     List<String> generateEvolutionDDL = HiveAvroORCQueryGenerator

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/conversion/hive/task/HiveConverterUtilsTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/conversion/hive/task/HiveConverterUtilsTest.java
@@ -19,11 +19,16 @@ package org.apache.gobblin.data.management.conversion.hive.task;
 
 import java.util.Map;
 
+import org.apache.avro.Schema;
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Test;
 import org.testng.Assert;
 import org.testng.collections.Maps;
 
 import com.google.common.base.Optional;
+
+import static org.apache.gobblin.data.management.conversion.hive.task.HiveConverterUtils.getORCSchemaPropsFromAvroSchema;
+
 
 public class HiveConverterUtilsTest {
   private final String inputDbName = "testdb";

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/conversion/hive/util/HiveAvroORCQueryGeneratorTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/conversion/hive/util/HiveAvroORCQueryGeneratorTest.java
@@ -60,7 +60,7 @@ public class HiveAvroORCQueryGeneratorTest {
             Optional.<String>absent(), Optional.<Map<String, String>>absent(), Optional.<List<String>>absent(),
             Optional.<Map<String, HiveAvroORCQueryGenerator.COLUMN_SORT_ORDER>>absent(), Optional.<Integer>absent(),
             Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent(),
-            null, isEvolutionEnabled, destinationTableMeta,
+            null, isEvolutionEnabled, true, destinationTableMeta,
             new HashMap<String, String>());
 
     Assert.assertEquals(q,
@@ -82,7 +82,7 @@ public class HiveAvroORCQueryGeneratorTest {
             Optional.<String>absent(), Optional.<Map<String, String>>absent(), Optional.<List<String>>absent(),
             Optional.<Map<String, HiveAvroORCQueryGenerator.COLUMN_SORT_ORDER>>absent(), Optional.<Integer>absent(),
             Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent(),
-            null, isEvolutionEnabled, destinationTableMeta,
+            null, isEvolutionEnabled, true, destinationTableMeta,
             new HashMap<String, String>());
 
     Assert.assertEquals(q,
@@ -104,7 +104,7 @@ public class HiveAvroORCQueryGeneratorTest {
             Optional.<String>absent(), Optional.<Map<String, String>>absent(), Optional.<List<String>>absent(),
             Optional.<Map<String, HiveAvroORCQueryGenerator.COLUMN_SORT_ORDER>>absent(), Optional.<Integer>absent(),
             Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent(),
-            null, isEvolutionEnabled, destinationTableMeta,
+            null, isEvolutionEnabled, true, destinationTableMeta,
             new HashMap<String, String>());
 
     Assert.assertEquals(q.trim(),
@@ -126,7 +126,7 @@ public class HiveAvroORCQueryGeneratorTest {
             Optional.<String>absent(), Optional.<Map<String, String>>absent(), Optional.<List<String>>absent(),
             Optional.<Map<String, HiveAvroORCQueryGenerator.COLUMN_SORT_ORDER>>absent(), Optional.<Integer>absent(),
             Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent(),
-            null, isEvolutionEnabled, destinationTableMeta,
+            null, isEvolutionEnabled, true, destinationTableMeta,
             new HashMap<String, String>());
 
     Assert.assertEquals(q.trim(),
@@ -149,7 +149,7 @@ public class HiveAvroORCQueryGeneratorTest {
         .generateCreateTableDDL(flattenedSchema, schemaName, "file:/user/hive/warehouse/" + schemaName,
             Optional.<String>absent(), Optional.<Map<String, String>>absent(), Optional.<List<String>>absent(),
             Optional.<Map<String, HiveAvroORCQueryGenerator.COLUMN_SORT_ORDER>>absent(), Optional.<Integer>absent(),
-            Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent(), null, isEvolutionEnabled,
+            Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent(), null, isEvolutionEnabled, true,
             destinationTableMeta, new HashMap<String, String>());
 
     Assert.assertEquals(q,
@@ -196,7 +196,7 @@ public class HiveAvroORCQueryGeneratorTest {
         .generateCreateTableDDL(flattenedSchema, schemaName, "file:/user/hive/warehouse/" + schemaName,
             Optional.<String>absent(), Optional.of(partitionDDLInfo), Optional.<List<String>>absent(),
             Optional.<Map<String, HiveAvroORCQueryGenerator.COLUMN_SORT_ORDER>>absent(), Optional.<Integer>absent(),
-            Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent(), null, isEvolutionEnabled,
+            Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent(), null, isEvolutionEnabled, true,
             destinationTableMeta, new HashMap<String, String>());
 
     Assert.assertEquals(q,
@@ -239,7 +239,7 @@ public class HiveAvroORCQueryGeneratorTest {
         .generateCreateTableDDL(schema, schemaName, "file:/user/hive/warehouse/" + schemaName,
             Optional.<String>absent(), Optional.<Map<String, String>>absent(), Optional.<List<String>>absent(),
             Optional.<Map<String, HiveAvroORCQueryGenerator.COLUMN_SORT_ORDER>>absent(), Optional.<Integer>absent(),
-            Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent(), null, isEvolutionEnabled,
+            Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent(), null, isEvolutionEnabled, true,
             destinationTableMeta, new HashMap<String, String>());
   }
 

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/AvroUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/AvroUtils.java
@@ -856,6 +856,15 @@ public class AvroUtils {
   }
 
   /**
+   * Escaping ";" and "'" character in the schema string when it is being used in DDL.
+   * These characters are not allowed to show as part of column name but could possibly appear in documentation field.
+   * Therefore the escaping behavior won't cause correctness issues.
+   */
+  public static String sanitizeSchemaString(String schemaString) {
+    return schemaString.replaceAll(";",  "\\\\;").replaceAll("'", "\\\\'");
+  }
+
+  /**
    * Deserialize a {@link GenericRecord} from a byte array. This method is not intended for high performance.
    */
   public static GenericRecord slowDeserializeGenericRecord(byte[] serializedRecord, Schema schema) throws IOException {

--- a/gobblin-utility/src/test/java/org/apache/gobblin/util/AvroUtilsTest.java
+++ b/gobblin-utility/src/test/java/org/apache/gobblin/util/AvroUtilsTest.java
@@ -264,6 +264,16 @@ public class AvroUtilsTest {
     Assert.assertEquals(AvroUtils.serializeAsPath(partition, false, false), new Path("a/b_c_d_e/title"));
   }
 
+  @Test
+  public void testStringEscaping() {
+    String invalidString = "foo;foo'bar";
+    String expectedString = "foo\\;foo\\'bar";
+    String actualString = AvroUtils.sanitizeSchemaString(invalidString);
+    Assert.assertEquals(actualString, expectedString);
+    // Verify that there's only one slash being added.
+    Assert.assertEquals(actualString.length(), invalidString.length() + 2);
+  }
+
   public static List<GenericRecord> getRecordFromFile(String path)
       throws IOException {
     Configuration config = new Configuration();


### PR DESCRIPTION
Dear Gobblin maintainers,

Two changes: 
- By setting `<PREFIX>.destination.tableProperties.schema.sourceOfTruth,avro.schema.literal` for example, we could have conversion output table have the ultimate Avro-type schema for offline-system to leverage, since ORC schema tends to be lossy. 
- Make the case-preservation configurable since it is not applicable for all use-cases and we will need to maintain backward-compatibility for legacy datasets. 


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1006


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

