### PR TITLE
[GOBBLIN-1045] Emit more events in compaction job

### DIFF
--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/action/CompactionHiveRegistrationAction.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/action/CompactionHiveRegistrationAction.java
@@ -50,9 +50,9 @@ import org.apache.gobblin.metrics.event.EventSubmitter;
 @Slf4j
 public class CompactionHiveRegistrationAction implements CompactionCompleteAction<FileSystemDataset> {
 
-  public static final String NUM_FILES = "numFiles";
-  public static final String NUM_ROWS = "numRows";
-  public static final String TOTAL_SIZE = "totalSize";
+  public static final String NUM_OUTPUT_FILES = "numOutputFiles";
+  public static final String RECORD_COUNT = "recordCount";
+  public static final String BYTE_COUNT = "byteCount";
   public static final String DATASET_URN = "datasetUrn";
 
   private final State state;
@@ -73,10 +73,10 @@ public class CompactionHiveRegistrationAction implements CompactionCompleteActio
     CompactionPathParser.CompactionParserResult result = new CompactionPathParser(state).parse(dataset);
 
     long numFiles = state.getPropAsLong(MRCompactionTask.FILE_COUNT, -1);
-    CountEventBuilder fileCountEvent = new CountEventBuilder(NUM_FILES, numFiles);
+    CountEventBuilder fileCountEvent = new CountEventBuilder(NUM_OUTPUT_FILES, numFiles);
     fileCountEvent.addMetadata(DATASET_URN, result.getDstAbsoluteDir());
-    fileCountEvent.addMetadata(NUM_ROWS, state.getProp(MRCompactionTask.RECORD_COUNT, "-1"));
-    fileCountEvent.addMetadata(TOTAL_SIZE, state.getProp(MRCompactionTask.BYTE_COUNT, "-1"));
+    fileCountEvent.addMetadata(RECORD_COUNT, state.getProp(MRCompactionTask.RECORD_COUNT, "-1"));
+    fileCountEvent.addMetadata(BYTE_COUNT, state.getProp(MRCompactionTask.BYTE_COUNT, "-1"));
     this.eventSubmitter.submit(fileCountEvent);
 
     if (state.contains(ConfigurationKeys.HIVE_REGISTRATION_POLICY)) {

--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/action/CompactionHiveRegistrationAction.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/action/CompactionHiveRegistrationAction.java
@@ -77,7 +77,11 @@ public class CompactionHiveRegistrationAction implements CompactionCompleteActio
     fileCountEvent.addMetadata(DATASET_URN, result.getDstAbsoluteDir());
     fileCountEvent.addMetadata(RECORD_COUNT, state.getProp(MRCompactionTask.RECORD_COUNT, "-1"));
     fileCountEvent.addMetadata(BYTE_COUNT, state.getProp(MRCompactionTask.BYTE_COUNT, "-1"));
-    this.eventSubmitter.submit(fileCountEvent);
+    if (this.eventSubmitter != null) {
+      this.eventSubmitter.submit(fileCountEvent);
+    } else {
+      log.warn("Will not emit events in {} as EventSubmitter is null", getClass().getName());
+    }
 
     if (state.contains(ConfigurationKeys.HIVE_REGISTRATION_POLICY)) {
       HiveRegister hiveRegister = HiveRegister.get(state);

--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/CompactorOutputCommitter.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/CompactorOutputCommitter.java
@@ -41,6 +41,11 @@ import org.slf4j.LoggerFactory;
  * {recordCount}.{timestamp}.<extensionName>(avro, orc, etc.).
  */
 public class CompactorOutputCommitter extends FileOutputCommitter {
+
+  public enum EVENT_COUNTER {
+    OUTPUT_FILE_COUNT
+  }
+
   /**
    * Note that the value of this key doesn't have dot.
    */
@@ -93,6 +98,7 @@ public class CompactorOutputCommitter extends FileOutputCommitter {
         Path newPath = new Path(status.getPath().getParent(), fileName);
         LOG.info(String.format("Renaming %s to %s", status.getPath(), newPath));
         fs.rename(status.getPath(), newPath);
+        context.getCounter(EVENT_COUNTER.OUTPUT_FILE_COUNT).increment(1);
       }
     }
 

--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/MRCompactionTask.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/MRCompactionTask.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.lib.output.FileOutputFormatCounter;
 
 import com.google.common.collect.ImmutableMap;
 
@@ -32,11 +33,11 @@ import org.apache.gobblin.compaction.event.CompactionSlaEventHelper;
 import org.apache.gobblin.compaction.suite.CompactionSuite;
 import org.apache.gobblin.compaction.suite.CompactionSuiteUtils;
 import org.apache.gobblin.compaction.verify.CompactionVerifier;
-import org.apache.gobblin.data.management.dataset.SimpleFileSystemDataset;
 import org.apache.gobblin.dataset.Dataset;
 import org.apache.gobblin.dataset.FileSystemDataset;
 import org.apache.gobblin.metrics.event.EventSubmitter;
 import org.apache.gobblin.runtime.TaskContext;
+import org.apache.gobblin.runtime.TaskState;
 import org.apache.gobblin.runtime.mapreduce.MRTask;
 
 
@@ -49,6 +50,11 @@ import org.apache.gobblin.runtime.mapreduce.MRTask;
  */
 @Slf4j
 public class MRCompactionTask extends MRTask {
+
+  public static final String RECORD_COUNT = "counter.recordCount";
+  public static final String FILE_COUNT = "counter.fileCount";
+  public static final String BYTE_COUNT = "counter.byteCount";
+
   protected final CompactionSuite suite;
   protected final Dataset dataset;
   protected final EventSubmitter eventSubmitter;
@@ -95,6 +101,8 @@ public class MRCompactionTask extends MRTask {
   public void onMRTaskComplete (boolean isSuccess, Throwable throwable) {
     if (isSuccess) {
       try {
+        setCounterInfo(taskContext.getTaskState());
+
         List<CompactionCompleteAction> actions = this.suite.getCompactionCompleteActions();
         for (CompactionCompleteAction action: actions) {
           action.addEventSubmitter(eventSubmitter);
@@ -110,6 +118,28 @@ public class MRCompactionTask extends MRTask {
       submitEvent(CompactionSlaEventHelper.COMPACTION_FAILED_EVENT_NAME);
       super.onMRTaskComplete(false, throwable);
     }
+  }
+
+  private void setCounterInfo(TaskState taskState)
+      throws IOException {
+
+    if (mrJob == null) {
+      return;
+    }
+
+    long recordCount = getCounterValue(mrJob, RecordKeyDedupReducerBase.EVENT_COUNTER.RECORD_COUNT);
+    if (recordCount == 0) {
+      // map only job
+      recordCount = getCounterValue(mrJob, RecordKeyMapperBase.EVENT_COUNTER.RECORD_COUNT);
+    }
+    taskState.setProp(RECORD_COUNT, recordCount);
+    taskState.setProp(FILE_COUNT, getCounterValue(mrJob, CompactorOutputCommitter.EVENT_COUNTER.OUTPUT_FILE_COUNT));
+    taskState.setProp(BYTE_COUNT, getCounterValue(mrJob, FileOutputFormatCounter.BYTES_WRITTEN));
+  }
+
+  private long getCounterValue(Job job, Enum<?> key)
+      throws IOException {
+    return job.getCounters().findCounter(key).getValue();
   }
 
   private void submitEvent(String eventName) {

--- a/gobblin-compaction/src/test/java/org/apache/gobblin/compaction/action/CompactionHiveRegistrationActionTest.java
+++ b/gobblin-compaction/src/test/java/org/apache/gobblin/compaction/action/CompactionHiveRegistrationActionTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.compaction.action;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.hadoop.fs.Path;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.Lists;
+
+import org.apache.gobblin.compaction.mapreduce.MRCompactionTask;
+import org.apache.gobblin.compaction.mapreduce.MRCompactor;
+import org.apache.gobblin.configuration.WorkUnitState;
+import org.apache.gobblin.data.management.dataset.SimpleFileSystemDataset;
+import org.apache.gobblin.dataset.FileSystemDataset;
+import org.apache.gobblin.metrics.GobblinTrackingEvent;
+import org.apache.gobblin.metrics.MetricContext;
+import org.apache.gobblin.metrics.context.NameConflictException;
+import org.apache.gobblin.metrics.event.CountEventBuilder;
+import org.apache.gobblin.metrics.event.EventSubmitter;
+
+
+public class CompactionHiveRegistrationActionTest {
+
+  @Test
+  public void testEvents()
+      throws Exception {
+
+    WorkUnitState state = new WorkUnitState();
+    String inputDir = "/data/tracking";
+    String inputSubDir = "hourly";
+    String destSubDir = "daily";
+    String pathPattern = "%s/myTopic/%s/2019/12/20";
+
+    String datasetPath = String.format(pathPattern, inputDir, inputSubDir);
+    state.setProp(MRCompactor.COMPACTION_INPUT_DIR, inputDir);
+    state.setProp(MRCompactor.COMPACTION_DEST_DIR, inputDir);
+    state.setProp(MRCompactor.COMPACTION_INPUT_SUBDIR, inputSubDir);
+    state.setProp(MRCompactor.COMPACTION_DEST_SUBDIR, destSubDir);
+
+    state.setProp(MRCompactionTask.FILE_COUNT, "10");
+    state.setProp(MRCompactionTask.RECORD_COUNT, "100");
+
+    CompactionHiveRegistrationAction action = new CompactionHiveRegistrationAction(state);
+    MockMetricContext mockMetricContext = new MockMetricContext(getClass().getName());
+    String namespace = "compaction.tracking.events";
+    EventSubmitter eventSubmitter = new EventSubmitter.Builder(mockMetricContext, namespace).build();
+    action.addEventSubmitter(eventSubmitter);
+
+    FileSystemDataset dataset = new SimpleFileSystemDataset(new Path(datasetPath));
+    action.onCompactionJobComplete(dataset);
+
+    String destinationPath = String.format(pathPattern, inputDir, destSubDir);
+
+    Assert.assertEquals(mockMetricContext.events.size(), 1);
+    CountEventBuilder fileCountEvent = CountEventBuilder.fromEvent(mockMetricContext.events.get(0));
+    Assert.assertEquals(fileCountEvent.getNamespace(), namespace);
+    Assert.assertEquals(fileCountEvent.getName(), CompactionHiveRegistrationAction.NUM_FILES);
+    Assert.assertEquals(fileCountEvent.getCount(), 10);
+    Map<String, String> metadata = fileCountEvent.getMetadata();
+    Assert.assertEquals(metadata.get(CompactionHiveRegistrationAction.DATASET_URN), destinationPath);
+    Assert.assertEquals(metadata.get(CompactionHiveRegistrationAction.NUM_ROWS), "100");
+    Assert.assertEquals(metadata.get(CompactionHiveRegistrationAction.TOTAL_SIZE), "-1");
+  }
+
+  private class MockMetricContext extends MetricContext {
+
+    List<GobblinTrackingEvent> events;
+
+    MockMetricContext(String name)
+        throws NameConflictException {
+      super(name,null, Lists.newArrayList(), false);
+      events = Lists.newArrayList();
+    }
+
+    @Override
+    public void submitEvent(GobblinTrackingEvent nonReusableEvent) {
+      events.add(nonReusableEvent);
+    }
+  }
+}

--- a/gobblin-compaction/src/test/java/org/apache/gobblin/compaction/action/CompactionHiveRegistrationActionTest.java
+++ b/gobblin-compaction/src/test/java/org/apache/gobblin/compaction/action/CompactionHiveRegistrationActionTest.java
@@ -73,12 +73,12 @@ public class CompactionHiveRegistrationActionTest {
     Assert.assertEquals(mockMetricContext.events.size(), 1);
     CountEventBuilder fileCountEvent = CountEventBuilder.fromEvent(mockMetricContext.events.get(0));
     Assert.assertEquals(fileCountEvent.getNamespace(), namespace);
-    Assert.assertEquals(fileCountEvent.getName(), CompactionHiveRegistrationAction.NUM_FILES);
+    Assert.assertEquals(fileCountEvent.getName(), CompactionHiveRegistrationAction.NUM_OUTPUT_FILES);
     Assert.assertEquals(fileCountEvent.getCount(), 10);
     Map<String, String> metadata = fileCountEvent.getMetadata();
     Assert.assertEquals(metadata.get(CompactionHiveRegistrationAction.DATASET_URN), destinationPath);
-    Assert.assertEquals(metadata.get(CompactionHiveRegistrationAction.NUM_ROWS), "100");
-    Assert.assertEquals(metadata.get(CompactionHiveRegistrationAction.TOTAL_SIZE), "-1");
+    Assert.assertEquals(metadata.get(CompactionHiveRegistrationAction.RECORD_COUNT), "100");
+    Assert.assertEquals(metadata.get(CompactionHiveRegistrationAction.BYTE_COUNT), "-1");
   }
 
   private class MockMetricContext extends MetricContext {

--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/CountEventBuilder.java
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/CountEventBuilder.java
@@ -78,7 +78,7 @@ public class CountEventBuilder extends GobblinEventBuilder {
 
     Map<String, String> metadata = event.getMetadata();
     long count = Long.parseLong(metadata.getOrDefault(COUNT_KEY, "0"));
-    CountEventBuilder countEventBuilder = new CountEventBuilder(event.getName(), count);
+    CountEventBuilder countEventBuilder = new CountEventBuilder(event.getName(), event.getNamespace(), count);
     metadata.forEach((key, value) -> {
       switch (key) {
         case COUNT_KEY:

--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/CountEventBuilder.java
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/CountEventBuilder.java
@@ -38,13 +38,13 @@ public class CountEventBuilder extends GobblinEventBuilder {
   public static final String COUNT_KEY = "count";
   @Setter
   @Getter
-  private int count;
+  private long count;
 
-  public CountEventBuilder(String name, int count) {
+  public CountEventBuilder(String name, long count) {
     this(name, null, count);
   }
 
-  public CountEventBuilder(String name, String namespace, int count) {
+  public CountEventBuilder(String name, String namespace, long count) {
     super(name, namespace);
     this.metadata.put(EVENT_TYPE, COUNT_EVENT_TYPE);
     this.count = count;
@@ -56,7 +56,7 @@ public class CountEventBuilder extends GobblinEventBuilder {
    */
   @Override
   public GobblinTrackingEvent build() {
-    this.metadata.put(COUNT_KEY, Integer.toString(count));
+    this.metadata.put(COUNT_KEY, Long.toString(count));
     return super.build();
   }
 
@@ -77,7 +77,7 @@ public class CountEventBuilder extends GobblinEventBuilder {
     }
 
     Map<String, String> metadata = event.getMetadata();
-    int count = Integer.parseInt(metadata.getOrDefault(COUNT_KEY, "0"));
+    long count = Long.parseLong(metadata.getOrDefault(COUNT_KEY, "0"));
     CountEventBuilder countEventBuilder = new CountEventBuilder(event.getName(), count);
     metadata.forEach((key, value) -> {
       switch (key) {

--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/EntityMissingEventBuilder.java
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/EntityMissingEventBuilder.java
@@ -70,7 +70,8 @@ public class EntityMissingEventBuilder extends GobblinEventBuilder {
 
     Map<String, String> metadata = event.getMetadata();
     String instance = metadata.get(INSTANCE_KEY);
-    EntityMissingEventBuilder eventBuilder = new EntityMissingEventBuilder(event.getName(), instance);
+    EntityMissingEventBuilder eventBuilder = new EntityMissingEventBuilder(
+        event.getName(), event.getNamespace(), instance);
     metadata.forEach((key, value) -> {
       switch (key) {
         case INSTANCE_KEY:

--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/FailureEventBuilder.java
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/FailureEventBuilder.java
@@ -99,7 +99,7 @@ public class FailureEventBuilder extends GobblinEventBuilder {
     }
 
     Map<String, String> metadata = event.getMetadata();
-    FailureEventBuilder failureEvent = new FailureEventBuilder(event.getName());
+    FailureEventBuilder failureEvent = new FailureEventBuilder(event.getName(), event.getNamespace());
 
     metadata.forEach((key, value) -> {
       switch (key) {

--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/JobStateEventBuilder.java
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/JobStateEventBuilder.java
@@ -71,7 +71,7 @@ public class JobStateEventBuilder extends GobblinEventBuilder {
     }
 
     Map<String, String> metadata = event.getMetadata();
-    JobStateEventBuilder eventBuilder = new JobStateEventBuilder(event.getName());
+    JobStateEventBuilder eventBuilder = new JobStateEventBuilder(event.getName(), event.getNamespace());
     metadata.forEach((key, value) -> {
       switch (key) {
         case STATUS_KEY:

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/mapreduce/MRTask.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/mapreduce/MRTask.java
@@ -61,7 +61,7 @@ public class MRTask extends BaseAbstractTask {
     }
   }
 
-  private final TaskContext taskContext;
+  protected final TaskContext taskContext;
   private final EventSubmitter eventSubmitter;
   protected Job mrJob;
 


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/GOBBLIN-1045


### Description
- [x] Here are some details about my PR:
  - Emit count event for the following item in compaction job
    - number of files, corresponding to hive metadata "numFiles"
    - record count, corresponding to hive metadata "numRows"
    - bytes written, corresponding to hive metadata "totalSize"


### Tests
- [x] My PR adds the following unit tests:
- `CompactionHiveRegistrationActionTest.testEvents` verify that a file count event is emitted successfully with required metadata


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

