### PR TITLE
[GOBBLIN-1046] Make /final subdir configurable in ORC-conversion output

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/converter/AbstractAvroToOrcConverter.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/converter/AbstractAvroToOrcConverter.java
@@ -71,6 +71,8 @@ import org.apache.gobblin.metrics.event.sla.SlaEventKeys;
 import org.apache.gobblin.util.AutoReturnableObject;
 import org.apache.gobblin.util.HadoopUtils;
 
+import static org.apache.gobblin.data.management.conversion.hive.dataset.ConvertibleHiveDataset.getFinalizedDestinationLocation;
+
 
 /**
  * Builds the Hive avro to ORC conversion query. The record type for this converter is {@link QueryBasedHiveConversionEntity}. A {@link QueryBasedHiveConversionEntity}
@@ -637,8 +639,8 @@ public abstract class AbstractAvroToOrcConverter extends Converter<Schema, Schem
    */
   private String getOrcDataLocation() {
     String orcDataLocation = getConversionConfig().getDestinationDataPath();
-
-    return orcDataLocation + Path.SEPARATOR + PUBLISHED_TABLE_SUBDIRECTORY;
+    return getConversionConfig().getDataDstPathUseSubdir() ? getFinalizedDestinationLocation(orcDataLocation)
+        : orcDataLocation;
   }
 
   /***

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/converter/AbstractAvroToOrcConverter.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/converter/AbstractAvroToOrcConverter.java
@@ -71,7 +71,7 @@ import org.apache.gobblin.metrics.event.sla.SlaEventKeys;
 import org.apache.gobblin.util.AutoReturnableObject;
 import org.apache.gobblin.util.HadoopUtils;
 
-import static org.apache.gobblin.data.management.conversion.hive.dataset.ConvertibleHiveDataset.getFinalizedDestinationLocation;
+import static org.apache.gobblin.data.management.conversion.hive.task.HiveConverterUtils.getOutputDataLocation;
 
 
 /**
@@ -639,7 +639,7 @@ public abstract class AbstractAvroToOrcConverter extends Converter<Schema, Schem
    */
   private String getOrcDataLocation() {
     String orcDataLocation = getConversionConfig().getDestinationDataPath();
-    return getConversionConfig().getDataDstPathUseSubdir() ? getFinalizedDestinationLocation(orcDataLocation)
+    return getConversionConfig().getDataDstPathUseSubdir() ? getOutputDataLocation(orcDataLocation)
         : orcDataLocation;
   }
 

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/dataset/ConvertibleHiveDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/dataset/ConvertibleHiveDataset.java
@@ -141,12 +141,21 @@ public class ConvertibleHiveDataset extends HiveDataset {
       String destTable = conversionConfigForFormat.get().getDestinationDbName() + "." + conversionConfigForFormat.get()
           .getDestinationTableName();
       DatasetDescriptor dest = new DatasetDescriptor(DatasetConstants.PLATFORM_HIVE, destTable);
-      String destLocation = conversionConfigForFormat.get().getDestinationDataPath() + Path.SEPARATOR + "final";
+      String destLocation = conversionConfigForFormat.get().getDataDstPathUseSubdir()
+          ? getFinalizedDestinationLocation(conversionConfigForFormat.get().getDestinationDataPath())
+          : conversionConfigForFormat.get().getDestinationDataPath();
       dest.addMetadata(DatasetConstants.FS_SCHEME, getSourceDataset().getMetadata().get(DatasetConstants.FS_SCHEME));
       dest.addMetadata(DatasetConstants.FS_LOCATION, destLocation);
       destDatasets.add(dest);
     }
     return destDatasets;
+  }
+
+  /**
+   *  The default behavior for ORC output in Avro2ORC is to add subdir "/final" under destination path from Config.
+   */
+  public static final String getFinalizedDestinationLocation(String destinationDataPathFromConfig) {
+    return destinationDataPathFromConfig + Path.SEPARATOR + "final";
   }
 
   private DatasetDescriptor createSourceDataset() {

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/dataset/ConvertibleHiveDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/dataset/ConvertibleHiveDataset.java
@@ -47,6 +47,8 @@ import org.apache.gobblin.data.management.copy.hive.HiveDatasetFinder;
 import org.apache.gobblin.hive.HiveMetastoreClientPool;
 import org.apache.gobblin.util.ConfigUtils;
 
+import static org.apache.gobblin.data.management.conversion.hive.task.HiveConverterUtils.getOutputDataLocation;
+
 
 /**
  * <p>
@@ -142,20 +144,13 @@ public class ConvertibleHiveDataset extends HiveDataset {
           .getDestinationTableName();
       DatasetDescriptor dest = new DatasetDescriptor(DatasetConstants.PLATFORM_HIVE, destTable);
       String destLocation = conversionConfigForFormat.get().getDataDstPathUseSubdir()
-          ? getFinalizedDestinationLocation(conversionConfigForFormat.get().getDestinationDataPath())
+          ? getOutputDataLocation(conversionConfigForFormat.get().getDestinationDataPath())
           : conversionConfigForFormat.get().getDestinationDataPath();
       dest.addMetadata(DatasetConstants.FS_SCHEME, getSourceDataset().getMetadata().get(DatasetConstants.FS_SCHEME));
       dest.addMetadata(DatasetConstants.FS_LOCATION, destLocation);
       destDatasets.add(dest);
     }
     return destDatasets;
-  }
-
-  /**
-   *  The default behavior for ORC output in Avro2ORC is to add subdir "/final" under destination path from Config.
-   */
-  public static final String getFinalizedDestinationLocation(String destinationDataPathFromConfig) {
-    return destinationDataPathFromConfig + Path.SEPARATOR + "final";
   }
 
   private DatasetDescriptor createSourceDataset() {

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/entities/StageableTableMetadata.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/entities/StageableTableMetadata.java
@@ -46,6 +46,7 @@ public class StageableTableMetadata {
   public static final String DESTINATION_TABLE_KEY = "destination.tableName";
   public static final String DESTINATION_DB_KEY = "destination.dbName";
   public static final String DESTINATION_DATA_PATH_KEY = "destination.dataPath";
+  public static final String DESTINATION_DATA_PATH_ADD_SUBDIR = "destination.dataPathAddSubDir";
   public static final String DESTINATION_TABLE_PROPERTIES_LIST_KEY = "destination.tableProperties";
   public static final String CLUSTER_BY_KEY = "clusterByList";
   public static final String NUM_BUCKETS_KEY = "numBuckets";
@@ -113,6 +114,8 @@ public class StageableTableMetadata {
   private final String destinationDbName;
   /** Path where files of the destination table should be located. */
   private final String destinationDataPath;
+  /** Flag whether adding a subdirectory after destinationDataPath */
+  private final Boolean dataDstPathUseSubdir;
   /** Table properties of destination table. */
   private final Properties destinationTableProperties;
   /** List of columns to cluster by. */
@@ -139,6 +142,9 @@ public class StageableTableMetadata {
         : HiveDataset.resolveTemplate(config.getString(DESTINATION_DB_KEY), referenceTable);
     this.destinationDataPath = referenceTable == null ? config.getString(DESTINATION_DATA_PATH_KEY)
         : HiveDataset.resolveTemplate(config.getString(DESTINATION_DATA_PATH_KEY), referenceTable);
+
+    // By default, this value is true and subDir "/final" is being added into orc output location.
+    this.dataDstPathUseSubdir = !config.hasPath(DESTINATION_DATA_PATH_ADD_SUBDIR) || config.getBoolean(DESTINATION_DATA_PATH_ADD_SUBDIR);
 
     // Optional
     this.destinationTableProperties =

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/entities/TableLikeStageableTableMetadata.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/entities/TableLikeStageableTableMetadata.java
@@ -33,7 +33,7 @@ import com.typesafe.config.Config;
 public class TableLikeStageableTableMetadata extends StageableTableMetadata {
 
   public TableLikeStageableTableMetadata(Table referenceTable, String destinationDB, String destinationTableName, String targetDataPath) {
-    super(destinationTableName, destinationTableName + "_STAGING", destinationDB, targetDataPath,
+    super(destinationTableName, destinationTableName + "_STAGING", destinationDB, targetDataPath, true,
         getTableProperties(referenceTable), new ArrayList<>(), Optional.of(referenceTable.getNumBuckets()), new Properties(), false, false, Optional.absent(),
         new ArrayList<>());
   }
@@ -43,6 +43,8 @@ public class TableLikeStageableTableMetadata extends StageableTableMetadata {
         HiveDataset.resolveTemplate(config.getString(StageableTableMetadata.DESTINATION_TABLE_KEY), referenceTable) + "_STAGING",
         HiveDataset.resolveTemplate(config.getString(StageableTableMetadata.DESTINATION_DB_KEY), referenceTable),
         HiveDataset.resolveTemplate(config.getString(DESTINATION_DATA_PATH_KEY), referenceTable),
+        (!config.hasPath(StageableTableMetadata.DESTINATION_DATA_PATH_ADD_SUBDIR) ||
+            Boolean.parseBoolean(HiveDataset.resolveTemplate(config.getString(StageableTableMetadata.DESTINATION_DATA_PATH_ADD_SUBDIR), referenceTable))),
         getTableProperties(referenceTable), new ArrayList<>(), Optional.of(referenceTable.getNumBuckets()),
         new Properties(), false, false, Optional.absent(), new ArrayList<>());
   }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/task/HiveConverterUtils.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/task/HiveConverterUtils.java
@@ -87,6 +87,7 @@ public class HiveConverterUtils {
    */
   private static final String PUBLISHED_TABLE_SUBDIRECTORY = "final";
 
+
   /***
    * Separators used by Hive
    */

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/task/HiveConverterUtils.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/task/HiveConverterUtils.java
@@ -87,7 +87,6 @@ public class HiveConverterUtils {
    */
   private static final String PUBLISHED_TABLE_SUBDIRECTORY = "final";
 
-
   /***
    * Separators used by Hive
    */


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

The output of Avro2ORC conversion pipeline used to require the output of it to have hard-coded `/final` under the value of `hive.conversion.avro.nestedOrc.destination.dataPath` which is not reasonable.  Adding the fix to make it possible to ignore `/final` in the output. 


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1046


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

