### PR TITLE
[GOBBLIN-1072] Being more conservative on releasing containers

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixMessagingService.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixMessagingService.java
@@ -77,8 +77,6 @@ public class GobblinHelixMessagingService extends DefaultMessagingService {
     if (instanceType == InstanceType.CONTROLLER) {
       List<Message> messages = generateMessagesForController(message);
       messagesToSendMap.put(InstanceType.CONTROLLER, messages);
-      // _dataAccessor.setControllerProperty(PropertyType.MESSAGES,
-      // newMessage.getRecord(), CreateMode.PERSISTENT);
     } else if (instanceType == InstanceType.PARTICIPANT) {
       List<Message> messages = new ArrayList<Message>();
       List<Map<String, String>> matchedList =

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnTaskRunner.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnTaskRunner.java
@@ -57,6 +57,8 @@ public class GobblinYarnTaskRunner extends GobblinTaskRunner {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(GobblinTaskRunner.class);
 
+  public static final String HELIX_YARN_INSTANCE_NAME_PREFIX = GobblinYarnTaskRunner.class.getSimpleName();
+
   public GobblinYarnTaskRunner(String applicationName, String helixInstanceName, ContainerId containerId, Config config,
       Optional<Path> appWorkDirOptional) throws Exception {
     super(applicationName, helixInstanceName, getApplicationId(containerId), getTaskRunnerId(containerId),
@@ -195,7 +197,7 @@ public class GobblinYarnTaskRunner extends GobblinTaskRunner {
       if (!Strings.isNullOrEmpty(helixInstanceTags)) {
         config = config.withValue(GobblinClusterConfigurationKeys.HELIX_INSTANCE_TAGS_KEY, ConfigValueFactory.fromAnyRef(helixInstanceTags));
       }
-        
+
       GobblinTaskRunner gobblinTaskRunner =
           new GobblinYarnTaskRunner(applicationName, helixInstanceName, containerId, config,
               Optional.<Path>absent());

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnService.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnService.java
@@ -108,6 +108,8 @@ import org.apache.gobblin.yarn.event.ContainerReleaseRequest;
 import org.apache.gobblin.yarn.event.ContainerShutdownRequest;
 import org.apache.gobblin.yarn.event.NewContainerRequest;
 
+import static org.apache.gobblin.yarn.GobblinYarnTaskRunner.HELIX_YARN_INSTANCE_NAME_PREFIX;
+
 
 /**
  * This class is responsible for all Yarn-related stuffs including ApplicationMaster registration,
@@ -135,6 +137,7 @@ public class YarnService extends AbstractIdleService {
 
   private final Optional<GobblinMetrics> gobblinMetrics;
   private final Optional<EventSubmitter> eventSubmitter;
+
 
   @VisibleForTesting
   @Getter(AccessLevel.PROTECTED)
@@ -726,7 +729,7 @@ public class YarnService extends AbstractIdleService {
         String instanceName = unusedHelixInstanceNames.poll();
         if (Strings.isNullOrEmpty(instanceName)) {
           // No unused instance name, so generating a new one.
-          instanceName = HelixUtils.getHelixInstanceName(GobblinYarnTaskRunner.class.getSimpleName(),
+          instanceName = HelixUtils.getHelixInstanceName(HELIX_YARN_INSTANCE_NAME_PREFIX,
               helixInstanceIdGenerator.incrementAndGet());
         }
 


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- https://issues.apache.org/jira/browse/GOBBLIN-1072


### Description
- An additional data structure `MaxValueEvictingQueue` to wrap multiple instances of `numTargetContainers` and behaved like an sliding-window where we could fetch the maxValue in the sliding-window in constant time. 
- The advantage of this data structure is, if there's fluctuation in the number of active Helix partitions, a single fluctuation wont't impact the number of containers we requested in `YarnService`. 
- The sliding-window's size is defined by the number of attempts that we query Helix for getting partitions number. 
- Use a different way to tag an instance as "unused" : Currently whenever we found an instance with no Helix partition assigned to it when inspecting, we tag it as "unused" and tell YarnService it could be a candidate for scaling down. To make it less aggressive, we maintain a map with Helix instance as the Key and the "lastIdleTime" as the value, when currentTime - lastIdleTime is beyond tolerance, we then tag this instance as unused. 


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

