### PR TITLE
GOBBLIN-1055 Gaas jobs not able to write to state store

### DIFF
--- a/gobblin-metastore/src/main/java/org/apache/gobblin/metastore/FsStateStore.java
+++ b/gobblin-metastore/src/main/java/org/apache/gobblin/metastore/FsStateStore.java
@@ -95,6 +95,7 @@ public class FsStateStore<T extends State> implements StateStore<T> {
       conf = new Configuration(otherConf);
     }
 
+    conf.setClassLoader(this.getClass().getClassLoader());
     WritableShimSerialization.addToHadoopConfiguration(conf);
 
     return conf;


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA]
    - https://issues.apache.org/jira/browse/GOBBLIN-1055


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):

The change pass the GobblinClassLoader to Hadoop through Configuration so that Hadoop can load the serializer properly. 

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

PR fixed a loop hole in passing parameters from Gobblin-metastore to Hadoop, and it was tested effective in Gaas flow execution with state.store.enabled=true.

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

