### PR TITLE
GOBBLIN-1052: Create a spec consumer path if it does not exist in FS …

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/FsJobConfigurationManager.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/FsJobConfigurationManager.java
@@ -99,8 +99,8 @@ public class FsJobConfigurationManager extends JobConfigurationManager {
         try {
           fetchJobSpecs();
         } catch (InterruptedException | ExecutionException e) {
-          log.error("Failed to fetch job specs", e);
-          throw new RuntimeException("Failed to fetch specs", e);
+          //Log error and swallow exception to allow executor to continue scheduling the thread
+          log.error("Failed to fetch job specs due to: {}", e);
         }
       }
     }, 0, this.refreshIntervalInSeconds, TimeUnit.SECONDS);
@@ -110,6 +110,7 @@ public class FsJobConfigurationManager extends JobConfigurationManager {
     List<Pair<SpecExecutor.Verb, JobSpec>> jobSpecs =
         (List<Pair<SpecExecutor.Verb, JobSpec>>) this._specConsumer.changedSpecs().get();
 
+    log.info("Fetched {} job specs", jobSpecs.size());
     for (Pair<SpecExecutor.Verb, JobSpec> entry : jobSpecs) {
       JobSpec jobSpec = entry.getValue();
       SpecExecutor.Verb verb = entry.getKey();

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/FsJobConfigurationManager.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/FsJobConfigurationManager.java
@@ -17,15 +17,14 @@
 package org.apache.gobblin.cluster;
 
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.commons.lang3.reflect.ConstructorUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.fs.FileSystem;
 
 import com.google.common.base.Optional;
 import com.google.common.eventbus.EventBus;
@@ -38,7 +37,6 @@ import org.apache.gobblin.runtime.api.JobSpec;
 import org.apache.gobblin.runtime.api.MutableJobCatalog;
 import org.apache.gobblin.runtime.api.SpecConsumer;
 import org.apache.gobblin.runtime.api.SpecExecutor;
-import org.apache.gobblin.util.ClassAliasResolver;
 import org.apache.gobblin.util.ConfigUtils;
 import org.apache.gobblin.util.ExecutorsUtils;
 
@@ -55,42 +53,26 @@ public class FsJobConfigurationManager extends JobConfigurationManager {
   private static final long DEFAULT_JOB_SPEC_REFRESH_INTERVAL = 60;
 
   private final long refreshIntervalInSeconds;
-
   private final ScheduledExecutorService fetchJobSpecExecutor;
+  private final Optional<MutableJobCatalog> jobCatalogOptional;
+  private final SpecConsumer specConsumer;
 
-  protected final SpecConsumer _specConsumer;
-
-  private final ClassAliasResolver<SpecConsumer> aliasResolver;
-
-  private final Optional<MutableJobCatalog> _jobCatalogOptional;
-
-  public FsJobConfigurationManager(EventBus eventBus, Config config) {
-    this(eventBus, config, null);
+  public FsJobConfigurationManager(EventBus eventBus, Config config, FileSystem fs) {
+    this(eventBus, config, null, fs);
   }
 
-  public FsJobConfigurationManager(EventBus eventBus, Config config, MutableJobCatalog jobCatalog) {
+  public FsJobConfigurationManager(EventBus eventBus, Config config, MutableJobCatalog jobCatalog, FileSystem fs) {
     super(eventBus, config);
-    this._jobCatalogOptional = jobCatalog != null ? Optional.of(jobCatalog) : Optional.absent();
+    this.jobCatalogOptional = jobCatalog != null ? Optional.of(jobCatalog) : Optional.absent();
     this.refreshIntervalInSeconds = ConfigUtils.getLong(config, GobblinClusterConfigurationKeys.JOB_SPEC_REFRESH_INTERVAL,
         DEFAULT_JOB_SPEC_REFRESH_INTERVAL);
 
     this.fetchJobSpecExecutor = Executors.newSingleThreadScheduledExecutor(
         ExecutorsUtils.newThreadFactory(Optional.of(log), Optional.of("FetchJobSpecExecutor")));
-
-    this.aliasResolver = new ClassAliasResolver<>(SpecConsumer.class);
-    try {
-      String specConsumerClassName = ConfigUtils.getString(config, GobblinClusterConfigurationKeys.SPEC_CONSUMER_CLASS_KEY,
-          GobblinClusterConfigurationKeys.DEFAULT_SPEC_CONSUMER_CLASS);
-      log.info("Using SpecConsumer ClassNameclass name/alias " + specConsumerClassName);
-      this._specConsumer = (SpecConsumer) ConstructorUtils
-          .invokeConstructor(Class.forName(this.aliasResolver.resolve(specConsumerClassName)), config);
-    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException | InstantiationException
-        | ClassNotFoundException e) {
-      throw new RuntimeException(e);
-    }
+    this.specConsumer = new FsSpecConsumer(fs, config);
   }
 
-  protected void startUp() throws Exception{
+  protected void startUp() throws Exception {
     super.startUp();
     // Schedule the job config fetch task
     this.fetchJobSpecExecutor.scheduleAtFixedRate(new Runnable() {
@@ -98,9 +80,9 @@ public class FsJobConfigurationManager extends JobConfigurationManager {
       public void run() {
         try {
           fetchJobSpecs();
-        } catch (InterruptedException | ExecutionException e) {
-          //Log error and swallow exception to allow executor to continue scheduling the thread
-          log.error("Failed to fetch job specs due to: {}", e);
+        } catch (Exception e) {
+          //Log error and swallow exception to allow executor service to continue scheduling the thread
+          log.error("Failed to fetch job specs due to: ", e);
         }
       }
     }, 0, this.refreshIntervalInSeconds, TimeUnit.SECONDS);
@@ -108,7 +90,7 @@ public class FsJobConfigurationManager extends JobConfigurationManager {
 
   void fetchJobSpecs() throws ExecutionException, InterruptedException {
     List<Pair<SpecExecutor.Verb, JobSpec>> jobSpecs =
-        (List<Pair<SpecExecutor.Verb, JobSpec>>) this._specConsumer.changedSpecs().get();
+        (List<Pair<SpecExecutor.Verb, JobSpec>>) this.specConsumer.changedSpecs().get();
 
     log.info("Fetched {} job specs", jobSpecs.size());
     for (Pair<SpecExecutor.Verb, JobSpec> entry : jobSpecs) {
@@ -116,20 +98,20 @@ public class FsJobConfigurationManager extends JobConfigurationManager {
       SpecExecutor.Verb verb = entry.getKey();
       if (verb.equals(SpecExecutor.Verb.ADD)) {
         // Handle addition
-        if (this._jobCatalogOptional.isPresent()) {
-          this._jobCatalogOptional.get().put(jobSpec);
+        if (this.jobCatalogOptional.isPresent()) {
+          this.jobCatalogOptional.get().put(jobSpec);
         }
         postNewJobConfigArrival(jobSpec.getUri().toString(), jobSpec.getConfigAsProperties());
       } else if (verb.equals(SpecExecutor.Verb.UPDATE)) {
         //Handle update.
-        if (this._jobCatalogOptional.isPresent()) {
-          this._jobCatalogOptional.get().put(jobSpec);
+        if (this.jobCatalogOptional.isPresent()) {
+          this.jobCatalogOptional.get().put(jobSpec);
         }
         postUpdateJobConfigArrival(jobSpec.getUri().toString(), jobSpec.getConfigAsProperties());
       } else if (verb.equals(SpecExecutor.Verb.DELETE)) {
         // Handle delete
-        if (this._jobCatalogOptional.isPresent()) {
-          this._jobCatalogOptional.get().remove(jobSpec.getUri());
+        if (this.jobCatalogOptional.isPresent()) {
+          this.jobCatalogOptional.get().remove(jobSpec.getUri());
         }
         postDeleteJobConfigArrival(jobSpec.getUri().toString(), jobSpec.getConfigAsProperties());
       }
@@ -137,7 +119,7 @@ public class FsJobConfigurationManager extends JobConfigurationManager {
       try {
         //Acknowledge the successful consumption of the JobSpec back to the SpecConsumer, so that the
         //SpecConsumer can delete the JobSpec.
-        this._specConsumer.commit(jobSpec);
+        this.specConsumer.commit(jobSpec);
       } catch (IOException e) {
         log.error("Error when committing to FsSpecConsumer: ", e);
       }

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
@@ -157,7 +157,7 @@ public class GobblinClusterConfigurationKeys {
   public static final long DEFAULT_HELIX_WORKFLOW_DELETE_TIMEOUT_SECONDS = 300;
 
   public static final String HELIX_WORKFLOW_LISTING_TIMEOUT_SECONDS = GOBBLIN_CLUSTER_PREFIX + "workflowListingTimeoutSeconds";
-  public static final long DEFAULT_HELIX_WORKFLOW_LISTING_TIMEOUT_SECONDS = 300;
+  public static final long DEFAULT_HELIX_WORKFLOW_LISTING_TIMEOUT_SECONDS = 60;
 
   public static final String CLEAN_ALL_DIST_JOBS = GOBBLIN_CLUSTER_PREFIX + "bootup.clean.dist.jobs";
   public static final boolean DEFAULT_CLEAN_ALL_DIST_JOBS = false;

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterManager.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterManager.java
@@ -18,7 +18,6 @@
 package org.apache.gobblin.cluster;
 
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -396,16 +395,15 @@ public class GobblinClusterManager implements ApplicationLauncher, StandardMetri
 
   private JobConfigurationManager create(Config config) {
     try {
-      List<Object> argumentList = (this.jobCatalog != null)? ImmutableList.of(this.eventBus, config, this.jobCatalog) :
-          ImmutableList.of(this.eventBus, config);
+      List<Object> argumentList = (this.jobCatalog != null)? ImmutableList.of(this.eventBus, config, this.jobCatalog, this.fs) :
+          ImmutableList.of(this.eventBus, config, this.fs);
       if (config.hasPath(GobblinClusterConfigurationKeys.JOB_CONFIGURATION_MANAGER_KEY)) {
-        return (JobConfigurationManager) GobblinConstructorUtils.invokeFirstConstructor(Class.forName(
-            config.getString(GobblinClusterConfigurationKeys.JOB_CONFIGURATION_MANAGER_KEY)), argumentList);
+        return (JobConfigurationManager) GobblinConstructorUtils.invokeLongestConstructor(Class.forName(
+            config.getString(GobblinClusterConfigurationKeys.JOB_CONFIGURATION_MANAGER_KEY)), argumentList.toArray(new Object[argumentList.size()]));
       } else {
         return new JobConfigurationManager(this.eventBus, config);
       }
-    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException | InstantiationException |
-        ClassNotFoundException e) {
+    } catch (ReflectiveOperationException e) {
       throw new RuntimeException(e);
     }
   }

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobScheduler.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobScheduler.java
@@ -377,7 +377,7 @@ public class GobblinHelixJobScheduler extends JobScheduler implements StandardMe
           Collections.singletonList(deleteJobArrival.getJobName()));
       Retryer<Map<String, String>> retryer = RetryerBuilder.<Map<String, String>>newBuilder()
           .retryIfException()
-          .withStopStrategy(StopStrategies.stopAfterAttempt(1))
+          .withStopStrategy(StopStrategies.stopAfterAttempt(5))
           .withAttemptTimeLimiter(AttemptTimeLimiters.fixedTimeLimit(this.helixWorkflowListingTimeoutMillis, TimeUnit.MILLISECONDS)).build();
       Map<String, String> jobNameToWorkflowIdMap;
       try {

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/HelixUtils.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/HelixUtils.java
@@ -278,7 +278,7 @@ public class HelixUtils {
   }
 
   /**
-   * Returns the Helix Workflow Ids given {@link Iterable} of Gobblin job names. The method returns a
+   * Returns the currently running Helix Workflow Ids given an {@link Iterable} of Gobblin job names. The method returns a
    * {@link java.util.Map} from Gobblin job name to the corresponding Helix Workflow Id. This method iterates
    * over all Helix workflows, and obtains the jobs of each workflow from its jobDag.
    *

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/HelixUtils.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/HelixUtils.java
@@ -31,6 +31,7 @@ import org.apache.helix.HelixManager;
 import org.apache.helix.manager.zk.ZKHelixManager;
 import org.apache.helix.model.HelixConfigScope;
 import org.apache.helix.task.JobConfig;
+import org.apache.helix.task.TargetState;
 import org.apache.helix.task.TaskConfig;
 import org.apache.helix.task.TaskDriver;
 import org.apache.helix.task.TaskState;
@@ -293,6 +294,10 @@ public class HelixUtils {
     Map<String, WorkflowConfig> workflowConfigMap = taskDriver.getWorkflows();
     for (String workflow : workflowConfigMap.keySet()) {
       WorkflowConfig workflowConfig = taskDriver.getWorkflowConfig(workflow);
+      //Filter out any stale Helix workflows which are not running.
+      if (workflowConfig.getTargetState() != TargetState.START) {
+        continue;
+      }
       Set<String> helixJobs = workflowConfig.getJobDag().getAllNodes();
       for (String helixJob : helixJobs) {
         Iterator<TaskConfig> taskConfigIterator = taskDriver.getJobConfig(helixJob).getTaskConfigMap().values().iterator();

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/FsJobConfigurationManagerTest.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/FsJobConfigurationManagerTest.java
@@ -51,6 +51,8 @@ import org.apache.gobblin.runtime.api.MutableJobCatalog;
 import org.apache.gobblin.runtime.api.SpecExecutor;
 import org.apache.gobblin.runtime.api.SpecProducer;
 import org.apache.gobblin.runtime.job_catalog.NonObservingFSJobCatalog;
+import org.apache.gobblin.util.filters.HiddenFilter;
+
 
 @Slf4j
 public class FsJobConfigurationManagerTest {
@@ -97,16 +99,15 @@ public class FsJobConfigurationManagerTest {
 
     Config config = ConfigFactory.empty()
         .withValue(ConfigurationKeys.JOB_CONFIG_FILE_GENERAL_PATH_KEY, ConfigValueFactory.fromAnyRef(jobConfDir))
-        .withValue(GobblinClusterConfigurationKeys.SPEC_CONSUMER_CLASS_KEY, ConfigValueFactory.fromAnyRef(FsSpecConsumer.class.getName()))
         .withValue(FsSpecConsumer.SPEC_PATH_KEY, ConfigValueFactory.fromAnyRef(fsSpecConsumerPathString))
         .withValue(GobblinClusterConfigurationKeys.JOB_SPEC_REFRESH_INTERVAL, ConfigValueFactory.fromAnyRef(1));
 
     this._jobCatalog = new NonObservingFSJobCatalog(config);
     ((NonObservingFSJobCatalog) this._jobCatalog).startAsync().awaitRunning();
 
-    jobConfigurationManager = new FsJobConfigurationManager(eventBus, config, this._jobCatalog);
+    jobConfigurationManager = new FsJobConfigurationManager(eventBus, config, this._jobCatalog, this.fs);
 
-    _specProducer = new FsSpecProducer(config);
+    _specProducer = new FsSpecProducer(this.fs, config);
   }
 
   private void addJobSpec(String jobSpecName, String version, String verb)
@@ -150,7 +151,7 @@ public class FsJobConfigurationManagerTest {
 
     //Ensure the JobSpec is deleted from the FsSpecConsumer path.
     Path fsSpecConsumerPath = new Path(fsSpecConsumerPathString);
-    Assert.assertEquals(this.fs.listStatus(fsSpecConsumerPath).length, 0);
+    Assert.assertEquals(this.fs.listStatus(fsSpecConsumerPath, new HiddenFilter()).length, 0);
 
     //Ensure NewJobConfigArrivalEvent is posted to EventBus
     Assert.assertEquals(newJobConfigArrivalEventCount, 1);
@@ -167,7 +168,7 @@ public class FsJobConfigurationManagerTest {
     Assert.assertTrue(jobSpec.getVersion().equals(version2));
 
     //Ensure the updated JobSpec is deleted from the FsSpecConsumer path.
-    Assert.assertEquals(this.fs.listStatus(fsSpecConsumerPath).length, 0);
+    Assert.assertEquals(this.fs.listStatus(fsSpecConsumerPath, new HiddenFilter()).length, 0);
 
     //Ensure UpdateJobConfigArrivalEvent is posted to EventBus
     Assert.assertEquals(newJobConfigArrivalEventCount, 1);
@@ -180,7 +181,7 @@ public class FsJobConfigurationManagerTest {
     this.jobConfigurationManager.fetchJobSpecs();
 
     //Ensure the JobSpec is deleted from the FsSpecConsumer path.
-    Assert.assertEquals(this.fs.listStatus(fsSpecConsumerPath).length, 0);
+    Assert.assertEquals(this.fs.listStatus(fsSpecConsumerPath, new HiddenFilter()).length, 0);
     this._jobCatalog.getJobSpec(new URI(jobSpecUriString));
 
     //Ensure DeleteJobConfigArrivalEvent is posted to EventBus

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/FsJobConfigurationManagerTest.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/FsJobConfigurationManagerTest.java
@@ -32,6 +32,7 @@ import org.testng.annotations.Test;
 
 import com.google.common.eventbus.EventBus;
 import com.google.common.io.Files;
+import com.google.common.util.concurrent.Service;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigValueFactory;
@@ -198,13 +199,14 @@ public class FsJobConfigurationManagerTest {
 
     //Add wait to ensure that fetchJobSpecExecutor thread is scheduled at least once.
     Thread.sleep(2000);
-    Mockito.verify(jobConfigurationManager, Mockito.times(1)).fetchJobSpecs();
+    int numInvocations = Mockito.mockingDetails(jobConfigurationManager).getInvocations().size();
+    Mockito.verify(jobConfigurationManager, Mockito.atLeast(1)).fetchJobSpecs();
 
     Thread.sleep(2000);
-    //Verify that there are no new invocations of fetchJobSpecs()
-    Mockito.verify(jobConfigurationManager, Mockito.times(1)).fetchJobSpecs();
-    //Ensure that the JobConfigurationManager Service is not running.
-    Assert.assertFalse(jobConfigurationManager.isRunning());
+    //Verify that there new invocations of fetchJobSpecs()
+    Mockito.verify(jobConfigurationManager, Mockito.atLeast(numInvocations + 1)).fetchJobSpecs();
+    //Ensure that the JobConfigurationManager Service is running.
+    Assert.assertTrue(!jobConfigurationManager.state().equals(Service.State.FAILED) && !jobConfigurationManager.state().equals(Service.State.TERMINATED));
   }
 
   @AfterClass

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/suite/IntegrationJobRestartViaSpecSuite.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/suite/IntegrationJobRestartViaSpecSuite.java
@@ -24,6 +24,9 @@ import java.io.Reader;
 import java.net.URI;
 import java.net.URISyntaxException;
 
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Files;
 import com.google.common.io.Resources;
@@ -52,7 +55,8 @@ public class IntegrationJobRestartViaSpecSuite extends IntegrationJobCancelSuite
 
   public IntegrationJobRestartViaSpecSuite() throws IOException {
     super();
-    this._specProducer = new FsSpecProducer(ConfigFactory.empty().withValue(FsSpecConsumer.SPEC_PATH_KEY, ConfigValueFactory.fromAnyRef(FS_SPEC_CONSUMER_DIR)));
+    FileSystem fs = FileSystem.getLocal(new Configuration());
+    this._specProducer = new FsSpecProducer(fs, ConfigFactory.empty().withValue(FsSpecConsumer.SPEC_PATH_KEY, ConfigValueFactory.fromAnyRef(FS_SPEC_CONSUMER_DIR)));
   }
 
   private Config getJobConfig() throws IOException {
@@ -80,7 +84,6 @@ public class IntegrationJobRestartViaSpecSuite extends IntegrationJobCancelSuite
     Config managerConfig = super.getManagerConfig();
     managerConfig = managerConfig.withValue(GobblinClusterConfigurationKeys.JOB_CONFIGURATION_MANAGER_KEY,
         ConfigValueFactory.fromAnyRef(FsJobConfigurationManager.class.getName()))
-    .withValue(GobblinClusterConfigurationKeys.SPEC_CONSUMER_CLASS_KEY, ConfigValueFactory.fromAnyRef(FsSpecConsumer.class.getName()))
         .withValue(GobblinClusterConfigurationKeys.JOB_SPEC_REFRESH_INTERVAL, ConfigValueFactory.fromAnyRef(1L))
     .withValue(FsSpecConsumer.SPEC_PATH_KEY, ConfigValueFactory.fromAnyRef(FS_SPEC_CONSUMER_DIR));
     return managerConfig;

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/FsSpecConsumer.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/FsSpecConsumer.java
@@ -33,12 +33,14 @@ import org.apache.avro.mapred.FsInput;
 import org.apache.avro.specific.SpecificDatumReader;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
 import com.typesafe.config.Config;
 
+import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.gobblin.runtime.job_spec.AvroJobSpec;
@@ -56,10 +58,14 @@ public class FsSpecConsumer implements SpecConsumer<Spec> {
   private Map<URI, Path> specToPathMap = new HashMap<>();
 
 
-  public FsSpecConsumer(FileSystem fs, Config config) {
+  public FsSpecConsumer(Config config) {
+    this(null, config);
+  }
+
+  public FsSpecConsumer(@Nullable FileSystem fs, Config config) {
     this.specDirPath = new Path(config.getString(SPEC_PATH_KEY));
     try {
-      this.fs = fs;
+      this.fs = (fs == null) ? FileSystem.get(new Configuration()) : fs;
       if (!this.fs.exists(specDirPath)) {
         this.fs.mkdirs(specDirPath);
       }

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/api/FsSpecProducerTest.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/api/FsSpecProducerTest.java
@@ -17,6 +17,7 @@
 package org.apache.gobblin.runtime.api;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
@@ -24,6 +25,8 @@ import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -39,12 +42,14 @@ public class FsSpecProducerTest {
   private FsSpecConsumer _fsSpecConsumer;
 
   @BeforeMethod
-  public void setUp() {
+  public void setUp()
+      throws IOException {
     File tmpDir = Files.createTempDir();
     Config config = ConfigFactory.empty().withValue(FsSpecConsumer.SPEC_PATH_KEY, ConfigValueFactory.fromAnyRef(
         tmpDir.getAbsolutePath()));
-    this._fsSpecProducer = new FsSpecProducer(config);
-    this._fsSpecConsumer = new FsSpecConsumer(config);
+    FileSystem fs = FileSystem.getLocal(new Configuration());
+    this._fsSpecProducer = new FsSpecProducer(fs, config);
+    this._fsSpecConsumer = new FsSpecConsumer(fs, config);
   }
 
   private JobSpec createTestJobSpec() throws URISyntaxException {

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/api/FsSpecProducerTest.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/api/FsSpecProducerTest.java
@@ -25,8 +25,6 @@ import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileSystem;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -47,9 +45,8 @@ public class FsSpecProducerTest {
     File tmpDir = Files.createTempDir();
     Config config = ConfigFactory.empty().withValue(FsSpecConsumer.SPEC_PATH_KEY, ConfigValueFactory.fromAnyRef(
         tmpDir.getAbsolutePath()));
-    FileSystem fs = FileSystem.getLocal(new Configuration());
-    this._fsSpecProducer = new FsSpecProducer(fs, config);
-    this._fsSpecConsumer = new FsSpecConsumer(fs, config);
+    this._fsSpecProducer = new FsSpecProducer(config);
+    this._fsSpecConsumer = new FsSpecConsumer(config);
   }
 
   private JobSpec createTestJobSpec() throws URISyntaxException {


### PR DESCRIPTION
…SpecConsumer

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1052


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Create a spec consumer path if it does not exist in FS SpecConsumer. This PR also makes the following improvements:
1. FsSpecProducer writes JobSpecs to a tmp location followed by a rename, instead of directly overwriting specs in the final location.
2. Change constructors of FsSpecProducer/FsSpecConsumer to allow passing in a FileSystem object.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Modified existing unit test cases.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

