### PR TITLE
[GOBBLIN-1013] Fix prepare_release_config build step on Windows

### DIFF
--- a/gradle/scripts/release.gradle
+++ b/gradle/scripts/release.gradle
@@ -34,17 +34,19 @@ println String.format("Release Version: %s", releaseVersion)
 // Modify the gradle.properties to indicate whether this is a release.  This results in the
 // source releases generating artifacts without -SNAPSHOT appended to the version when they are
 // built.
-task prepare_release_config(type: Copy) {
-    from "$rootDir/gradle.properties"
-    into "$rootDir"
-    rename { filename ->
-        filename + ".release" }
-    filter { line ->
-        if (isRelease && line.startsWith("release=")) {
-            "release=true"
+task prepare_release_config() {
+    project.copy {
+        from "$rootDir/gradle.properties"
+        into "$rootDir"
+        rename { filename ->
+            filename + ".release"
         }
-        else {
-            line
+        filter { line ->
+            if (isRelease && line.startsWith("release=")) {
+                "release=true"
+            } else {
+                line
+            }
         }
     }
 }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1013


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
On Windows OS, the build was failing due to a bug in Gradle
https://github.com/gradle/gradle/issues/4663

For a workaround, we use a different way of copying the properties file.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

