### PR TITLE
GOBBLIN-1048: Provide an option to pass and set System properties via…

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
@@ -193,4 +193,6 @@ public class GobblinClusterConfigurationKeys {
   public static final String HELIX_PARTITION_ID_KEY = GOBBLIN_HELIX_PREFIX + "partitionId" ;
   public static final String TASK_RUNNER_HOST_NAME_KEY = GOBBLIN_HELIX_PREFIX + "hostName";
   public static final String CONTAINER_ID_KEY = GOBBLIN_HELIX_PREFIX + "containerId";
+
+  public static final String GOBBLIN_CLUSTER_SYSTEM_PROPERTY_PREFIX = GOBBLIN_CLUSTER_PREFIX + "sysProps";
 }

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterManager.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterManager.java
@@ -150,6 +150,10 @@ public class GobblinClusterManager implements ApplicationLauncher, StandardMetri
 
     this.applicationId = applicationId;
 
+    //Helix uses System#getProperty() for ZK configuration overrides such as sessionTimeout. The overrides specified
+    // in the application configuration have to be extracted and set before initializing HelixManager.
+    HelixUtils.setSystemProperties(config);
+
     initializeHelixManager();
 
     this.fs = buildFileSystem(config);

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterManager.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterManager.java
@@ -150,7 +150,8 @@ public class GobblinClusterManager implements ApplicationLauncher, StandardMetri
 
     this.applicationId = applicationId;
 
-    //Helix uses System#getProperty() for ZK configuration overrides such as sessionTimeout. The overrides specified
+    //Set system properties passed in via application config. As an example, Helix uses System#getProperty() for ZK configuration
+    // overrides such as sessionTimeout. In this case, the overrides specified
     // in the application configuration have to be extracted and set before initializing HelixManager.
     HelixUtils.setSystemProperties(config);
 

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinTaskRunner.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinTaskRunner.java
@@ -174,7 +174,8 @@ public class GobblinTaskRunner implements StandardMetricsBridge {
     this.config = saveConfigToFile(config);
     this.clusterName = this.config.getString(GobblinClusterConfigurationKeys.HELIX_CLUSTER_NAME_KEY);
 
-    //Helix uses System#getProperty() for ZK configuration overrides such as sessionTimeout. The overrides specified
+    //Set system properties passed in via application config. As an example, Helix uses System#getProperty() for ZK configuration
+    // overrides such as sessionTimeout. In this case, the overrides specified
     // in the application configuration have to be extracted and set before initializing HelixManager.
     HelixUtils.setSystemProperties(config);
 

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinTaskRunner.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinTaskRunner.java
@@ -174,6 +174,10 @@ public class GobblinTaskRunner implements StandardMetricsBridge {
     this.config = saveConfigToFile(config);
     this.clusterName = this.config.getString(GobblinClusterConfigurationKeys.HELIX_CLUSTER_NAME_KEY);
 
+    //Helix uses System#getProperty() for ZK configuration overrides such as sessionTimeout. The overrides specified
+    // in the application configuration have to be extracted and set before initializing HelixManager.
+    HelixUtils.setSystemProperties(config);
+
     initHelixManager();
 
     this.containerMetrics = buildContainerMetrics();

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/HelixUtils.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/HelixUtils.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -39,11 +40,15 @@ import org.apache.helix.task.WorkflowConfig;
 import org.apache.helix.task.WorkflowContext;
 import org.apache.helix.tools.ClusterSetup;
 
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.runtime.JobException;
 import org.apache.gobblin.runtime.listeners.JobListener;
+import org.apache.gobblin.util.ConfigUtils;
 
 import static org.apache.helix.task.TaskState.STOPPED;
 
@@ -307,5 +312,18 @@ public class HelixUtils {
       }
     }
     return jobNameToWorkflowId;
+  }
+
+  /**
+   * Return the system properties from the input {@link Config} instance
+   * @param config
+   */
+  public static void setSystemProperties(Config config) {
+    Properties properties = ConfigUtils.configToProperties(ConfigUtils.getConfig(config, GobblinClusterConfigurationKeys.GOBBLIN_CLUSTER_SYSTEM_PROPERTY_PREFIX,
+        ConfigFactory.empty()));
+
+    for (Map.Entry<Object, Object> entry: properties.entrySet()) {
+      System.setProperty(entry.getKey().toString(), entry.getValue().toString());
+    }
   }
 }

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/HelixUtilsTest.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/HelixUtilsTest.java
@@ -33,6 +33,7 @@ import org.testng.annotations.Test;
 
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigValueFactory;
 
 import org.apache.gobblin.util.ConfigUtils;
 
@@ -78,6 +79,23 @@ public class HelixUtilsTest {
     Assert.assertEquals(properties.getProperty("k3"), "1000");
     Assert.assertEquals(properties.getProperty("k4"), "true");
     Assert.assertEquals(properties.getProperty("k5"), "10000");
+  }
+
+  @Test
+  public void testSetSystemProperties() {
+    //Set a dummy property before calling HelixUtils#setSystemProperties() and assert that this property and value
+    //exists even after the call to the setSystemProperties() method.
+    System.setProperty("prop1", "val1");
+
+    Config config = ConfigFactory.empty().withValue(GobblinClusterConfigurationKeys.GOBBLIN_CLUSTER_SYSTEM_PROPERTY_PREFIX + ".prop2",
+        ConfigValueFactory.fromAnyRef("val2"))
+        .withValue(GobblinClusterConfigurationKeys.GOBBLIN_CLUSTER_SYSTEM_PROPERTY_PREFIX + ".prop3", ConfigValueFactory.fromAnyRef("val3"));
+
+    HelixUtils.setSystemProperties(config);
+
+    Assert.assertEquals(System.getProperty("prop1"), "val1");
+    Assert.assertEquals(System.getProperty("prop2"), "val2");
+    Assert.assertEquals(System.getProperty("prop3"), "val3");
   }
 
   @AfterClass


### PR DESCRIPTION
… Gobblin Cluster application config

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1048


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Helix accesses and sets ZK config overrides (e.g. ZK client session timeout) via Java System properties. This task provides an ability to pass system overrides via Gobblin Cluster application configuration and sets these overrides in the cluster manager and task runners.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Added unit test in HelixUtilsTest.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

