### PR TITLE
GOBBLIN-1097: ResultChainingIterator.add argument cannot be null

### DIFF
--- a/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/ResultChainingIterator.java
+++ b/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/ResultChainingIterator.java
@@ -45,7 +45,9 @@ public class ResultChainingIterator implements Iterator<JsonElement> {
   }
 
   public void add(Iterator<JsonElement> iter) {
-    this.iter = Iterators.concat(this.iter, iter);
+    if (iter != null) {
+      this.iter = Iterators.concat(this.iter, iter);
+    }
   }
 
   @Override


### PR DESCRIPTION

Dear Gobblin maintainers,

### JIRA
https://issues.apache.org/jira/browse/GOBBLIN-1097

### Description
ResultChainingIterator.add should check if the argument iterator is null

### Tests
https://ltx1-holdemaz05.grid.linkedin.com:8443/executor?execid=24779423



