### PR TITLE
[GOBBLIN-1098] Remove commons-lang and slf4j from the orc-dep fat jar

### DIFF
--- a/gobblin-modules/gobblin-orc-dep/build.gradle
+++ b/gobblin-modules/gobblin-orc-dep/build.gradle
@@ -52,6 +52,12 @@ configurations {
 
 shadowJar {
   zip64 true
+
+  dependencies {
+    exclude dependency('org.slf4j:.*')
+    exclude dependency('commons-lang:.*')
+  }
+
   relocate 'org.apache.hadoop.hive', 'shadow.gobblin.orc.org.apache.hadoop.hive'
   relocate 'com.google', 'shadow.gobblin.orc.com.google'
 }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1098


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
The commons-lang and slf4j are commonly used dependencies and are likely to result in conflicts when included in a fat jar without shading. Remove these dependencies from the orc-dep fat jar to avoid conflicts.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Built and tested with the new fat jar.

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

