### PR TITLE
[GOBBLIN-1058] Refactor method emitting GTE for ease of adding new tags 

### DIFF
--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaExtractor.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaExtractor.java
@@ -101,7 +101,7 @@ public abstract class KafkaExtractor<S, D> extends EventBasedExtractor<S, D> {
     } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
       throw new RuntimeException(e);
     }
-    this.statsTracker = new KafkaExtractorStatsTracker(state,partitions);
+    this.statsTracker = new KafkaExtractorStatsTracker(state, partitions);
 
     // The actual high watermark starts with the low watermark
     this.workUnitState.setActualHighWatermark(this.lowWatermark);

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaExtractorStatsTracker.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaExtractorStatsTracker.java
@@ -319,18 +319,52 @@ public class KafkaExtractorStatsTracker {
    */
   public void emitTrackingEvents(MetricContext context, MultiLongWatermark lowWatermark, MultiLongWatermark highWatermark,
       MultiLongWatermark nextWatermark) {
-    Map<KafkaPartition, Map<String, String>> tagsForPartitionsMap = Maps.newHashMap();
-    for (int i = 0; i < this.partitions.size(); i++) {
-      log.info(String.format("Actual high watermark for partition %s=%d, expected=%d", this.partitions.get(i),
-          nextWatermark.get(i), highWatermark.get(i)));
-      tagsForPartitionsMap
-          .put(this.partitions.get(i), createTagsForPartition(i, lowWatermark, highWatermark, nextWatermark));
-    }
+    emitTrackingEventsWithAdditionalTags(context, lowWatermark, highWatermark, nextWatermark, Maps.newHashMap());
+  }
+
+  /**
+   * Emit Tracking events reporting the various statistics to be consumed by a monitoring application, with additional
+   * map representing tags beyond what are constructed in {@link #createTagsForPartition(int, MultiLongWatermark, MultiLongWatermark, MultiLongWatermark) }
+   *
+   * Choose to not to make createTagsForPartition extensible to avoid additional derived class just for additional k-v pairs
+   * in the tag maps.
+   *
+   * @param additionalTags caller-provided mapping from {@link KafkaPartition} to {@link Map<String, String>}, which will
+   *                       be merged with result of {@link #createTagsForPartition}.
+   */
+  public void emitTrackingEventsWithAdditionalTags(MetricContext context, MultiLongWatermark lowWatermark, MultiLongWatermark highWatermark,
+      MultiLongWatermark nextWatermark, Map<KafkaPartition, Map<String, String>> additionalTags) {
+    Map<KafkaPartition, Map<String, String>> tagsForPartitionsMap =
+        generateTagsForPartitions(lowWatermark, highWatermark, nextWatermark, additionalTags);
+
     for (Map.Entry<KafkaPartition, Map<String, String>> eventTags : tagsForPartitionsMap.entrySet()) {
       EventSubmitter.Builder eventSubmitterBuilder = new EventSubmitter.Builder(context, GOBBLIN_KAFKA_NAMESPACE);
       eventSubmitterBuilder.addMetadata(this.taskEventMetadataGenerator.getMetadata(workUnitState, KAFKA_EXTRACTOR_TOPIC_METADATA_EVENT_NAME));
       eventSubmitterBuilder.build().submit(KAFKA_EXTRACTOR_TOPIC_METADATA_EVENT_NAME, eventTags.getValue());
     }
+  }
+
+  /**
+   * A helper function to merge tags for KafkaPartition. Separate into a package-private method for ease of testing.
+   */
+  Map<KafkaPartition, Map<String, String>> generateTagsForPartitions(MultiLongWatermark lowWatermark, MultiLongWatermark highWatermark,
+      MultiLongWatermark nextWatermark, Map<KafkaPartition, Map<String, String>> additionalTags) {
+    Map<KafkaPartition, Map<String, String>> tagsForPartitionsMap = Maps.newHashMap();
+    for (int i = 0; i < this.partitions.size(); i++) {
+      KafkaPartition partitionKey = this.partitions.get(i);
+
+      log.info(String.format("Actual high watermark for partition %s=%d, expected=%d", this.partitions.get(i),
+          nextWatermark.get(i), highWatermark.get(i)));
+      tagsForPartitionsMap
+          .put(this.partitions.get(i), createTagsForPartition(i, lowWatermark, highWatermark, nextWatermark));
+
+      // Merge with additionalTags from argument-provided map if exists.
+      if (additionalTags.containsKey(partitionKey)) {
+        tagsForPartitionsMap.get(partitionKey).putAll(additionalTags.get(partitionKey));
+      }
+    }
+
+    return tagsForPartitionsMap;
   }
 
   /**

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaExtractorStatsTracker.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaExtractorStatsTracker.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
@@ -347,6 +348,7 @@ public class KafkaExtractorStatsTracker {
   /**
    * A helper function to merge tags for KafkaPartition. Separate into a package-private method for ease of testing.
    */
+  @VisibleForTesting
   Map<KafkaPartition, Map<String, String>> generateTagsForPartitions(MultiLongWatermark lowWatermark, MultiLongWatermark highWatermark,
       MultiLongWatermark nextWatermark, Map<KafkaPartition, Map<String, String>> additionalTags) {
     Map<KafkaPartition, Map<String, String>> tagsForPartitionsMap = Maps.newHashMap();

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSource.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSource.java
@@ -278,7 +278,9 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
       setLimiterReportKeyListToWorkUnits(workUnitList, getLimiterExtractorReportKeys());
       return workUnitList;
     } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
-      throw new RuntimeException(e);
+      throw new RuntimeException("Checked exception caught", e);
+    } catch (Throwable t) {
+      throw new RuntimeException("Unexpected throwable caught, ", t);
     } finally {
       try {
         if (this.kafkaConsumerClient.get() != null) {

--- a/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaExtractorStatsTrackerTest.java
+++ b/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaExtractorStatsTrackerTest.java
@@ -17,7 +17,9 @@
 package org.apache.gobblin.source.extractor.extract.kafka;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
@@ -25,15 +27,19 @@ import org.testng.annotations.Test;
 
 import org.apache.gobblin.configuration.WorkUnitState;
 
+import com.google.common.collect.ImmutableMap;
+
 
 public class KafkaExtractorStatsTrackerTest {
   List<KafkaPartition> kafkaPartitions = new ArrayList<>();
   private KafkaExtractorStatsTracker extractorStatsTracker;
+  final static KafkaPartition PARTITION0 =  new KafkaPartition.Builder().withTopicName("test-topic").withId(0).build();
+  final static KafkaPartition PARTITION1 =  new KafkaPartition.Builder().withTopicName("test-topic").withId(1).build();
 
   @BeforeClass
   public void setUp() {
-    kafkaPartitions.add(new KafkaPartition.Builder().withTopicName("test-topic").withId(0).build());
-    kafkaPartitions.add(new KafkaPartition.Builder().withTopicName("test-topic").withId(1).build());
+    kafkaPartitions.add(PARTITION0);
+    kafkaPartitions.add(PARTITION1);
     WorkUnitState workUnitState = new WorkUnitState();
     workUnitState.setProp("gobblin.kafka.recordLevelSlaMinutes", 10L);
     this.extractorStatsTracker = new KafkaExtractorStatsTracker(workUnitState, kafkaPartitions);
@@ -163,5 +169,19 @@ public class KafkaExtractorStatsTrackerTest {
     long logAppendTimeStamp = System.currentTimeMillis() - 10;
     this.extractorStatsTracker.onDecodeableRecord(1, readStartTime, decodeStartTime, 150, logAppendTimeStamp);
     Assert.assertEquals(this.extractorStatsTracker.getAvgRecordSize(1), 150);
+  }
+
+  @Test
+  public void testGenerateTagsForPartitions() throws Exception {
+    MultiLongWatermark lowWatermark = new MultiLongWatermark(Arrays.asList(new Long(10), new Long(20)));
+    MultiLongWatermark highWatermark = new MultiLongWatermark(Arrays.asList(new Long(20), new Long(30)));
+    MultiLongWatermark nextWatermark = new MultiLongWatermark(Arrays.asList(new Long(15), new Long(25)));
+    Map<KafkaPartition, Map<String, String>> addtionalTags =
+        ImmutableMap.of(PARTITION0, ImmutableMap.of("testKey", "testValue"));
+    Map<KafkaPartition, Map<String, String>> result =
+        extractorStatsTracker.generateTagsForPartitions(lowWatermark, highWatermark, nextWatermark, addtionalTags);
+    Assert.assertTrue(result.get(PARTITION0).containsKey("testKey"));
+    Assert.assertEquals(result.get(PARTITION0).get("testKey"), "testValue");
+    Assert.assertFalse(result.get(PARTITION1).containsKey("testKey"));
   }
 }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
    - https://issues.apache.org/jira/browse/GOBBLIN-1058


### Description
To make it easier for caller of `KafkaExtractorStatsTracker#emitTrackingEvents` to add additional tags in to metric map, adding another method with `additionalTag` as an argument. We don't choose to make `createTagsForPartition` extensible since it seems wasty to create more derived classes only with the purpose of adding more k-v pairs into an event for monitoring purpose. 


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

