### PR TITLE
GOBBLIN-1016: Allow Gobblin Application Master to join Helix cluster …

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixMessagingService.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixMessagingService.java
@@ -184,8 +184,6 @@ public class GobblinHelixMessagingService extends DefaultMessagingService {
           && stringMatches(resourceName, Strings.nullToEmpty(row.getRecordId()))
           && stringMatches(partitionName, Strings.nullToEmpty(row.getMapKey()))
           && stringMatches(partitionState, Strings.nullToEmpty(row.getMapValue()));
-      //return stringMatches(instanceName, row.getMapSubKey()) && stringMatches(resourceName, row.getRecordId())
-      //    && stringMatches(partitionName, row.getMapKey()) && stringMatches(partitionState, row.getMapValue());
     }
 
     /**

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixMessagingService.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixMessagingService.java
@@ -173,13 +173,19 @@ public class GobblinHelixMessagingService extends DefaultMessagingService {
      * @param row row of currently persisted data
      * @return true if it matches, false otherwise
      */
+
     private boolean rowMatches(Criteria criteria, ZNRecordRow row) {
       String instanceName = normalizePattern(criteria.getInstanceName());
       String resourceName = normalizePattern(criteria.getResource());
       String partitionName = normalizePattern(criteria.getPartition());
       String partitionState = normalizePattern(criteria.getPartitionState());
-      return stringMatches(instanceName, row.getMapSubKey()) && stringMatches(resourceName, row.getRecordId())
-          && stringMatches(partitionName, row.getMapKey()) && stringMatches(partitionState, row.getMapValue());
+      return (stringMatches(instanceName, Strings.nullToEmpty(row.getMapSubKey())) ||
+          stringMatches(instanceName, Strings.nullToEmpty(row.getRecordId())))
+          && stringMatches(resourceName, Strings.nullToEmpty(row.getRecordId()))
+          && stringMatches(partitionName, Strings.nullToEmpty(row.getMapKey()))
+          && stringMatches(partitionState, Strings.nullToEmpty(row.getMapValue()));
+      //return stringMatches(instanceName, row.getMapSubKey()) && stringMatches(resourceName, row.getRecordId())
+      //    && stringMatches(partitionName, row.getMapKey()) && stringMatches(partitionState, row.getMapValue());
     }
 
     /**

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixMultiManager.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixMultiManager.java
@@ -232,7 +232,7 @@ public class GobblinHelixMultiManager implements StandardMetricsBridge {
       this.managerClusterHelixManager = buildHelixManager(this.config,
           zkConnectionString,
           GobblinClusterConfigurationKeys.HELIX_CLUSTER_NAME_KEY,
-          isHelixClusterManaged ? InstanceType.ADMINISTRATOR : InstanceType.CONTROLLER);
+          isHelixClusterManaged ? InstanceType.PARTICIPANT : InstanceType.CONTROLLER);
       this.jobClusterHelixManager = this.managerClusterHelixManager;
     }
   }

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/AbstractYarnAppSecurityManager.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/AbstractYarnAppSecurityManager.java
@@ -17,20 +17,13 @@
 
 package org.apache.gobblin.yarn;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Optional;
-import com.google.common.base.Throwables;
-import com.google.common.util.concurrent.AbstractIdleService;
-import com.typesafe.config.Config;
 import java.io.IOException;
 import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import org.apache.gobblin.cluster.GobblinHelixMessagingService;
-import org.apache.gobblin.util.ConfigUtils;
-import org.apache.gobblin.util.ExecutorsUtils;
+
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsAction;
@@ -43,6 +36,16 @@ import org.apache.helix.InstanceType;
 import org.apache.helix.model.Message;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Optional;
+import com.google.common.base.Throwables;
+import com.google.common.util.concurrent.AbstractIdleService;
+import com.typesafe.config.Config;
+
+import org.apache.gobblin.cluster.GobblinHelixMessagingService;
+import org.apache.gobblin.util.ConfigUtils;
+import org.apache.gobblin.util.ExecutorsUtils;
 
 /**
  * <p>
@@ -186,7 +189,7 @@ public abstract class AbstractYarnAppSecurityManager extends AbstractIdleService
         HelixMessageSubTypes.TOKEN_FILE_UPDATED.toString().toLowerCase() + UUID.randomUUID().toString());
     tokenFileUpdatedMessage.setMsgSubType(HelixMessageSubTypes.TOKEN_FILE_UPDATED.toString());
     tokenFileUpdatedMessage.setMsgState(Message.MessageState.NEW);
-    if (instanceType == InstanceType.CONTROLLER) {
+    if ((instanceType == InstanceType.CONTROLLER) || (instanceType == InstanceType.ADMINISTRATOR)) {
       tokenFileUpdatedMessage.setTgtSessionId("*");
     }
 

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/AbstractYarnAppSecurityManager.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/AbstractYarnAppSecurityManager.java
@@ -39,6 +39,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
+import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.AbstractIdleService;
 import com.typesafe.config.Config;
@@ -170,8 +171,13 @@ public abstract class AbstractYarnAppSecurityManager extends AbstractIdleService
    */
   @VisibleForTesting
   protected void sendTokenFileUpdatedMessage(InstanceType instanceType) {
+    sendTokenFileUpdatedMessage(instanceType, "");
+  }
+
+  @VisibleForTesting
+  protected void sendTokenFileUpdatedMessage(InstanceType instanceType, String instanceName) {
     Criteria criteria = new Criteria();
-    criteria.setInstanceName("%");
+    criteria.setInstanceName(Strings.isNullOrEmpty(instanceName) ? "%" : instanceName);
     criteria.setResource("%");
     criteria.setPartition("%");
     criteria.setPartitionState("%");
@@ -189,7 +195,7 @@ public abstract class AbstractYarnAppSecurityManager extends AbstractIdleService
         HelixMessageSubTypes.TOKEN_FILE_UPDATED.toString().toLowerCase() + UUID.randomUUID().toString());
     tokenFileUpdatedMessage.setMsgSubType(HelixMessageSubTypes.TOKEN_FILE_UPDATED.toString());
     tokenFileUpdatedMessage.setMsgState(Message.MessageState.NEW);
-    if ((instanceType == InstanceType.CONTROLLER) || (instanceType == InstanceType.ADMINISTRATOR)) {
+    if (instanceType == InstanceType.CONTROLLER) {
       tokenFileUpdatedMessage.setTgtSessionId("*");
     }
 

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnAppLauncher.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnAppLauncher.java
@@ -92,8 +92,10 @@ import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
 import org.apache.gobblin.cluster.GobblinClusterConfigurationKeys;
+import org.apache.gobblin.cluster.GobblinClusterManager;
 import org.apache.gobblin.cluster.GobblinClusterUtils;
 import org.apache.gobblin.cluster.GobblinHelixConstants;
+import org.apache.gobblin.cluster.GobblinHelixMessagingService;
 import org.apache.gobblin.cluster.HelixUtils;
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.rest.JobExecutionInfoServer;
@@ -188,6 +190,8 @@ public class GobblinYarnAppLauncher {
   private final Path sinkLogRootDir;
 
   private final Closer closer = Closer.create();
+  private final String helixInstanceName;
+  private final GobblinHelixMessagingService messagingService;
 
   // Yarn application ID
   private volatile Optional<ApplicationId> applicationId = Optional.absent();
@@ -279,6 +283,10 @@ public class GobblinYarnAppLauncher {
 
     this.isHelixClusterManaged = ConfigUtils.getBoolean(this.config, GobblinClusterConfigurationKeys.IS_HELIX_CLUSTER_MANAGED,
         GobblinClusterConfigurationKeys.DEFAULT_IS_HELIX_CLUSTER_MANAGED);
+    this.helixInstanceName = ConfigUtils.getString(config, GobblinClusterConfigurationKeys.HELIX_INSTANCE_NAME_KEY,
+        GobblinClusterManager.class.getSimpleName());
+
+    this.messagingService = new GobblinHelixMessagingService(this.helixManager);
 
   }
 
@@ -800,12 +808,13 @@ public class GobblinYarnAppLauncher {
   void sendShutdownRequest() {
     Criteria criteria = new Criteria();
     criteria.setInstanceName("%");
-    criteria.setResource("%");
     criteria.setPartition("%");
     criteria.setPartitionState("%");
+    criteria.setResource("%");
     if (this.isHelixClusterManaged) {
-      //In the managed mode, the Gobblin Yarn Application Master connects to the Helix cluster in the Administrator role.
-      criteria.setRecipientInstanceType(InstanceType.ADMINISTRATOR);
+      //In the managed mode, the Gobblin Yarn Application Master connects to the Helix cluster in the Participant role.
+      criteria.setRecipientInstanceType(InstanceType.PARTICIPANT);
+      criteria.setInstanceName(this.helixInstanceName);
     } else {
       criteria.setRecipientInstanceType(InstanceType.CONTROLLER);
     }
@@ -817,7 +826,7 @@ public class GobblinYarnAppLauncher {
     shutdownRequest.setMsgState(Message.MessageState.NEW);
     shutdownRequest.setTgtSessionId("*");
 
-    int messagesSent = this.helixManager.getMessagingService().send(criteria, shutdownRequest);
+    int messagesSent = this.messagingService.send(criteria, shutdownRequest);
     if (messagesSent == 0) {
       LOGGER.error(String.format("Failed to send the %s message to the controller", shutdownRequest.getMsgSubType()));
     }

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnAppSecurityManagerWithKeytabs.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnAppSecurityManagerWithKeytabs.java
@@ -90,12 +90,12 @@ public class YarnAppSecurityManagerWithKeytabs extends AbstractYarnAppSecurityMa
     writeDelegationTokenToFile();
 
     if (!this.firstLogin) {
-      // Send a message to the controller and all the participants if this is not the first login
-      if (this.isHelixClusterManaged) {
-        sendTokenFileUpdatedMessage(InstanceType.PARTICIPANT, this.helixInstanceName);
-      } else {
+      // Send a message to the controller (when the cluster is not managed)
+      // and all the participants if this is not the first login
+      if (!this.isHelixClusterManaged) {
         sendTokenFileUpdatedMessage(InstanceType.CONTROLLER);
       }
+      sendTokenFileUpdatedMessage(InstanceType.PARTICIPANT, this.helixInstanceName);
     }
   }
 
@@ -138,13 +138,11 @@ public class YarnAppSecurityManagerWithKeytabs extends AbstractYarnAppSecurityMa
     writeDelegationTokenToFile();
 
     if (!this.firstLogin) {
-      // Send a message to the controller and all the participants
-      if (this.isHelixClusterManaged) {
-        sendTokenFileUpdatedMessage(InstanceType.PARTICIPANT, this.helixInstanceName);
-      } else {
+      // Send a message to the controller (when the cluster is not managed) and all the participants
+      if (!this.isHelixClusterManaged) {
         sendTokenFileUpdatedMessage(InstanceType.CONTROLLER);
       }
+      sendTokenFileUpdatedMessage(InstanceType.PARTICIPANT, this.helixInstanceName);
     }
   }
-
 }

--- a/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/GobblinYarnAppLauncherTest.java
+++ b/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/GobblinYarnAppLauncherTest.java
@@ -17,15 +17,6 @@
 
 package org.apache.gobblin.yarn;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.eventbus.EventBus;
-import com.google.common.io.Closer;
-import com.google.common.util.concurrent.Service;
-import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
-import com.typesafe.config.ConfigValueFactory;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -42,18 +33,6 @@ import java.util.concurrent.TimeoutException;
 
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.test.TestingServer;
-import org.apache.gobblin.cluster.GobblinClusterConfigurationKeys;
-import org.apache.gobblin.cluster.GobblinHelixConstants;
-import org.apache.gobblin.cluster.GobblinHelixMultiManager;
-import org.apache.gobblin.cluster.HelixMessageTestBase;
-import org.apache.gobblin.cluster.HelixUtils;
-import org.apache.gobblin.cluster.TestHelper;
-import org.apache.gobblin.cluster.TestShutdownMessageHandlerFactory;
-import org.apache.gobblin.configuration.ConfigurationKeys;
-import org.apache.gobblin.configuration.DynamicConfigGenerator;
-import org.apache.gobblin.runtime.app.ServiceBasedAppLauncher;
-import org.apache.gobblin.testing.AssertWithBackoff;
-
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
@@ -74,6 +53,28 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.eventbus.EventBus;
+import com.google.common.io.Closer;
+import com.google.common.util.concurrent.Service;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigValueFactory;
+
+import org.apache.gobblin.cluster.GobblinClusterConfigurationKeys;
+import org.apache.gobblin.cluster.GobblinHelixConstants;
+import org.apache.gobblin.cluster.GobblinHelixMultiManager;
+import org.apache.gobblin.cluster.HelixMessageTestBase;
+import org.apache.gobblin.cluster.HelixUtils;
+import org.apache.gobblin.cluster.TestHelper;
+import org.apache.gobblin.cluster.TestShutdownMessageHandlerFactory;
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.configuration.DynamicConfigGenerator;
+import org.apache.gobblin.runtime.app.ServiceBasedAppLauncher;
+import org.apache.gobblin.testing.AssertWithBackoff;
+
 import static org.mockito.Mockito.times;
 
 
@@ -92,6 +93,8 @@ import static org.mockito.Mockito.times;
  */
 @Test(groups = { "gobblin.yarn" }, singleThreaded=true)
 public class GobblinYarnAppLauncherTest implements HelixMessageTestBase {
+  private static final Object MANAGED_HELIX_CLUSTER_NAME = "GobblinYarnAppLauncherTestManagedHelix";
+  public static final String TEST_HELIX_INSTANCE_NAME_MANAGED = HelixUtils.getHelixInstanceName("TestInstance", 1);
 
   public static final String DYNAMIC_CONF_PATH = "dynamic.conf";
   public static final String YARN_SITE_XML_PATH = "yarn-site.xml";
@@ -102,10 +105,13 @@ public class GobblinYarnAppLauncherTest implements HelixMessageTestBase {
   private CuratorFramework curatorFramework;
 
   private Config config;
+  private Config configManagedHelix;
 
   private HelixManager helixManager;
+  private HelixManager helixManagerManagedHelix;
 
   private GobblinYarnAppLauncher gobblinYarnAppLauncher;
+  private GobblinYarnAppLauncher gobblinYarnAppLauncherManagedHelix;
   private ApplicationId applicationId;
 
   private final Closer closer = Closer.create();
@@ -185,6 +191,20 @@ public class GobblinYarnAppLauncherTest implements HelixMessageTestBase {
         InstanceType.CONTROLLER, zkConnectionString);
 
     this.gobblinYarnAppLauncher = new GobblinYarnAppLauncher(this.config, clusterConf);
+
+    this.configManagedHelix = ConfigFactory.parseURL(url)
+        .withValue("gobblin.cluster.zk.connection.string",
+            ConfigValueFactory.fromAnyRef(testingZKServer.getConnectString()))
+        .withValue(GobblinClusterConfigurationKeys.HELIX_CLUSTER_NAME_KEY, ConfigValueFactory.fromAnyRef(MANAGED_HELIX_CLUSTER_NAME))
+        .withValue(GobblinClusterConfigurationKeys.HELIX_INSTANCE_NAME_KEY, ConfigValueFactory.fromAnyRef(TEST_HELIX_INSTANCE_NAME_MANAGED))
+        .withValue(GobblinClusterConfigurationKeys.IS_HELIX_CLUSTER_MANAGED, ConfigValueFactory.fromAnyRef("true"))
+        .resolve();
+
+    this.helixManagerManagedHelix = HelixManagerFactory.getZKHelixManager(
+        this.configManagedHelix.getString(GobblinClusterConfigurationKeys.HELIX_CLUSTER_NAME_KEY), TEST_HELIX_INSTANCE_NAME_MANAGED,
+        InstanceType.PARTICIPANT, zkConnectionString);
+
+    this.gobblinYarnAppLauncherManagedHelix = new GobblinYarnAppLauncher(this.configManagedHelix, clusterConf);
   }
 
   @Test
@@ -207,6 +227,18 @@ public class GobblinYarnAppLauncherTest implements HelixMessageTestBase {
     Assert.assertEquals(
         this.curatorFramework.checkExists()
             .forPath(String.format("/%s/CONTROLLER", GobblinYarnAppLauncherTest.class.getSimpleName())).getVersion(),
+        0);
+
+    //Create managed Helix cluster and test it is created successfully
+    HelixUtils.createGobblinHelixCluster(
+        this.configManagedHelix.getString(GobblinClusterConfigurationKeys.ZK_CONNECTION_STRING_KEY),
+        this.configManagedHelix.getString(GobblinClusterConfigurationKeys.HELIX_CLUSTER_NAME_KEY));
+
+    Assert.assertEquals(this.curatorFramework.checkExists()
+        .forPath(String.format("/%s/CONTROLLER", MANAGED_HELIX_CLUSTER_NAME)).getVersion(), 0);
+    Assert.assertEquals(
+        this.curatorFramework.checkExists()
+            .forPath(String.format("/%s/CONTROLLER", MANAGED_HELIX_CLUSTER_NAME)).getVersion(),
         0);
   }
 
@@ -265,8 +297,8 @@ public class GobblinYarnAppLauncherTest implements HelixMessageTestBase {
     Assert.assertEquals(this.curatorFramework.checkExists()
         .forPath(String.format("/%s/CONTROLLER/MESSAGES", GobblinYarnAppLauncherTest.class.getSimpleName()))
         .getVersion(), 0);
-    YarnSecurityManagerTest.GetControllerMessageNumFunc getCtrlMessageNum =
-        new YarnSecurityManagerTest.GetControllerMessageNumFunc(GobblinYarnAppLauncherTest.class.getSimpleName(),
+    YarnSecurityManagerTest.GetHelixMessageNumFunc getCtrlMessageNum =
+        new YarnSecurityManagerTest.GetHelixMessageNumFunc(GobblinYarnAppLauncherTest.class.getSimpleName(), InstanceType.CONTROLLER, "",
             this.curatorFramework);
     AssertWithBackoff assertWithBackoff =
         AssertWithBackoff.create().logger(LoggerFactory.getLogger("testSendShutdownRequest")).timeoutMs(20000);
@@ -274,7 +306,51 @@ public class GobblinYarnAppLauncherTest implements HelixMessageTestBase {
 
     // Give Helix sometime to handle the message
     assertWithBackoff.assertEquals(getCtrlMessageNum, 0, "all controller messages processed");
+
+    this.helixManagerManagedHelix.connect();
+    this.helixManagerManagedHelix.getMessagingService().registerMessageHandlerFactory(GobblinHelixConstants.SHUTDOWN_MESSAGE_TYPE,
+        new TestShutdownMessageHandlerFactory(this));
+
+    this.gobblinYarnAppLauncherManagedHelix.connectHelixManager();
+    this.gobblinYarnAppLauncherManagedHelix.sendShutdownRequest();
+
+    Assert.assertEquals(this.curatorFramework.checkExists()
+        .forPath(String.format("/%s/INSTANCES/%s/MESSAGES", this.configManagedHelix.getString(GobblinClusterConfigurationKeys.HELIX_CLUSTER_NAME_KEY), TEST_HELIX_INSTANCE_NAME_MANAGED))
+        .getVersion(), 0);
+    YarnSecurityManagerTest.GetHelixMessageNumFunc getInstanceMessageNum =
+        new YarnSecurityManagerTest.GetHelixMessageNumFunc(this.configManagedHelix.getString(
+            GobblinClusterConfigurationKeys.HELIX_CLUSTER_NAME_KEY),
+            InstanceType.PARTICIPANT, TEST_HELIX_INSTANCE_NAME_MANAGED, this.curatorFramework);
+    assertWithBackoff =
+        AssertWithBackoff.create().logger(LoggerFactory.getLogger("testSendShutdownRequest")).timeoutMs(20000);
+    assertWithBackoff.assertEquals(getInstanceMessageNum, 1, "1 controller message queued");
+
+    // Give Helix sometime to handle the message
+    assertWithBackoff.assertEquals(getInstanceMessageNum, 0, "all controller messages processed");
   }
+
+  /*static class GetInstanceMessageFunc implements Function<Void, Integer> {
+    private final CuratorFramework curatorFramework;
+    private final String testName;
+    private final String instanceName;
+
+    public GetInstanceMessageFunc(String testName, String instanceName, CuratorFramework curatorFramework) {
+      this.curatorFramework = curatorFramework;
+      this.testName = testName;
+      this.instanceName = instanceName;
+    }
+
+    @Override
+    public Integer apply(Void input) {
+      try {
+        return this.curatorFramework.getChildren().forPath().size();
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+  }*/
+
 
   @AfterClass
   public void tearDown() throws IOException, TimeoutException {
@@ -286,6 +362,10 @@ public class GobblinYarnAppLauncherTest implements HelixMessageTestBase {
 
       if (this.helixManager.isConnected()) {
         this.helixManager.disconnect();
+      }
+
+      if (this.helixManagerManagedHelix.isConnected()) {
+        this.helixManagerManagedHelix.disconnect();
       }
 
       this.gobblinYarnAppLauncher.disconnectHelixManager();

--- a/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/GobblinYarnAppLauncherTest.java
+++ b/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/GobblinYarnAppLauncherTest.java
@@ -329,29 +329,6 @@ public class GobblinYarnAppLauncherTest implements HelixMessageTestBase {
     assertWithBackoff.assertEquals(getInstanceMessageNum, 0, "all controller messages processed");
   }
 
-  /*static class GetInstanceMessageFunc implements Function<Void, Integer> {
-    private final CuratorFramework curatorFramework;
-    private final String testName;
-    private final String instanceName;
-
-    public GetInstanceMessageFunc(String testName, String instanceName, CuratorFramework curatorFramework) {
-      this.curatorFramework = curatorFramework;
-      this.testName = testName;
-      this.instanceName = instanceName;
-    }
-
-    @Override
-    public Integer apply(Void input) {
-      try {
-        return this.curatorFramework.getChildren().forPath().size();
-      } catch (Exception e) {
-        throw new RuntimeException(e);
-      }
-    }
-
-  }*/
-
-
   @AfterClass
   public void tearDown() throws IOException, TimeoutException {
     try {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1016


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
In the managed cluster mode, the Gobblin Yarn Application Master joins Helix cluster in the ADMINISTRATOR role. However, Helix does not support messaging for instances which are not CONTROLLER or PARTICIPANT. To properly handle shutdown and token file update messages, the AppMaster should connect to the Helix cluster as a PARTICIPANT, these message types need to be destined to PARTICIPANT instead of CONTROLLER as is the case today.



### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Added unit tests to YarnAppSecurityManagerTest and GobblinYarnAppLauncherTest classes.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

