### PR TITLE
[GOBBLIN-1100] Set average fetch time in the KafkaExtractor even when…

### DIFF
--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaExtractor.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaExtractor.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 
 import lombok.Getter;
 
@@ -321,6 +322,11 @@ public abstract class KafkaExtractor<S, D> extends EventBasedExtractor<S, D> {
     this.workUnitState.setActualHighWatermark(this.nextWatermark);
     if (isInstrumentationEnabled()) {
       this.statsTracker.emitTrackingEvents(getMetricContext(), this.lowWatermark, this.highWatermark, this.nextWatermark);
+    } else {
+      // Need to call this even when not emitting metrics because some state, such as the average pull time,
+      // is updated when the tags are generated
+      this.statsTracker.generateTagsForPartitions(this.lowWatermark, this.highWatermark, this.nextWatermark,
+          Maps.newHashMap());
     }
   }
 

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaExtractorStatsTracker.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaExtractorStatsTracker.java
@@ -396,30 +396,9 @@ public class KafkaExtractorStatsTracker {
   /**
    * Emit Tracking events reporting the various statistics to be consumed by a monitoring application.
    * @param context the current {@link MetricContext}
-   * @param lowWatermark begin Kafka offset for each topic partition
-   * @param highWatermark the expected last Kafka offset for each topic partition to be consumed by the Extractor
-   * @param nextWatermark the offset of next valid message for each Kafka topic partition consumed by the Extractor
+   * @param tagsForPartitionsMap tags for each partition
    */
-  public void emitTrackingEvents(MetricContext context, MultiLongWatermark lowWatermark, MultiLongWatermark highWatermark,
-      MultiLongWatermark nextWatermark) {
-    emitTrackingEventsWithAdditionalTags(context, lowWatermark, highWatermark, nextWatermark, Maps.newHashMap());
-  }
-
-  /**
-   * Emit Tracking events reporting the various statistics to be consumed by a monitoring application, with additional
-   * map representing tags beyond what are constructed in {@link #createTagsForPartition(int, MultiLongWatermark, MultiLongWatermark, MultiLongWatermark) }
-   *
-   * Choose to not to make createTagsForPartition extensible to avoid additional derived class just for additional k-v pairs
-   * in the tag maps.
-   *
-   * @param additionalTags caller-provided mapping from {@link KafkaPartition} to {@link Map<String, String>}, which will
-   *                       be merged with result of {@link #createTagsForPartition}.
-   */
-  public void emitTrackingEventsWithAdditionalTags(MetricContext context, MultiLongWatermark lowWatermark, MultiLongWatermark highWatermark,
-      MultiLongWatermark nextWatermark, Map<KafkaPartition, Map<String, String>> additionalTags) {
-    Map<KafkaPartition, Map<String, String>> tagsForPartitionsMap =
-        generateTagsForPartitions(lowWatermark, highWatermark, nextWatermark, additionalTags);
-
+  public void emitTrackingEvents(MetricContext context, Map<KafkaPartition, Map<String, String>> tagsForPartitionsMap) {
     for (Map.Entry<KafkaPartition, Map<String, String>> eventTags : tagsForPartitionsMap.entrySet()) {
       EventSubmitter.Builder eventSubmitterBuilder = new EventSubmitter.Builder(context, GOBBLIN_KAFKA_NAMESPACE);
       eventSubmitterBuilder.addMetadata(this.taskEventMetadataGenerator.getMetadata(workUnitState, KAFKA_EXTRACTOR_TOPIC_METADATA_EVENT_NAME));


### PR DESCRIPTION
… metrics are disabled

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1100


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
The KafkaExtractor close method only calls the KafkaExtractorStatsTracker#emitTrackingEvents method when metrics instrumentation is enabled. This method calls KafkaExtractorStatsTracker#generateTagsForPartitions, which has the side effect of setting the average fetch time in the WorkUnitState. The average fetch time is required for the work unit packing to pack optimally.

Add a call to KafkaExtractorStatsTracker#generateTagsForPartitions in KafkaExtractor#close when metrics instrumentation is disabled to restore the behavior that existed prior to the KafkaExtractorStatsTracker refactoring.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
KafkaExtractorStatsTrackerTest

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

