### PR TITLE
GOBBLIN-1036: Add hadoop override configurations when instantiating FileSystem object in GobblinTaskRunner and GobblinClusterManager

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
@@ -181,4 +181,6 @@ public class GobblinClusterConfigurationKeys {
   // the cluster
   public static final String IS_HELIX_CLUSTER_MANAGED = GOBBLIN_CLUSTER_PREFIX + "isHelixClusterManaged";
   public static final boolean DEFAULT_IS_HELIX_CLUSTER_MANAGED = false;
+
+  public static final String HADOOP_CONFIG_OVERRIDES_PREFIX = GOBBLIN_CLUSTER_PREFIX + "hadoop.inject";
 }

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterManager.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterManager.java
@@ -73,6 +73,7 @@ import org.apache.gobblin.runtime.app.ApplicationLauncher;
 import org.apache.gobblin.runtime.app.ServiceBasedAppLauncher;
 import org.apache.gobblin.scheduler.SchedulerService;
 import org.apache.gobblin.util.ConfigUtils;
+import org.apache.gobblin.util.JobConfigurationUtils;
 import org.apache.gobblin.util.JvmUtils;
 import org.apache.gobblin.util.reflection.GobblinConstructorUtils;
 
@@ -114,6 +115,7 @@ public class GobblinClusterManager implements ApplicationLauncher, StandardMetri
 
   protected final Path appWorkDir;
 
+  @Getter
   protected final FileSystem fs;
 
   protected final String applicationId;
@@ -353,9 +355,15 @@ public class GobblinClusterManager implements ApplicationLauncher, StandardMetri
    * Build the {@link FileSystem} for the Application Master.
    */
   private FileSystem buildFileSystem(Config config) throws IOException {
+    Config hadoopOverrides = ConfigUtils.getConfigOrEmpty(config, GobblinClusterConfigurationKeys.HADOOP_CONFIG_OVERRIDES_PREFIX);
+
+    Configuration conf = new Configuration();
+    //Add any Hadoop-specific overrides into the Configuration object
+    JobConfigurationUtils.putPropertiesIntoConfiguration(ConfigUtils.configToProperties(hadoopOverrides), conf);
+
     return config.hasPath(ConfigurationKeys.FS_URI_KEY) ? FileSystem
-        .get(URI.create(config.getString(ConfigurationKeys.FS_URI_KEY)), new Configuration())
-        : FileSystem.get(new Configuration());
+        .get(URI.create(config.getString(ConfigurationKeys.FS_URI_KEY)), conf)
+        : FileSystem.get(conf);
   }
 
   /**

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinClusterManagerTest.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinClusterManagerTest.java
@@ -21,6 +21,7 @@ import java.net.URL;
 
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.test.TestingServer;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.helix.HelixManager;
 import org.apache.helix.HelixManagerFactory;
@@ -61,6 +62,7 @@ import org.apache.gobblin.testing.AssertWithBackoff;
 @Test(groups = { "gobblin.cluster" })
 public class GobblinClusterManagerTest implements HelixMessageTestBase {
   public final static Logger LOG = LoggerFactory.getLogger(GobblinClusterManagerTest.class);
+  public static final String HADOOP_OVERRIDE_PROPERTY_NAME = "prop";
 
   private TestingServer testingZKServer;
 
@@ -83,6 +85,8 @@ public class GobblinClusterManagerTest implements HelixMessageTestBase {
                    ConfigValueFactory.fromAnyRef(testingZKServer.getConnectString()))
         .withValue(GobblinClusterConfigurationKeys.HELIX_TASK_QUOTA_CONFIG_KEY,
             ConfigValueFactory.fromAnyRef("DEFAULT:1,OTHER:10"))
+        .withValue(GobblinClusterConfigurationKeys.HADOOP_CONFIG_OVERRIDES_PREFIX + "." + HADOOP_OVERRIDE_PROPERTY_NAME,
+            ConfigValueFactory.fromAnyRef("value"))
         .resolve();
 
     String zkConnectionString = config.getString(GobblinClusterConfigurationKeys.ZK_CONNECTION_STRING_KEY);
@@ -174,6 +178,12 @@ public class GobblinClusterManagerTest implements HelixMessageTestBase {
             return !GobblinClusterManagerTest.this.gobblinClusterManager.isHelixManagerConnected();
           }
         }, "Cluster Manager shutdown");
+  }
+
+  @Test
+  public void testBuildFileSystemConfig() {
+    FileSystem fileSystem = this.gobblinClusterManager.getFs();
+    Assert.assertEquals(fileSystem.getConf().get(HADOOP_OVERRIDE_PROPERTY_NAME), "value");
   }
 
   @AfterClass

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinClusterManagerTest.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinClusterManagerTest.java
@@ -87,6 +87,8 @@ public class GobblinClusterManagerTest implements HelixMessageTestBase {
             ConfigValueFactory.fromAnyRef("DEFAULT:1,OTHER:10"))
         .withValue(GobblinClusterConfigurationKeys.HADOOP_CONFIG_OVERRIDES_PREFIX + "." + HADOOP_OVERRIDE_PROPERTY_NAME,
             ConfigValueFactory.fromAnyRef("value"))
+        .withValue(GobblinClusterConfigurationKeys.HADOOP_CONFIG_OVERRIDES_PREFIX + "." + "fs.file.impl.disable.cache",
+            ConfigValueFactory.fromAnyRef("true"))
         .resolve();
 
     String zkConnectionString = config.getString(GobblinClusterConfigurationKeys.ZK_CONNECTION_STRING_KEY);

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinTaskRunnerTest.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinTaskRunnerTest.java
@@ -75,6 +75,8 @@ public class GobblinTaskRunnerTest {
                    ConfigValueFactory.fromAnyRef(testingZKServer.getConnectString()))
         .withValue(GobblinClusterConfigurationKeys.HADOOP_CONFIG_OVERRIDES_PREFIX + "." + HADOOP_OVERRIDE_PROPERTY_NAME,
             ConfigValueFactory.fromAnyRef("value"))
+        .withValue(GobblinClusterConfigurationKeys.HADOOP_CONFIG_OVERRIDES_PREFIX + "." + "fs.file.impl.disable.cache",
+            ConfigValueFactory.fromAnyRef("true"))
         .resolve();
 
     String zkConnectionString = config.getString(GobblinClusterConfigurationKeys.ZK_CONNECTION_STRING_KEY);

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinTaskRunnerTest.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinTaskRunnerTest.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.net.URL;
 
 import org.apache.curator.test.TestingServer;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,6 +53,8 @@ import org.apache.gobblin.testing.AssertWithBackoff;
 public class GobblinTaskRunnerTest {
   public final static Logger LOG = LoggerFactory.getLogger(GobblinTaskRunnerTest.class);
 
+  public static final String HADOOP_OVERRIDE_PROPERTY_NAME = "prop";
+
   private TestingServer testingZKServer;
 
   private GobblinTaskRunner gobblinTaskRunner;
@@ -70,6 +73,8 @@ public class GobblinTaskRunnerTest {
     Config config = ConfigFactory.parseURL(url)
         .withValue("gobblin.cluster.zk.connection.string",
                    ConfigValueFactory.fromAnyRef(testingZKServer.getConnectString()))
+        .withValue(GobblinClusterConfigurationKeys.HADOOP_CONFIG_OVERRIDES_PREFIX + "." + HADOOP_OVERRIDE_PROPERTY_NAME,
+            ConfigValueFactory.fromAnyRef("value"))
         .resolve();
 
     String zkConnectionString = config.getString(GobblinClusterConfigurationKeys.ZK_CONNECTION_STRING_KEY);
@@ -102,6 +107,12 @@ public class GobblinTaskRunnerTest {
           return GobblinTaskRunnerTest.this.gobblinTaskRunner.isStopped();
         }
       }, "gobblinTaskRunner stopped");
+  }
+
+  @Test
+  public void testBuildFileSystemConfig() {
+    FileSystem fileSystem = this.gobblinTaskRunner.getFs();
+    Assert.assertEquals(fileSystem.getConf().get(HADOOP_OVERRIDE_PROPERTY_NAME), "value");
   }
 
   @AfterClass


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1036


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Add hadoop override configurations when instantiating FileSystem object in GobblinTaskRunner and GobblinClusterManager

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Unit tests.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

