### PR TITLE
[GOBBLIN-1065] Fix SSL verification issue for macOS

### DIFF
--- a/dev/gobblin-pr
+++ b/dev/gobblin-pr
@@ -41,6 +41,10 @@ import textwrap
 # import ssl
 # print(ssl.OPENSSL_VERSION)
 
+# Enabling following lines if you found SSL: CERTIFICATE_VERIFY_FAILED with Python3 
+#import ssl
+#ssl._create_default_https_context = ssl._create_unverified_context
+
 # Python 3 compatibility
 try:
     import urllib2 as urllib


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-XXX


### Description
Symptoms:
```ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1056)```

Solution found from: https://stackoverflow.com/questions/35569042/ssl-certificate-verify-failed-with-python3 


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

