### PR TITLE
[GOBBLIN-1026] Allow metadata publishing order to be configured.

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -486,6 +486,9 @@ public class ConfigurationKeys {
   public static final String PUBLISHER_LATEST_FILE_ARRIVAL_TIMESTAMP =
       DATA_PUBLISHER_PREFIX + ".latest.file.arrival.timestamp";
 
+  public static final String DATA_PUBLISHER_METADATA_FIRST = DATA_PUBLISHER_PREFIX + ".metadataFirst";
+  public static final boolean DEFAULT_DATA_PUBLISHER_METADATA_FIRST = true;
+
   /**
    * Configuration properties used by the extractor.
    */

--- a/gobblin-api/src/main/java/org/apache/gobblin/publisher/DataPublisher.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/publisher/DataPublisher.java
@@ -130,7 +130,8 @@ public abstract class DataPublisher implements Closeable, CapabilityAware {
    * if they are dependent on data getting published first.
    */
   protected boolean shouldPublishMetadataFirst() {
-    return true;
+    return this.state.getPropAsBoolean(ConfigurationKeys.DATA_PUBLISHER_METADATA_FIRST,
+            ConfigurationKeys.DEFAULT_DATA_PUBLISHER_METADATA_FIRST);
   }
 
   @Override


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1026


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
  DataPublisher always assume the metadata to be published first. In LinkedIn we had a MultiDataPublisher extend this data publisher, which is used by multiple jobs. Those jobs requires different order of the metadata publishing. Instead of splitting multiDataPublisher into different data publishers and provide override boolean flags, we simply add the configuration to allow user to config the behavior.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

