### PR TITLE
[GOBBLIN-1081] Adding support of timestamp type for CsvToJsonConverter

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/converter/csv/CsvToJsonConverterV2.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/converter/csv/CsvToJsonConverterV2.java
@@ -265,6 +265,12 @@ public class CsvToJsonConverterV2 extends Converter<String, JsonArray, String[],
       JsonElement convert(String value) {
         return new JsonPrimitive(value);
       }
+    },
+    TIMESTAMP {
+      @Override
+      JsonElement convert(String value) {
+        return new JsonPrimitive(value);
+      }
     };
     abstract JsonElement convert(String value);
   }

--- a/gobblin-core/src/test/resources/converter/csv/schema_with_10_fields.json
+++ b/gobblin-core/src/test/resources/converter/csv/schema_with_10_fields.json
@@ -4,7 +4,7 @@
     "comment": "",
     "isNullable": "true",
     "dataType": {
-      "type": "string"
+      "type": "timestamp"
     }
   },
   {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### JIRA
- https://issues.apache.org/jira/browse/GOBBLIN-1081


### Description
 - Currently CsvToJsonConverterV2 only supprot string, bool, double and int. Need to support Avro logic type timestamp. This converter doesn't do any transformation on the data. It just needs to pass the timestamp string down to the subsequent converters

### Tests
 - updated existing unit test
 - integration test by running a Gobblin job with converter CsvToJsonConverterV2, and set one column to timestamp.


### Commits

