### PR TITLE
[GOBBLIN-1049] Move workunit commit logic to the end of publish().

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/publisher/DataPublisher.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/publisher/DataPublisher.java
@@ -81,6 +81,15 @@ public abstract class DataPublisher implements Closeable, CapabilityAware {
       publishData(states);
       publishMetadata(states);
     }
+    markCommit(states);
+  }
+
+  protected void markCommit(Collection<? extends WorkUnitState> states) {
+    for (WorkUnitState workUnitState : states) {
+      if (workUnitState.getWorkingState() == WorkUnitState.WorkingState.SUCCESSFUL) {
+        workUnitState.setWorkingState(WorkUnitState.WorkingState.COMMITTED);
+      }
+    }
   }
 
   public State getState() {

--- a/gobblin-core/src/main/java/org/apache/gobblin/publisher/BaseDataPublisher.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/publisher/BaseDataPublisher.java
@@ -365,13 +365,6 @@ public class BaseDataPublisher extends SingleTaskDataPublisher {
     }
 
     this.parallelRunnerCloser.close();
-
-    for (WorkUnitState workUnitState : states) {
-      // Upon successfully committing the data to the final output directory, set states
-      // of successful tasks to COMMITTED. leaving states of unsuccessful ones unchanged.
-      // This makes sense to the COMMIT_ON_PARTIAL_SUCCESS policy.
-      workUnitState.setWorkingState(WorkUnitState.WorkingState.COMMITTED);
-    }
   }
 
   /**

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/JobLauncherTestHelper.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/JobLauncherTestHelper.java
@@ -345,8 +345,7 @@ public class JobLauncherTestHelper {
       Assert.assertEquals(datasetState.getState(), JobState.RunningState.COMMITTED);
       Assert.assertEquals(datasetState.getTaskCount(), 1);
       TaskState taskState = datasetState.getTaskStates().get(0);
-      // BaseDataPublisher will change the state to COMMITTED
-      Assert.assertEquals(taskState.getWorkingState(), WorkUnitState.WorkingState.COMMITTED);
+      Assert.assertEquals(taskState.getWorkingState(), WorkUnitState.WorkingState.FAILED);
     } else {
       // Task 0 should have failed
       Assert.assertTrue(this.datasetStateStore.getAll(jobName, "Dataset0-current.jst").isEmpty());


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1049


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
   Add the markCommit() in the DataPublisher interface, which is at the end of the publishing logic.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

