### PR TITLE
[GOBBLIN-1007] Unknown system variable 'query_cache_type' when using MySQL 8 as the state store

### DIFF
--- a/gradle/scripts/dependencyDefinitions.gradle
+++ b/gradle/scripts/dependencyDefinitions.gradle
@@ -100,7 +100,7 @@ ext.externalDependency = [
     "jdo2": "javax.jdo:jdo2-api:2.1",
     "azkaban": "com.linkedin.azkaban:azkaban:2.5.0",
     "commonsVfs": "org.apache.commons:commons-vfs2:2.0",
-    "mysqlConnector": "mysql:mysql-connector-java:5.1.38",
+    "mysqlConnector": "mysql:mysql-connector-java:5.1.44",
     "javaxInject": "javax.inject:javax.inject:1",
     "guice": "com.google.inject:guice:4.0",
     "guiceServlet": "com.google.inject.extensions:guice-servlet:4.0",


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-1007] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1007


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):


### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

