### PR TITLE
[GOBBLIN-1038] Set default dataset descriptor configs based on the DataNode

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/BaseDataNode.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/BaseDataNode.java
@@ -42,10 +42,6 @@ public class BaseDataNode implements DataNode {
   private Config rawConfig;
   @Getter
   private boolean active = true;
-  @Getter
-  public final String defaultDatasetDescriptorClass = null;
-  @Getter
-  public final String defaultDatasetDescriptorPlatform = null;
 
   public BaseDataNode(Config nodeProps) throws DataNodeCreationException {
     try {
@@ -59,5 +55,15 @@ public class BaseDataNode implements DataNode {
     } catch (Exception e) {
       throw new DataNodeCreationException(e);
     }
+  }
+
+  @Override
+  public String getDefaultDatasetDescriptorClass() {
+    return null;
+  }
+
+  @Override
+  public String getDefaultDatasetDescriptorPlatform() {
+    return null;
   }
 }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/BaseDataNode.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/BaseDataNode.java
@@ -42,6 +42,10 @@ public class BaseDataNode implements DataNode {
   private Config rawConfig;
   @Getter
   private boolean active = true;
+  @Getter
+  public final String defaultDatasetDescriptorClass = null;
+  @Getter
+  public final String defaultDatasetDescriptorPlatform = null;
 
   public BaseDataNode(Config nodeProps) throws DataNodeCreationException {
     try {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/DataNode.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/DataNode.java
@@ -39,6 +39,16 @@ public interface DataNode {
   Config getRawConfig();
 
   /**
+   * @return a default dataset descriptor class for this DataNode, or null if a default should not be used.
+   */
+  String getDefaultDatasetDescriptorClass();
+
+  /**
+   * @return a default dataset descriptor platform for this DataNode, or null if a default should not be used.
+   */
+  String getDefaultDatasetDescriptorPlatform();
+
+  /**
    * @return true if the {@link DataNode} is active
    */
   boolean isActive();

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/datanodes/HttpDataNode.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/datanodes/HttpDataNode.java
@@ -24,6 +24,7 @@ import joptsimple.internal.Strings;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
+import org.apache.gobblin.service.modules.dataset.HttpDatasetDescriptor;
 import org.apache.gobblin.service.modules.flowgraph.BaseDataNode;
 import org.apache.gobblin.service.modules.flowgraph.DataNode;
 import org.apache.gobblin.service.modules.flowgraph.FlowGraphConfigurationKeys;
@@ -41,6 +42,10 @@ public class HttpDataNode extends BaseDataNode  {
   private String httpDomain;
   @Getter
   private String authenticationType;
+  @Getter
+  public final String defaultDatasetDescriptorClass = HttpDatasetDescriptor.class.getCanonicalName();
+  @Getter
+  public final String defaultDatasetDescriptorPlatform = "http";
 
   public HttpDataNode(Config nodeProps) throws DataNode.DataNodeCreationException {
     super(nodeProps);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/datanodes/HttpDataNode.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/datanodes/HttpDataNode.java
@@ -42,10 +42,7 @@ public class HttpDataNode extends BaseDataNode  {
   private String httpDomain;
   @Getter
   private String authenticationType;
-  @Getter
-  public final String defaultDatasetDescriptorClass = HttpDatasetDescriptor.class.getCanonicalName();
-  @Getter
-  public final String defaultDatasetDescriptorPlatform = "http";
+  public static final String PLATFORM = "http";
 
   public HttpDataNode(Config nodeProps) throws DataNode.DataNodeCreationException {
     super(nodeProps);
@@ -62,5 +59,15 @@ public class HttpDataNode extends BaseDataNode  {
     } catch (Exception e) {
       throw new DataNode.DataNodeCreationException(e);
     }
+  }
+
+  @Override
+  public String getDefaultDatasetDescriptorClass() {
+    return HttpDatasetDescriptor.class.getCanonicalName();
+  }
+
+  @Override
+  public String getDefaultDatasetDescriptorPlatform() {
+    return PLATFORM;
   }
 }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/datanodes/SqlDataNode.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/datanodes/SqlDataNode.java
@@ -23,6 +23,7 @@ import joptsimple.internal.Strings;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
+import org.apache.gobblin.service.modules.dataset.SqlDatasetDescriptor;
 import org.apache.gobblin.service.modules.flowgraph.BaseDataNode;
 import org.apache.gobblin.service.modules.flowgraph.FlowGraphConfigurationKeys;
 import org.apache.gobblin.util.ConfigUtils;
@@ -39,6 +40,8 @@ public class SqlDataNode extends BaseDataNode {
   private Integer port;
   @Getter
   private String jdbcDriver;
+  @Getter
+  public final String defaultDatasetDescriptorClass = SqlDatasetDescriptor.class.getCanonicalName();
 
   public SqlDataNode(Config nodeProps) throws DataNodeCreationException {
     super(nodeProps);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/datanodes/SqlDataNode.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/datanodes/SqlDataNode.java
@@ -40,8 +40,6 @@ public class SqlDataNode extends BaseDataNode {
   private Integer port;
   @Getter
   private String jdbcDriver;
-  @Getter
-  public final String defaultDatasetDescriptorClass = SqlDatasetDescriptor.class.getCanonicalName();
 
   public SqlDataNode(Config nodeProps) throws DataNodeCreationException {
     super(nodeProps);
@@ -55,5 +53,10 @@ public class SqlDataNode extends BaseDataNode {
     } catch (Exception e) {
       throw new DataNodeCreationException(e);
     }
+  }
+
+  @Override
+  public String getDefaultDatasetDescriptorClass() {
+    return SqlDatasetDescriptor.class.getCanonicalName();
   }
 }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/datanodes/fs/AdlsDataNode.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/datanodes/fs/AdlsDataNode.java
@@ -21,10 +21,6 @@ import java.net.URI;
 import com.google.common.base.Strings;
 import com.typesafe.config.Config;
 
-import lombok.Getter;
-
-import org.apache.gobblin.service.modules.dataset.FSDatasetDescriptor;
-
 
 /**
  * An implementation of an ADL (Azure Data Lake) {@link org.apache.gobblin.service.modules.flowgraph.DataNode}.
@@ -32,8 +28,6 @@ import org.apache.gobblin.service.modules.dataset.FSDatasetDescriptor;
 public class AdlsDataNode extends FileSystemDataNode {
   public static final String ADLS_SCHEME = "adl";
   public static final String ABFS_SCHEME = "abfs";
-  @Getter
-  public final String defaultDatasetDescriptorPlatform = "adl";
 
   public AdlsDataNode(Config nodeProps) throws DataNodeCreationException {
     super(nodeProps);
@@ -55,5 +49,10 @@ public class AdlsDataNode extends FileSystemDataNode {
       return false;
     }
     return true;
+  }
+
+  @Override
+  public String getDefaultDatasetDescriptorPlatform() {
+    return ADLS_SCHEME;
   }
 }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/datanodes/fs/AdlsDataNode.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/datanodes/fs/AdlsDataNode.java
@@ -21,6 +21,10 @@ import java.net.URI;
 import com.google.common.base.Strings;
 import com.typesafe.config.Config;
 
+import lombok.Getter;
+
+import org.apache.gobblin.service.modules.dataset.FSDatasetDescriptor;
+
 
 /**
  * An implementation of an ADL (Azure Data Lake) {@link org.apache.gobblin.service.modules.flowgraph.DataNode}.
@@ -28,6 +32,8 @@ import com.typesafe.config.Config;
 public class AdlsDataNode extends FileSystemDataNode {
   public static final String ADLS_SCHEME = "adl";
   public static final String ABFS_SCHEME = "abfs";
+  @Getter
+  public final String defaultDatasetDescriptorPlatform = "adl";
 
   public AdlsDataNode(Config nodeProps) throws DataNodeCreationException {
     super(nodeProps);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/datanodes/fs/FileSystemDataNode.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/datanodes/fs/FileSystemDataNode.java
@@ -28,6 +28,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 import org.apache.gobblin.annotation.Alpha;
+import org.apache.gobblin.service.modules.dataset.FSDatasetDescriptor;
 import org.apache.gobblin.service.modules.flowgraph.BaseDataNode;
 import org.apache.gobblin.service.modules.flowgraph.FlowGraphConfigurationKeys;
 import org.apache.gobblin.util.ConfigUtils;
@@ -41,6 +42,8 @@ import org.apache.gobblin.util.ConfigUtils;
 @EqualsAndHashCode (callSuper = true)
 public abstract class FileSystemDataNode extends BaseDataNode {
   public static final String FS_URI_KEY = FlowGraphConfigurationKeys.DATA_NODE_PREFIX + "fs.uri";
+  @Getter
+  public final String defaultDatasetDescriptorClass = FSDatasetDescriptor.class.getCanonicalName();
 
   @Getter
   private String fsUri;

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/datanodes/fs/FileSystemDataNode.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/datanodes/fs/FileSystemDataNode.java
@@ -42,8 +42,6 @@ import org.apache.gobblin.util.ConfigUtils;
 @EqualsAndHashCode (callSuper = true)
 public abstract class FileSystemDataNode extends BaseDataNode {
   public static final String FS_URI_KEY = FlowGraphConfigurationKeys.DATA_NODE_PREFIX + "fs.uri";
-  @Getter
-  public final String defaultDatasetDescriptorClass = FSDatasetDescriptor.class.getCanonicalName();
 
   @Getter
   private String fsUri;
@@ -67,4 +65,9 @@ public abstract class FileSystemDataNode extends BaseDataNode {
   }
 
   public abstract boolean isUriValid(URI fsUri);
+
+  @Override
+  public String getDefaultDatasetDescriptorClass() {
+    return FSDatasetDescriptor.class.getCanonicalName();
+  }
 }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/datanodes/fs/HdfsDataNode.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/datanodes/fs/HdfsDataNode.java
@@ -22,8 +22,6 @@ import java.net.URI;
 import com.google.common.base.Strings;
 import com.typesafe.config.Config;
 
-import lombok.Getter;
-
 import org.apache.gobblin.annotation.Alpha;
 
 
@@ -34,8 +32,6 @@ import org.apache.gobblin.annotation.Alpha;
 @Alpha
 public class HdfsDataNode extends FileSystemDataNode {
   public static final String HDFS_SCHEME = "hdfs";
-  @Getter
-  public final String defaultDatasetDescriptorPlatform = "hdfs";
 
   public HdfsDataNode(Config nodeProps) throws DataNodeCreationException {
     super(nodeProps);
@@ -58,5 +54,10 @@ public class HdfsDataNode extends FileSystemDataNode {
       return false;
     }
     return true;
+  }
+
+  @Override
+  public String getDefaultDatasetDescriptorPlatform() {
+    return HDFS_SCHEME;
   }
 }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/datanodes/fs/HdfsDataNode.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/datanodes/fs/HdfsDataNode.java
@@ -22,6 +22,8 @@ import java.net.URI;
 import com.google.common.base.Strings;
 import com.typesafe.config.Config;
 
+import lombok.Getter;
+
 import org.apache.gobblin.annotation.Alpha;
 
 
@@ -32,6 +34,8 @@ import org.apache.gobblin.annotation.Alpha;
 @Alpha
 public class HdfsDataNode extends FileSystemDataNode {
   public static final String HDFS_SCHEME = "hdfs";
+  @Getter
+  public final String defaultDatasetDescriptorPlatform = "hdfs";
 
   public HdfsDataNode(Config nodeProps) throws DataNodeCreationException {
     super(nodeProps);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/datanodes/fs/LocalFSDataNode.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/datanodes/fs/LocalFSDataNode.java
@@ -23,6 +23,9 @@ import org.apache.gobblin.annotation.Alpha;
 
 import com.typesafe.config.Config;
 
+import lombok.Getter;
+
+
 /**
  * An implementation of {@link LocalFSDataNode}. All the properties specific to a LocalFS based data node (e.g. fs.uri)
  * are validated here.
@@ -30,6 +33,8 @@ import com.typesafe.config.Config;
 @Alpha
 public class LocalFSDataNode extends FileSystemDataNode {
   public static final String LOCAL_FS_SCHEME = "file";
+  @Getter
+  public final String defaultDatasetDescriptorPlatform = "local";
 
   public LocalFSDataNode(Config nodeProps) throws DataNodeCreationException {
     super(nodeProps);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/datanodes/fs/LocalFSDataNode.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/datanodes/fs/LocalFSDataNode.java
@@ -19,11 +19,9 @@ package org.apache.gobblin.service.modules.flowgraph.datanodes.fs;
 
 import java.net.URI;
 
-import org.apache.gobblin.annotation.Alpha;
-
 import com.typesafe.config.Config;
 
-import lombok.Getter;
+import org.apache.gobblin.annotation.Alpha;
 
 
 /**
@@ -33,8 +31,7 @@ import lombok.Getter;
 @Alpha
 public class LocalFSDataNode extends FileSystemDataNode {
   public static final String LOCAL_FS_SCHEME = "file";
-  @Getter
-  public final String defaultDatasetDescriptorPlatform = "local";
+  public static final String PLATFORM = "local";
 
   public LocalFSDataNode(Config nodeProps) throws DataNodeCreationException {
     super(nodeProps);
@@ -52,5 +49,10 @@ public class LocalFSDataNode extends FileSystemDataNode {
       return true;
     }
     return false;
+  }
+
+  @Override
+  public String getDefaultDatasetDescriptorPlatform() {
+    return PLATFORM;
   }
 }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/datanodes/hive/HiveDataNode.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/datanodes/hive/HiveDataNode.java
@@ -28,6 +28,8 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 import org.apache.gobblin.annotation.Alpha;
+import org.apache.gobblin.service.modules.dataset.FSDatasetDescriptor;
+import org.apache.gobblin.service.modules.dataset.HiveDatasetDescriptor;
 import org.apache.gobblin.service.modules.flowgraph.BaseDataNode;
 import org.apache.gobblin.service.modules.flowgraph.FlowGraphConfigurationKeys;
 import org.apache.gobblin.util.ConfigUtils;
@@ -41,6 +43,10 @@ import org.apache.gobblin.util.ConfigUtils;
 @EqualsAndHashCode (callSuper = true)
 public class HiveDataNode extends BaseDataNode {
   public static final String METASTORE_URI_KEY = FlowGraphConfigurationKeys.DATA_NODE_PREFIX + "hive.metastore.uri";
+  @Getter
+  public final String defaultDatasetDescriptorClass = HiveDatasetDescriptor.class.getCanonicalName();
+  @Getter
+  public final String defaultDatasetDescriptorPlatform = "hive";
 
   @Getter
   private String metastoreUri;

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/datanodes/hive/HiveDataNode.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/datanodes/hive/HiveDataNode.java
@@ -28,7 +28,6 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 import org.apache.gobblin.annotation.Alpha;
-import org.apache.gobblin.service.modules.dataset.FSDatasetDescriptor;
 import org.apache.gobblin.service.modules.dataset.HiveDatasetDescriptor;
 import org.apache.gobblin.service.modules.flowgraph.BaseDataNode;
 import org.apache.gobblin.service.modules.flowgraph.FlowGraphConfigurationKeys;
@@ -43,10 +42,7 @@ import org.apache.gobblin.util.ConfigUtils;
 @EqualsAndHashCode (callSuper = true)
 public class HiveDataNode extends BaseDataNode {
   public static final String METASTORE_URI_KEY = FlowGraphConfigurationKeys.DATA_NODE_PREFIX + "hive.metastore.uri";
-  @Getter
-  public final String defaultDatasetDescriptorClass = HiveDatasetDescriptor.class.getCanonicalName();
-  @Getter
-  public final String defaultDatasetDescriptorPlatform = "hive";
+  public static final String PLATFORM = "hive";
 
   @Getter
   private String metastoreUri;
@@ -83,5 +79,15 @@ public class HiveDataNode extends BaseDataNode {
       return false;
     }
     return true;
+  }
+
+  @Override
+  public String getDefaultDatasetDescriptorClass() {
+    return HiveDatasetDescriptor.class.getCanonicalName();
+  }
+
+  @Override
+  public String getDefaultDatasetDescriptorPlatform() {
+    return PLATFORM;
   }
 }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1038


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

Set default dataset descriptor config for class/platform by including them in each DataNode. For ones like `BaseDataNode` where it doesn't make sense, they are null so there is no default.

Also added a check that all dest nodes are the same type of datanode since it wouldn't work anyway for there to be multiple types.

## Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

