### PR TITLE
GOBBLIN-1099: Handle orphaned Yarn containers in Gobblin-on-Yarn clus…

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterManager.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterManager.java
@@ -56,6 +56,7 @@ import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigValueFactory;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -108,6 +109,7 @@ public class GobblinClusterManager implements ApplicationLauncher, StandardMetri
   protected ServiceBasedAppLauncher applicationLauncher;
 
   // An EventBus used for communications between services running in the ApplicationMaster
+  @Getter(AccessLevel.PUBLIC)
   protected final EventBus eventBus = new EventBus(GobblinClusterManager.class.getSimpleName());
 
   protected final Path appWorkDir;
@@ -399,12 +401,6 @@ public class GobblinClusterManager implements ApplicationLauncher, StandardMetri
   public void handleApplicationMasterShutdownRequest(ClusterManagerShutdownRequest shutdownRequest) {
     stop();
   }
-
-  @VisibleForTesting
-  EventBus getEventBus() {
-    return this.eventBus;
-  }
-
 
   /**
    * Creates and returns a {@link MessageHandlerFactory} for handling of Helix

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinTaskRunner.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinTaskRunner.java
@@ -91,7 +91,6 @@ import org.apache.gobblin.util.HadoopUtils;
 import org.apache.gobblin.util.JvmUtils;
 import org.apache.gobblin.util.reflection.GobblinConstructorUtils;
 
-
 /**
  * The main class running in the containers managing services for running Gobblin
  * {@link org.apache.gobblin.source.workunit.WorkUnit}s.
@@ -415,7 +414,7 @@ public class GobblinTaskRunner implements StandardMetricsBridge {
     if (this.taskDriverHelixManager.isPresent()) {
       String taskDriverCluster = clusterConfig.getString(GobblinClusterConfigurationKeys.TASK_DRIVER_CLUSTER_NAME_KEY);
       logger.warn("Dropping instance: {} from task driver cluster: {}", helixInstanceName, taskDriverCluster);
-      HelixUtils.dropInstanceIfExists(admin, taskDriverCluster, helixInstanceName);
+      HelixUtils.dropInstanceIfExists(admin, clusterName, helixInstanceName);
     }
     admin.close();
 
@@ -444,8 +443,7 @@ public class GobblinTaskRunner implements StandardMetricsBridge {
     try {
       retryer.call(connectHelixManagerCallable);
     } catch (ExecutionException | RetryException e) {
-      logger.error("Connecting to Helix manager failed", e);
-      throw Throwables.propagate(e);
+      Throwables.propagate(e);
     }
   }
 

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/HelixUtils.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/HelixUtils.java
@@ -356,13 +356,11 @@ public class HelixUtils {
     return accessor.getProperty(liveInstanceKey) != null;
   }
 
-  public static boolean dropInstanceIfExists(HelixAdmin admin, String clusterName, String helixInstanceName) {
+  public static void dropInstanceIfExists(HelixAdmin admin, String clusterName, String helixInstanceName) {
     try {
       admin.dropInstance(clusterName, new InstanceConfig(helixInstanceName));
-      return true;
     } catch (HelixException e) {
       log.error("Could not drop instance: {} due to: {}", helixInstanceName, e);
-      return false;
     }
   }
 }

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinApplicationMaster.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinApplicationMaster.java
@@ -119,7 +119,8 @@ public class GobblinApplicationMaster extends GobblinClusterManager {
   protected YarnService buildYarnService(Config config, String applicationName, String applicationId,
       YarnConfiguration yarnConfiguration, FileSystem fs)
       throws Exception {
-    return new YarnService(config, applicationName, applicationId, yarnConfiguration, fs, this.eventBus);
+    return new YarnService(config, applicationName, applicationId, yarnConfiguration, fs, this.eventBus,
+        this.getMultiManager().getJobClusterHelixManager());
   }
 
   /**

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnService.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnService.java
@@ -193,7 +193,6 @@ public class YarnService extends AbstractIdleService {
   // into the queue if the container running the instance completes. Unused Helix
   // instance names get picked up when replacement containers get allocated.
   private final ConcurrentLinkedQueue<String> unusedHelixInstanceNames = Queues.newConcurrentLinkedQueue();
-  private boolean reuseUnusedHelixInstanceNames = true;
 
   private volatile boolean shutdownInProgress = false;
 
@@ -634,6 +633,9 @@ public class YarnService extends AbstractIdleService {
    */
   protected void handleContainerCompletion(ContainerStatus containerStatus) {
     Map.Entry<Container, String> completedContainerEntry = this.containerMap.remove(containerStatus.getContainerId());
+    //Get the Helix instance name for the completed container. Because callbacks are processed asynchronously, we might
+    //encounter situations where handleContainerCompletion() is called before onContainersAllocated(), resulting in the
+    //containerId missing from the containersMap.
     String completedInstanceName = completedContainerEntry == null?  UNKNOWN_HELIX_INSTANCE : completedContainerEntry.getValue();
 
     LOGGER.info(String.format("Container %s running Helix instance %s has completed with exit status %d",

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnService.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnService.java
@@ -65,6 +65,7 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.security.AMRMTokenIdentifier;
 import org.apache.hadoop.yarn.util.Records;
+import org.apache.helix.HelixManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -82,6 +83,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Queues;
+import com.google.common.collect.Sets;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 import com.google.common.io.Closer;
@@ -123,6 +125,8 @@ public class YarnService extends AbstractIdleService {
 
   private static final Splitter SPLITTER = Splitter.on(',').omitEmptyStrings().trimResults();
 
+  private static final String UNKNOWN_HELIX_INSTANCE = "UNKNOWN";
+
   private final String applicationName;
   private final String applicationId;
   private final String appViewAcl;
@@ -156,6 +160,7 @@ public class YarnService extends AbstractIdleService {
 
   private final Optional<String> containerJvmArgs;
   private final String containerTimezone;
+  private final HelixManager helixManager;
 
   private volatile Optional<Resource> maxResourceCapacity = Optional.absent();
 
@@ -188,6 +193,7 @@ public class YarnService extends AbstractIdleService {
   // into the queue if the container running the instance completes. Unused Helix
   // instance names get picked up when replacement containers get allocated.
   private final ConcurrentLinkedQueue<String> unusedHelixInstanceNames = Queues.newConcurrentLinkedQueue();
+  private boolean reuseUnusedHelixInstanceNames = true;
 
   private volatile boolean shutdownInProgress = false;
 
@@ -199,15 +205,18 @@ public class YarnService extends AbstractIdleService {
   @VisibleForTesting
   @Getter(AccessLevel.PROTECTED)
   private int numRequestedContainers = 0;
+  private final Set<String> blacklistedInstances = Sets.newHashSet();
 
   public YarnService(Config config, String applicationName, String applicationId, YarnConfiguration yarnConfiguration,
-      FileSystem fs, EventBus eventBus) throws Exception {
+      FileSystem fs, EventBus eventBus, HelixManager helixManager) throws Exception {
     this.applicationName = applicationName;
     this.applicationId = applicationId;
 
     this.config = config;
 
     this.eventBus = eventBus;
+
+    this.helixManager = helixManager;
 
     this.gobblinMetrics = config.getBoolean(ConfigurationKeys.METRICS_ENABLED_KEY) ?
         Optional.of(buildGobblinMetrics()) : Optional.<GobblinMetrics>absent();
@@ -625,7 +634,7 @@ public class YarnService extends AbstractIdleService {
    */
   protected void handleContainerCompletion(ContainerStatus containerStatus) {
     Map.Entry<Container, String> completedContainerEntry = this.containerMap.remove(containerStatus.getContainerId());
-    String completedInstanceName = completedContainerEntry == null? "unknown" : completedContainerEntry.getValue();
+    String completedInstanceName = completedContainerEntry == null?  UNKNOWN_HELIX_INSTANCE : completedContainerEntry.getValue();
 
     LOGGER.info(String.format("Container %s running Helix instance %s has completed with exit status %d",
         containerStatus.getContainerId(), completedInstanceName, containerStatus.getExitStatus()));
@@ -635,10 +644,26 @@ public class YarnService extends AbstractIdleService {
           containerStatus.getContainerId(), containerStatus.getDiagnostics()));
     }
 
-    if (this.releasedContainerCache.getIfPresent(containerStatus.getContainerId()) != null) {
-      LOGGER.info("Container release requested, so not spawning a replacement for containerId {}",
-          containerStatus.getContainerId());
-      return;
+    if (containerStatus.getExitStatus() == ContainerExitStatus.ABORTED) {
+      if (this.releasedContainerCache.getIfPresent(containerStatus.getContainerId()) != null) {
+        LOGGER.info("Container release requested, so not spawning a replacement for containerId {}", containerStatus.getContainerId());
+        return;
+      } else {
+        LOGGER.info("Container {} aborted due to lost NM", containerStatus.getContainerId());
+       // Container release was not requested. Likely, the container was running on a node on which the NM died.
+       // In this case, RM assumes that the containers are "lost", even though the container process may still be
+        // running on the node. We need to ensure that the Helix instances running on the orphaned containers
+        // are fenced off from the Helix cluster to avoid double publishing and state being committed by the
+        // instances.
+        if (!UNKNOWN_HELIX_INSTANCE.equals(completedInstanceName)) {
+          String clusterName = this.helixManager.getClusterName();
+          //Disable the orphaned instance.
+          if (HelixUtils.isInstanceLive(helixManager, completedInstanceName)) {
+            LOGGER.info("Disabling the Helix instance {}", completedInstanceName);
+            this.helixManager.getClusterManagmentTool().enableInstance(clusterName, completedInstanceName, false);
+          }
+        }
+      }
     }
 
     if (this.shutdownInProgress) {
@@ -723,10 +748,10 @@ public class YarnService extends AbstractIdleService {
         LOGGER.info(String.format("Container %s has been allocated", container.getId()));
 
         String instanceName = unusedHelixInstanceNames.poll();
-        if (Strings.isNullOrEmpty(instanceName)) {
+        while (Strings.isNullOrEmpty(instanceName) || HelixUtils.isInstanceLive(helixManager, instanceName)) {
           // No unused instance name, so generating a new one.
-          instanceName = HelixUtils.getHelixInstanceName(HELIX_YARN_INSTANCE_NAME_PREFIX,
-              helixInstanceIdGenerator.incrementAndGet());
+          instanceName = HelixUtils
+              .getHelixInstanceName(HELIX_YARN_INSTANCE_NAME_PREFIX, helixInstanceIdGenerator.incrementAndGet());
         }
 
         final String finalInstanceName = instanceName;

--- a/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/GobblinYarnAppLauncherTest.java
+++ b/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/GobblinYarnAppLauncherTest.java
@@ -480,7 +480,7 @@ public class GobblinYarnAppLauncherTest implements HelixMessageTestBase {
   private static class TestYarnService extends YarnService {
     public TestYarnService(Config config, String applicationName, String applicationId, YarnConfiguration yarnConfiguration,
         FileSystem fs, EventBus eventBus) throws Exception {
-      super(config, applicationName, applicationId, yarnConfiguration, fs, eventBus);
+      super(config, applicationName, applicationId, yarnConfiguration, fs, eventBus, null);
     }
 
     @Override

--- a/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnServiceTest.java
+++ b/gobblin-yarn/src/test/java/org/apache/gobblin/yarn/YarnServiceTest.java
@@ -17,13 +17,6 @@
 
 package org.apache.gobblin.yarn;
 
-import com.google.common.base.Predicate;
-import com.google.common.eventbus.EventBus;
-import com.google.common.io.Closer;
-import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
-import com.typesafe.config.ConfigValueFactory;
-
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.URL;
@@ -35,7 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
-import org.apache.gobblin.testing.AssertWithBackoff;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -63,6 +56,15 @@ import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+
+import com.google.common.base.Predicate;
+import com.google.common.eventbus.EventBus;
+import com.google.common.io.Closer;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigValueFactory;
+
+import org.apache.gobblin.testing.AssertWithBackoff;
 
 
 /**
@@ -282,7 +284,7 @@ public class YarnServiceTest {
    static class TestYarnService extends YarnService {
     public TestYarnService(Config config, String applicationName, String applicationId, YarnConfiguration yarnConfiguration,
         FileSystem fs, EventBus eventBus) throws Exception {
-      super(config, applicationName, applicationId, yarnConfiguration, fs, eventBus);
+      super(config, applicationName, applicationId, yarnConfiguration, fs, eventBus, null);
     }
 
     protected ContainerLaunchContext newContainerLaunchContext(Container container, String helixInstanceName)


### PR DESCRIPTION
…ters

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1099


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
A Yarn application may leave behind orphaned containers, which can happen due to lost node managers. The orphaned containers however can continue to run (potentially forever) as participants in the Helix cluster. This can cause the following problems for a Gobblin-on-Yarn application:

Double publish of data and commit of state
Task failures and partition starvation during application restarts, as Helix may assign tasks to the orphaned containers which have a stale state and configuration
Container failures on application restarts due to Helix instance name collisions with orphaned containers

This PR incorporates the following changes to handle orphaned containers:
1. Disables live instances during Yarn application start up and shutdown in GobblinYarnAppLauncher. This ensures that any orphaned Helix instances are disabled from joining the cluster on restart and any tasks running on these instances are cancelled.
2. The GobblinApplicationMaster (inside YarnService) ensures that Helix instance name assigned to a newly allocated container is not a currently live instance to avoid instance name collisions. We also handle NM failures/restarts that result in Yarn RM "aborting" the container (i.e. container is deemed dead from Yarn's point of view, even though the container may physically be alive). In this case, we disable the instance to ensure it is fenced off from the Helix cluster.
3. Gobblin workers (i.e. GobblinYarnTaskRunner) retry in case of failure in joining a Helix cluster. The retry logic disconnects from the Helix cluster and drops the instance before reattempting to join the cluster. 

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Added unit test in GobblinTaskRunnerTest

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

