### PR TITLE
GOBBLIN-1034: Ensure underlying writers are expired from the Partitio…

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/writer/PartitionedDataWriter.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/writer/PartitionedDataWriter.java
@@ -76,7 +76,7 @@ public class PartitionedDataWriter<S, D> extends WriterWrapper<D> implements Fin
   // NOTE: this config must be set only in streaming mode. For batch mode, setting this config will result
   // in incorrect behavior.
   public static final String PARTITIONED_WRITER_CACHE_TTL_SECONDS = "partitionedDataWriter.cache.ttl.seconds";
-  public static final Long DEFAULT_PARTITIONED_WRITER_CACHE_TTL_SECONDS = 3600L;
+  public static final Long DEFAULT_PARTITIONED_WRITER_CACHE_TTL_SECONDS = Long.MAX_VALUE;
 
   private static final GenericRecord NON_PARTITIONED_WRITER_KEY =
       new GenericData.Record(SchemaBuilder.record("Dummy").fields().endRecord());
@@ -136,6 +136,8 @@ public class PartitionedDataWriter<S, D> extends WriterWrapper<D> implements Fin
               writer.close();
             } catch (IOException e) {
               log.error("Exception {} encountered when closing data writer on cache eviction", e);
+              //Should propagate the exception to avoid committing/publishing corrupt files.
+              throw new RuntimeException(e);
             }
           }
         }

--- a/gobblin-core/src/main/java/org/apache/gobblin/writer/PartitionedDataWriter.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/writer/PartitionedDataWriter.java
@@ -120,7 +120,8 @@ public class PartitionedDataWriter<S, D> extends WriterWrapper<D> implements Fin
     if(builder.schema != null) {
       this.state.setProp(WRITER_LATEST_SCHEMA, builder.getSchema());
     }
-    Long cacheExpiryInterval = this.state.getPropAsLong(PARTITIONED_WRITER_CACHE_TTL_SECONDS, DEFAULT_PARTITIONED_WRITER_CACHE_TTL_SECONDS);
+    long cacheExpiryInterval = this.state.getPropAsLong(PARTITIONED_WRITER_CACHE_TTL_SECONDS, DEFAULT_PARTITIONED_WRITER_CACHE_TTL_SECONDS);
+    log.debug("PartitionedDataWriter: Setting cache expiry interval to {} seconds", cacheExpiryInterval);
 
     this.partitionWriters = CacheBuilder.newBuilder()
         .expireAfterAccess(cacheExpiryInterval, TimeUnit.SECONDS)


### PR DESCRIPTION
…nedDataWriter cache to avoid accumulation of writers for long running Gobblin jobs

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1034


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Currently, the underlying writers are never evicted from the PartitionedDataWriter cache. For long running Gobblin jobs (e.g. streaming), this will cause a memory leak particularly if the underlying writers maintain state. 



### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Added unit test.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

