### PR TITLE
Add job orchestrated time, use job start/prepare time to set job start time in GaaS jobs

### DIFF
--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/TimingEvent.java
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/TimingEvent.java
@@ -94,7 +94,7 @@ public class TimingEvent extends GobblinEventBuilder implements Closeable {
   public static final String METADATA_DURATION = "durationMillis";
   public static final String METADATA_TIMING_EVENT = "timingEvent";
   public static final String METADATA_MESSAGE = "message";
-  public static final String JOB_ORCHESTRATION_TIME = "jobOrchestrationTime";
+  public static final String JOB_ORCHESTRATED_TIME = "jobOrchestratedTime";
   public static final String JOB_START_TIME = "jobStartTime";
   public static final String JOB_END_TIME = "jobEndTime";
 

--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/TimingEvent.java
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/TimingEvent.java
@@ -94,6 +94,7 @@ public class TimingEvent extends GobblinEventBuilder implements Closeable {
   public static final String METADATA_DURATION = "durationMillis";
   public static final String METADATA_TIMING_EVENT = "timingEvent";
   public static final String METADATA_MESSAGE = "message";
+  public static final String JOB_ORCHESTRATION_TIME = "jobOrchestrationTime";
   public static final String JOB_START_TIME = "jobStartTime";
   public static final String JOB_END_TIME = "jobEndTime";
 

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/JobStatus.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/JobStatus.java
@@ -38,6 +38,7 @@ public class JobStatus {
   private final String flowName;
   private final String flowGroup;
   private final String eventName;
+  private final long orchestratedTime;
   private final long startTime;
   private final long endTime;
   private final String message;

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/JobStatusRetriever.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/JobStatusRetriever.java
@@ -74,7 +74,7 @@ public abstract class JobStatusRetriever implements LatestFlowExecutionIdTracker
     String jobTag = jobState.getProp(TimingEvent.FlowEventConstants.JOB_TAG_FIELD);
     long jobExecutionId = Long.parseLong(jobState.getProp(TimingEvent.FlowEventConstants.JOB_EXECUTION_ID_FIELD, "0"));
     String eventName = jobState.getProp(JobStatusRetriever.EVENT_NAME_FIELD);
-    long orchestrationTime = Long.parseLong(jobState.getProp(TimingEvent.JOB_ORCHESTRATED_TIME, "0"));
+    long orchestratedTime = Long.parseLong(jobState.getProp(TimingEvent.JOB_ORCHESTRATED_TIME, "0"));
     long startTime = Long.parseLong(jobState.getProp(TimingEvent.JOB_START_TIME, "0"));
     long endTime = Long.parseLong(jobState.getProp(TimingEvent.JOB_END_TIME, "0"));
     String message = jobState.getProp(TimingEvent.METADATA_MESSAGE, "");
@@ -87,7 +87,7 @@ public abstract class JobStatusRetriever implements LatestFlowExecutionIdTracker
 
     return JobStatus.builder().flowName(flowName).flowGroup(flowGroup).flowExecutionId(flowExecutionId).
         jobName(jobName).jobGroup(jobGroup).jobTag(jobTag).jobExecutionId(jobExecutionId).eventName(eventName).
-        lowWatermark(lowWatermark).highWatermark(highWatermark).orchestratedTime(orchestrationTime).startTime(startTime).endTime(endTime).
+        lowWatermark(lowWatermark).highWatermark(highWatermark).orchestratedTime(orchestratedTime).startTime(startTime).endTime(endTime).
         message(message).processedCount(processedCount).maxAttempts(maxAttempts).currentAttempts(currentAttempts).
         shouldRetry(shouldRetry).build();
   }

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/JobStatusRetriever.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/JobStatusRetriever.java
@@ -74,7 +74,7 @@ public abstract class JobStatusRetriever implements LatestFlowExecutionIdTracker
     String jobTag = jobState.getProp(TimingEvent.FlowEventConstants.JOB_TAG_FIELD);
     long jobExecutionId = Long.parseLong(jobState.getProp(TimingEvent.FlowEventConstants.JOB_EXECUTION_ID_FIELD, "0"));
     String eventName = jobState.getProp(JobStatusRetriever.EVENT_NAME_FIELD);
-    long orchestrationTime = Long.parseLong(jobState.getProp(TimingEvent.JOB_ORCHESTRATION_TIME, "0"));
+    long orchestrationTime = Long.parseLong(jobState.getProp(TimingEvent.JOB_ORCHESTRATED_TIME, "0"));
     long startTime = Long.parseLong(jobState.getProp(TimingEvent.JOB_START_TIME, "0"));
     long endTime = Long.parseLong(jobState.getProp(TimingEvent.JOB_END_TIME, "0"));
     String message = jobState.getProp(TimingEvent.METADATA_MESSAGE, "");

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/JobStatusRetriever.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/JobStatusRetriever.java
@@ -74,6 +74,7 @@ public abstract class JobStatusRetriever implements LatestFlowExecutionIdTracker
     String jobTag = jobState.getProp(TimingEvent.FlowEventConstants.JOB_TAG_FIELD);
     long jobExecutionId = Long.parseLong(jobState.getProp(TimingEvent.FlowEventConstants.JOB_EXECUTION_ID_FIELD, "0"));
     String eventName = jobState.getProp(JobStatusRetriever.EVENT_NAME_FIELD);
+    long orchestrationTime = Long.parseLong(jobState.getProp(TimingEvent.JOB_ORCHESTRATION_TIME, "0"));
     long startTime = Long.parseLong(jobState.getProp(TimingEvent.JOB_START_TIME, "0"));
     long endTime = Long.parseLong(jobState.getProp(TimingEvent.JOB_END_TIME, "0"));
     String message = jobState.getProp(TimingEvent.METADATA_MESSAGE, "");
@@ -86,7 +87,7 @@ public abstract class JobStatusRetriever implements LatestFlowExecutionIdTracker
 
     return JobStatus.builder().flowName(flowName).flowGroup(flowGroup).flowExecutionId(flowExecutionId).
         jobName(jobName).jobGroup(jobGroup).jobTag(jobTag).jobExecutionId(jobExecutionId).eventName(eventName).
-        lowWatermark(lowWatermark).highWatermark(highWatermark).startTime(startTime).endTime(endTime).
+        lowWatermark(lowWatermark).highWatermark(highWatermark).orchestratedTime(orchestrationTime).startTime(startTime).endTime(endTime).
         message(message).processedCount(processedCount).maxAttempts(maxAttempts).currentAttempts(currentAttempts).
         shouldRetry(shouldRetry).build();
   }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
@@ -613,9 +613,9 @@ public class DagManager extends AbstractIdleService {
       }
       ExecutionStatus executionStatus = valueOf(jobStatus.getEventName());
       long timeOutForJobStart = DagManagerUtils.getJobStartSla(node);
-      long jobOrchestrationTime = jobStatus.getOrchestratedTime();
+      long jobOrchestratedTime = jobStatus.getOrchestratedTime();
 
-      if (executionStatus == ORCHESTRATED && System.currentTimeMillis() - jobOrchestrationTime > timeOutForJobStart) {
+      if (executionStatus == ORCHESTRATED && System.currentTimeMillis() - jobOrchestratedTime > timeOutForJobStart) {
         log.info("Job {} of flow {} exceeded the job start SLA of {} ms. Killing the job now...",
             DagManagerUtils.getJobName(node),
             DagManagerUtils.getFullyQualifiedDagName(node),

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
@@ -613,9 +613,9 @@ public class DagManager extends AbstractIdleService {
       }
       ExecutionStatus executionStatus = valueOf(jobStatus.getEventName());
       long timeOutForJobStart = DagManagerUtils.getJobStartSla(node);
-      long jobStartTime = jobStatus.getStartTime();
+      long jobOrchestrationTime = jobStatus.getOrchestratedTime();
 
-      if (executionStatus == ORCHESTRATED && System.currentTimeMillis() - jobStartTime > timeOutForJobStart) {
+      if (executionStatus == ORCHESTRATED && System.currentTimeMillis() - jobOrchestrationTime > timeOutForJobStart) {
         log.info("Job {} of flow {} exceeded the job start SLA of {} ms. Killing the job now...",
             DagManagerUtils.getJobName(node),
             DagManagerUtils.getFullyQualifiedDagName(node),
@@ -737,7 +737,7 @@ public class DagManager extends AbstractIdleService {
         TimingEvent jobOrchestrationTimer = this.eventSubmitter.isPresent() ? this.eventSubmitter.get().
             getTimingEvent(TimingEvent.LauncherTimings.JOB_ORCHESTRATED) : null;
 
-        //Submit the job to the SpecProducer, which in turn performs the actual job submission to the SpecExecutor instance.
+        // Submit the job to the SpecProducer, which in turn performs the actual job submission to the SpecExecutor instance.
         // The SpecProducer implementations submit the job to the underlying executor and return when the submission is complete,
         // either successfully or unsuccessfully. To catch any exceptions in the job submission, the DagManagerThread
         // blocks (by calling Future#get()) until the submission is completed.

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaAvroJobStatusMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaAvroJobStatusMonitor.java
@@ -131,7 +131,7 @@ public class KafkaAvroJobStatusMonitor extends KafkaJobStatusMonitor {
         break;
       case TimingEvent.LauncherTimings.JOB_ORCHESTRATED:
         properties.put(JobStatusRetriever.EVENT_NAME_FIELD, ExecutionStatus.ORCHESTRATED.name());
-        properties.put(TimingEvent.JOB_ORCHESTRATION_TIME, properties.getProperty(TimingEvent.METADATA_END_TIME));
+        properties.put(TimingEvent.JOB_ORCHESTRATED_TIME, properties.getProperty(TimingEvent.METADATA_END_TIME));
         break;
       case TimingEvent.LauncherTimings.JOB_PREPARE:
       case TimingEvent.LauncherTimings.JOB_START:

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaAvroJobStatusMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaAvroJobStatusMonitor.java
@@ -131,11 +131,12 @@ public class KafkaAvroJobStatusMonitor extends KafkaJobStatusMonitor {
         break;
       case TimingEvent.LauncherTimings.JOB_ORCHESTRATED:
         properties.put(JobStatusRetriever.EVENT_NAME_FIELD, ExecutionStatus.ORCHESTRATED.name());
-        properties.put(TimingEvent.JOB_START_TIME, properties.getProperty(TimingEvent.METADATA_END_TIME));
+        properties.put(TimingEvent.JOB_ORCHESTRATION_TIME, properties.getProperty(TimingEvent.METADATA_END_TIME));
         break;
       case TimingEvent.LauncherTimings.JOB_PREPARE:
       case TimingEvent.LauncherTimings.JOB_START:
         properties.put(JobStatusRetriever.EVENT_NAME_FIELD, ExecutionStatus.RUNNING.name());
+        properties.put(TimingEvent.JOB_START_TIME, properties.getProperty(TimingEvent.METADATA_END_TIME));
         break;
       case TimingEvent.FlowTimings.FLOW_SUCCEEDED:
       case TimingEvent.LauncherTimings.JOB_SUCCEEDED:

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaJobStatusMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaJobStatusMonitor.java
@@ -104,7 +104,7 @@ public abstract class KafkaJobStatusMonitor extends HighLevelConsumer<byte[], by
      try {
        this.scheduledExecutorService.awaitTermination(30, TimeUnit.SECONDS);
      } catch (InterruptedException e) {
-       log.error("Exception {} encountered when shutting down state store cleaner", e);
+       log.error("Exception encountered when shutting down state store cleaner", e);
      }
   }
 
@@ -161,11 +161,11 @@ public abstract class KafkaJobStatusMonitor extends HighLevelConsumer<byte[], by
           < ORDERED_EXECUTION_STATUSES.indexOf(ExecutionStatus.valueOf(previousStatus))) {
         log.warn(String.format("Received status %s when status is already %s for flow (%s, %s, %s), job (%s, %s)",
             currentStatus, previousStatus, flowGroup, flowName, flowExecutionId, jobGroup, jobName));
-        return;
+        jobStatus = mergeState(states.get(states.size() - 1), jobStatus);
+      } else {
+        jobStatus = mergeState(jobStatus, states.get(states.size() - 1));
       }
     }
-
-    jobStatus = mergedProperties(jobStatus, states);
 
     modifyStateIfRetryRequired(jobStatus);
 
@@ -182,16 +182,14 @@ public abstract class KafkaJobStatusMonitor extends HighLevelConsumer<byte[], by
     }
   }
 
-  private static org.apache.gobblin.configuration.State mergedProperties(org.apache.gobblin.configuration.State jobStatus,
-      List<org.apache.gobblin.configuration.State> states) {
-    Properties mergedProperties = new Properties();
+  private static org.apache.gobblin.configuration.State mergeState(org.apache.gobblin.configuration.State state,
+      org.apache.gobblin.configuration.State fallbackState) {
+    Properties mergedState = new Properties();
 
-    if (states.size() > 0) {
-      mergedProperties.putAll(states.get(states.size() - 1).getProperties());
-    }
-    mergedProperties.putAll(jobStatus.getProperties());
+    mergedState.putAll(fallbackState.getProperties());
+    mergedState.putAll(state.getProperties());
 
-    return new org.apache.gobblin.configuration.State(mergedProperties);
+    return new org.apache.gobblin.configuration.State(mergedState);
   }
 
   public static String jobStatusTableName(String flowExecutionId, String jobGroup, String jobName) {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaJobStatusMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaJobStatusMonitor.java
@@ -182,6 +182,14 @@ public abstract class KafkaJobStatusMonitor extends HighLevelConsumer<byte[], by
     }
   }
 
+  /**
+   * Merge states based on precedence defined by {@link #ORDERED_EXECUTION_STATUSES}.
+   * The state instance in the 1st argument reflects the more recent state of a job
+   * (and is thus, given higher priority) compared to the 2nd argument.
+   * @param state higher priority state
+   * @param fallbackState lower priority state
+   * @return merged state
+   */
   private static org.apache.gobblin.configuration.State mergeState(org.apache.gobblin.configuration.State state,
       org.apache.gobblin.configuration.State fallbackState) {
     Properties mergedState = new Properties();

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/FsJobStatusRetrieverTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/FsJobStatusRetrieverTest.java
@@ -17,16 +17,15 @@
 
 package org.apache.gobblin.service.monitoring;
 
-import java.io.File;
-
-import org.apache.commons.io.FileUtils;
-import org.testng.annotations.BeforeClass;
-
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigValueFactory;
-
+import java.io.File;
+import java.io.IOException;
+import org.apache.commons.io.FileUtils;
 import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
 
 
 public class FsJobStatusRetrieverTest extends JobStatusRetrieverTest {
@@ -39,6 +38,31 @@ public class FsJobStatusRetrieverTest extends JobStatusRetrieverTest {
     Config config = ConfigFactory.empty().withValue(FsJobStatusRetriever.CONF_PREFIX + "." + ConfigurationKeys.STATE_STORE_ROOT_DIR_KEY,
         ConfigValueFactory.fromAnyRef(stateStoreDir));
     this.jobStatusRetriever = new FsJobStatusRetriever(config);
+  }
+
+  @Test
+  public void testGetJobStatusesForFlowExecution() throws IOException {
+    super.testGetJobStatusesForFlowExecution();
+  }
+
+  @Test (dependsOnMethods = "testGetJobStatusesForFlowExecution")
+  public void testJobTiming() throws Exception {
+    super.testJobTiming();
+  }
+
+  @Test (dependsOnMethods = "testJobTiming")
+  public void testOutOfOrderJobTimingEvents() throws IOException {
+    super.testOutOfOrderJobTimingEvents();
+  }
+
+  @Test (dependsOnMethods = "testJobTiming")
+  public void testGetJobStatusesForFlowExecution1() {
+    super.testGetJobStatusesForFlowExecution1();
+  }
+
+  @Test (dependsOnMethods = "testGetJobStatusesForFlowExecution1")
+  public void testGetLatestExecutionIdsForFlow() throws Exception {
+    super.testGetLatestExecutionIdsForFlow();
   }
 
   @Override

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/JobStatusRetrieverTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/JobStatusRetrieverTest.java
@@ -71,7 +71,7 @@ public abstract class JobStatusRetrieverTest {
     } else if (status.equals(ExecutionStatus.COMPLETE.name())) {
       properties.setProperty(TimingEvent.JOB_END_TIME, String.valueOf(endTime));
     } else if (status.equals(ExecutionStatus.ORCHESTRATED.name())) {
-      properties.setProperty(TimingEvent.JOB_ORCHESTRATION_TIME, String.valueOf(endTime));
+      properties.setProperty(TimingEvent.JOB_ORCHESTRATED_TIME, String.valueOf(endTime));
     }
     State jobStatus = new State(properties);
 

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/JobStatusRetrieverTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/JobStatusRetrieverTest.java
@@ -35,7 +35,7 @@ public abstract class JobStatusRetrieverTest {
   protected static final String FLOW_GROUP = "myFlowGroup";
   protected static final String FLOW_NAME = "myFlowName";
   protected String jobGroup;
-  private static final String myJobGroup = "myJobGroup";
+  private static final String MY_JOB_GROUP = "myJobGroup";
   protected static final String MY_JOB_NAME_1 = "myJobName1";
   private static final String MY_JOB_NAME_2 = "myJobName2";
   private static final long JOB_EXECUTION_ID = 1111L;
@@ -57,7 +57,7 @@ public abstract class JobStatusRetrieverTest {
     properties.setProperty(TimingEvent.FlowEventConstants.FLOW_EXECUTION_ID_FIELD, String.valueOf(flowExecutionId));
     properties.setProperty(TimingEvent.FlowEventConstants.JOB_NAME_FIELD, jobName);
     if (!jobName.equals(JobStatusRetriever.NA_KEY)) {
-      jobGroup = myJobGroup;
+      jobGroup = MY_JOB_GROUP;
       properties.setProperty(TimingEvent.FlowEventConstants.JOB_EXECUTION_ID_FIELD, String.valueOf(JOB_EXECUTION_ID));
       properties.setProperty(TimingEvent.METADATA_MESSAGE, MESSAGE);
       properties.setProperty(JobStatusRetriever.EVENT_NAME_FIELD, status);
@@ -94,7 +94,7 @@ public abstract class JobStatusRetrieverTest {
     Assert.assertEquals(jobStatus.getHighWatermark(), "");
 
     addJobStatusToStateStore(flowExecutionId, MY_JOB_NAME_1, ExecutionStatus.RUNNING.name(), JOB_START_TIME, JOB_START_TIME);
-    jobStatusIterator = this.jobStatusRetriever.getJobStatusesForFlowExecution(FLOW_NAME, FLOW_GROUP, flowExecutionId);
+    jobStatusIterator = this.jobStatusRetriever.getJobStatusesForFlowExecution(FLOW_NAME, FLOW_GROUP, flowExecutionId, MY_JOB_NAME_1, MY_JOB_GROUP);
     jobStatus = jobStatusIterator.next();
     Assert.assertEquals(jobStatus.getEventName(), ExecutionStatus.RUNNING.name());
     Assert.assertEquals(jobStatus.getJobName(), MY_JOB_NAME_1);
@@ -105,6 +105,9 @@ public abstract class JobStatusRetrieverTest {
     jobStatusIterator = this.jobStatusRetriever.getJobStatusesForFlowExecution(FLOW_NAME, FLOW_GROUP, flowExecutionId);
     Assert.assertTrue(jobStatusIterator.hasNext());
     jobStatus = jobStatusIterator.next();
+    if (jobStatus.getJobName().equals(JobStatusRetriever.NA_KEY)) {
+      jobStatus = jobStatusIterator.next();
+    }
     Assert.assertTrue(jobStatus.getJobName().equals(MY_JOB_NAME_1) || jobStatus.getJobName().equals(MY_JOB_NAME_2));
 
     String jobName = jobStatus.getJobName();
@@ -120,6 +123,9 @@ public abstract class JobStatusRetrieverTest {
     Iterator<JobStatus>
         jobStatusIterator = this.jobStatusRetriever.getJobStatusesForFlowExecution(FLOW_NAME, FLOW_GROUP, 1234L);
     JobStatus jobStatus = jobStatusIterator.next();
+    if (jobStatus.getJobName().equals(JobStatusRetriever.NA_KEY)) {
+      jobStatus = jobStatusIterator.next();
+    }
     Assert.assertEquals(jobStatus.getEventName(), ExecutionStatus.COMPLETE.name());
     Assert.assertEquals(jobStatus.getStartTime(), JOB_START_TIME);
     Assert.assertEquals(jobStatus.getEndTime(), JOB_END_TIME);
@@ -128,13 +134,13 @@ public abstract class JobStatusRetrieverTest {
   @Test (dependsOnMethods = "testJobTiming")
   public void testGetJobStatusesForFlowExecution1() {
     long flowExecutionId = 1234L;
-    Iterator<JobStatus> jobStatusIterator = this.jobStatusRetriever.getJobStatusesForFlowExecution(FLOW_NAME, FLOW_GROUP, flowExecutionId,
-        MY_JOB_NAME_1, myJobGroup);
+    Iterator<JobStatus> jobStatusIterator = this.jobStatusRetriever.
+        getJobStatusesForFlowExecution(FLOW_NAME, FLOW_GROUP, flowExecutionId, MY_JOB_NAME_1, MY_JOB_GROUP);
 
     Assert.assertTrue(jobStatusIterator.hasNext());
     JobStatus jobStatus = jobStatusIterator.next();
     Assert.assertEquals(jobStatus.getJobName(), MY_JOB_NAME_1);
-    Assert.assertEquals(jobStatus.getJobGroup(), myJobGroup);
+    Assert.assertEquals(jobStatus.getJobGroup(), MY_JOB_GROUP);
     Assert.assertEquals(jobStatus.getJobExecutionId(), JOB_EXECUTION_ID);
     Assert.assertEquals(jobStatus.getFlowName(), FLOW_NAME);
     Assert.assertEquals(jobStatus.getFlowGroup(), FLOW_GROUP);

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/MysqlJobStatusRetrieverTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/MysqlJobStatusRetrieverTest.java
@@ -17,17 +17,14 @@
 
 package org.apache.gobblin.service.monitoring;
 
-import java.util.Iterator;
-
-import org.testng.Assert;
-import org.testng.annotations.BeforeClass;
-
+import java.io.IOException;
 import org.apache.gobblin.config.ConfigBuilder;
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.metastore.MysqlJobStatusStateStore;
 import org.apache.gobblin.metastore.testing.ITestMetastoreDatabase;
 import org.apache.gobblin.metastore.testing.TestMetastoreDatabaseFactory;
-import org.apache.gobblin.service.ExecutionStatus;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
 
 
 public class MysqlJobStatusRetrieverTest extends JobStatusRetrieverTest {
@@ -49,6 +46,31 @@ public class MysqlJobStatusRetrieverTest extends JobStatusRetrieverTest {
     this.jobStatusRetriever = new MysqlJobStatusRetriever(configBuilder.build());
     this.dbJobStateStore = ((MysqlJobStatusRetriever) this.jobStatusRetriever).getStateStore();
     cleanUpDir();
+  }
+
+  @Test
+  public void testGetJobStatusesForFlowExecution() throws IOException {
+    super.testGetJobStatusesForFlowExecution();
+  }
+
+  @Test (dependsOnMethods = "testGetJobStatusesForFlowExecution")
+  public void testJobTiming() throws Exception {
+    super.testJobTiming();
+  }
+
+  @Test (dependsOnMethods = "testJobTiming")
+  public void testOutOfOrderJobTimingEvents() throws IOException {
+    super.testOutOfOrderJobTimingEvents();
+  }
+
+  @Test (dependsOnMethods = "testJobTiming")
+  public void testGetJobStatusesForFlowExecution1() {
+    super.testGetJobStatusesForFlowExecution1();
+  }
+
+  @Test (dependsOnMethods = "testGetJobStatusesForFlowExecution1")
+  public void testGetLatestExecutionIdsForFlow() throws Exception {
+    super.testGetLatestExecutionIdsForFlow();
   }
 
   @Override

--- a/gradle/scripts/dependencyDefinitions.gradle
+++ b/gradle/scripts/dependencyDefinitions.gradle
@@ -86,7 +86,7 @@ ext.externalDependency = [
     "zkClient": "com.101tec:zkclient:0.7",
     "quartz": "org.quartz-scheduler:quartz:2.2.3",
     "testng": "org.testng:testng:6.9.10",
-    "junit": "junit:junit:4.12",
+    "junit": "org.junit.jupiter:junit-jupiter-api:5.3.2",
     "mockserver":"org.mock-server:mockserver-netty:3.10.4",
     "jacksonCore": "org.codehaus.jackson:jackson-core-asl:1.9.13",
     "jacksonMapper": "org.codehaus.jackson:jackson-mapper-asl:1.9.13",

--- a/gradle/scripts/dependencyDefinitions.gradle
+++ b/gradle/scripts/dependencyDefinitions.gradle
@@ -86,7 +86,7 @@ ext.externalDependency = [
     "zkClient": "com.101tec:zkclient:0.7",
     "quartz": "org.quartz-scheduler:quartz:2.2.3",
     "testng": "org.testng:testng:6.9.10",
-    "junit": "org.junit.jupiter:junit-jupiter-api:5.3.2",
+    "junit": "junit:junit:4.12",
     "mockserver":"org.mock-server:mockserver-netty:3.10.4",
     "jacksonCore": "org.codehaus.jackson:jackson-core-asl:1.9.13",
     "jacksonMapper": "org.codehaus.jackson:jackson-mapper-asl:1.9.13",


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1086


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
update gaas job start timer using events coming from job execution

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
trivial changes

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

