### PR TITLE
[GOBBLIN-1078] Coordination between task cancel and initialization in Helix Task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,7 @@ FsDatasetStateStoreTest/
 GobblinHelixTaskTest/
 commit-sequence-store-test/
 gobblin-test-harness/src/test/resources/runtime_test/state_store/
+gobblin-integration-test-work-dir/
+
+gobblin-test-utils/src/main/gen-avro/
+gobblin-test-utils/src/main/gen-proto/

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixTask.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixTask.java
@@ -19,9 +19,13 @@ package org.apache.gobblin.cluster;
 
 import java.util.Map;
 import java.util.concurrent.Callable;
-import java.util.concurrent.TimeUnit;
 
-import org.apache.gobblin.util.ConfigUtils;
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.runtime.TaskState;
+import org.apache.gobblin.runtime.util.StateStores;
+import org.apache.gobblin.source.workunit.MultiWorkUnit;
+import org.apache.gobblin.source.workunit.WorkUnit;
+import org.apache.gobblin.util.Id;
 import org.apache.gobblin.util.retry.RetryerFactory;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -41,14 +45,6 @@ import com.typesafe.config.ConfigValueFactory;
 
 import lombok.extern.slf4j.Slf4j;
 
-import org.apache.gobblin.annotation.Alpha;
-import org.apache.gobblin.configuration.ConfigurationKeys;
-import org.apache.gobblin.runtime.TaskState;
-import org.apache.gobblin.runtime.util.StateStores;
-import org.apache.gobblin.source.workunit.MultiWorkUnit;
-import org.apache.gobblin.source.workunit.WorkUnit;
-import org.apache.gobblin.util.Id;
-
 
 /**
  * An implementation of Helix's {@link org.apache.helix.task.Task} that wraps and runs one or more Gobblin
@@ -65,7 +61,6 @@ import org.apache.gobblin.util.Id;
  *   a file that will be collected by the {@link GobblinHelixJobLauncher} later upon completion of the job.
  * </p>
  */
-@Alpha
 @Slf4j
 public class GobblinHelixTask implements Task {
 

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SleepingTask.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SleepingTask.java
@@ -32,6 +32,7 @@ import org.apache.gobblin.runtime.task.BaseAbstractTask;
 @Slf4j
 public class SleepingTask extends BaseAbstractTask {
   public static final String TASK_STATE_FILE_KEY = "task.state.file.path";
+  public static final String SLEEP_TIME_IN_SECONDS = "data.publisher.sleep.time.in.seconds";
 
   private final long sleepTime;
   private File taskStateFile;
@@ -39,7 +40,7 @@ public class SleepingTask extends BaseAbstractTask {
   public SleepingTask(TaskContext taskContext) {
     super(taskContext);
     TaskState taskState = taskContext.getTaskState();
-    sleepTime = taskState.getPropAsLong("data.publisher.sleep.time.in.seconds", 10L);
+    sleepTime = taskState.getPropAsLong(SLEEP_TIME_IN_SECONDS, 10L);
     taskStateFile = new File(taskState.getProp(TASK_STATE_FILE_KEY));
     try {
       if (taskStateFile.exists()) {

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/suite/IntegrationJobCancelSuite.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/suite/IntegrationJobCancelSuite.java
@@ -25,6 +25,15 @@ import com.typesafe.config.Config;
 public class IntegrationJobCancelSuite extends IntegrationBasicSuite {
   public static final String JOB_ID = "job_HelloWorldTestJob_1234";
   public static final String TASK_STATE_FILE = "/tmp/IntegrationJobCancelSuite/taskState/_RUNNING";
+  private int sleepingTime = 10;
+
+  public IntegrationJobCancelSuite() {
+    // for backward compatible.
+  }
+
+  public IntegrationJobCancelSuite(int sleepingTime) {
+    this.sleepingTime = sleepingTime;
+  }
 
   public IntegrationJobCancelSuite(Config jobConfigOverrides) {
     super(jobConfigOverrides);


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- https://issues.apache.org/jira/browse/GOBBLIN-1078


### Description
The task cancel and task.run is called in different thread from helix side, which introduced problems when: 
- Task get cancelled for some reasons from Helix side, therefore calling `SingleTask#cancel `
- However, TaskAttempt object within SingleTask has not been initialized, therefore it didn't pass the non-null checking and only prints a log. After that, the run method in different thread start to run and never get cancelled. 

This sequence could result in violation of helix quota in each participant: While helix believe there's no partition assigned to a participant and assign a new partition, the previous not-yet-cancelled partition is still running. 

We added a barrier in cancel method to ensure cancel is blocked if taskAttempt object is not yet being initialized. Added unit test to simulate the sequence as well. 


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

