### PR TITLE
GOBBLIN-1101(DSS-25241): Enhance bulk api retry for ExceedQuota

### DIFF
--- a/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/BulkResultIterator.java
+++ b/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/BulkResultIterator.java
@@ -107,8 +107,9 @@ public class BulkResultIterator implements Iterator<JsonElement> {
   private void threadSleep(long millis) {
     try {
       Thread.sleep(millis);
-    } catch (Exception ee) {
-      log.warn("--sleep exception--");
+    } catch (Exception e) {
+      log.error("--Failed to sleep--", e);
+      throw new RuntimeException(e);
     }
   }
 

--- a/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/BulkResultIterator.java
+++ b/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/BulkResultIterator.java
@@ -72,7 +72,7 @@ public class BulkResultIterator implements Iterator<JsonElement> {
     Throwable rootCause = null;
     int executeCount = 0;
     while (executeCount < retryLimit + 1) {
-      executeCount ++;
+      executeCount++;
       try {
         if (this.csvReader == null) {
           this.csvReader = openAndSeekCsvReader(rootCause);
@@ -89,7 +89,7 @@ public class BulkResultIterator implements Iterator<JsonElement> {
         if (e.isCurrentExceptionExceedQuota()) {
           log.warn("--Caught ExceededQuota: " + e.getMessage());
           threadSleep(retryExceedQuotaInterval);
-          executeCount --; // if the current exception is Quota Exceeded, keep trying forever
+          executeCount--; // if the current exception is Quota Exceeded, keep trying forever
         }
         log.info("***Retrying***1: {} - {}", fileIdVO, e.getMessage());
         this.csvReader = null; // in next loop, call openAndSeekCsvReader
@@ -158,13 +158,13 @@ public class BulkResultIterator implements Iterator<JsonElement> {
       if ((lastSkippedLine == null && preLoadedLine != null) || (lastSkippedLine != null && !lastSkippedLine.equals(
           preLoadedLine))) {
         // check if last skipped line is same as the line before error
-        String msg = rootCause == null? "null" : rootCause.getMessage();
+        String msg = rootCause == null ? "null" : rootCause.getMessage();
         throw new OpenAndSeekException("Failed to verify last skipped line - root cause [" + msg + "]", rootCause);
       }
       return csvReader;
 
     } catch (Exception currentException) { // failed to open reader and skip lineCount lines // ssl failures go here
-      Throwable cause = rootCause == null? currentException : rootCause;
+      Throwable cause = rootCause == null ? currentException : rootCause;
       throw new OpenAndSeekException("Failed to [" + cause.getMessage() + "]" , cause, currentException);
     }
   }

--- a/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/BulkResultIterator.java
+++ b/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/BulkResultIterator.java
@@ -186,6 +186,7 @@ public class BulkResultIterator implements Iterator<JsonElement> {
   }
 }
 
+
 class OpenAndSeekException extends Exception {
   private boolean _isCurrentExceptionExceedQuota;
   public OpenAndSeekException(String msg, Throwable rootCause) {

--- a/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/BulkResultIterator.java
+++ b/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/BulkResultIterator.java
@@ -82,7 +82,7 @@ public class BulkResultIterator implements Iterator<JsonElement> {
         rootCause = e.getCause();
         // Each organization is allowed 10 concurrent long-running requests. If the limit is reached,
         // any new synchronous Apex request results in a runtime exception.
-        if (e.isCurrentExceptionExceedQuta()) {
+        if (e.isCurrentExceptionExceedQuota()) {
           log.warn("--Caught ExceededQuota: " + e.getMessage());
           threadSleep(5 * 60 * 1000); // 5 minutes
           executeCount --; // if the current exception is Quota Exceeded, keep trying forever
@@ -196,7 +196,7 @@ class OpenAndSeekException extends Exception {
       _isCurrentExceptionExceedQuota = true;
     }
   }
-  public boolean isCurrentExceptionExceedQuta() {
+  public boolean isCurrentExceptionExceedQuota() {
     return _isCurrentExceptionExceedQuota;
   }
 }

--- a/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/BulkResultIterator.java
+++ b/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/BulkResultIterator.java
@@ -158,6 +158,7 @@ public class BulkResultIterator implements Iterator<JsonElement> {
         throw new OpenAndSeekException("Failed to verify last skipped line - root cause [" + msg + "]", rootCause);
       }
       return csvReader;
+
     } catch (Exception currentException) { // failed to open reader and skip lineCount lines // ssl failures go here
       Throwable cause = rootCause == null? currentException : rootCause;
       throw new OpenAndSeekException("Failed to [" + cause.getMessage() + "]" , cause, currentException);

--- a/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/ResultChainingIterator.java
+++ b/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/ResultChainingIterator.java
@@ -35,8 +35,10 @@ public class ResultChainingIterator implements Iterator<JsonElement> {
   private Iterator<JsonElement> iter;
   private int recordCount = 0;
 
-  public ResultChainingIterator(BulkConnection conn, List<FileIdVO> fileIdList, int retryLimit) {
-    Iterator<BulkResultIterator> iterOfFiles = fileIdList.stream().map(x -> new BulkResultIterator(conn, x, retryLimit)).iterator();
+  public ResultChainingIterator(BulkConnection conn, List<FileIdVO> fileIdList, int retryLimit,
+      long retryInterval, long retryExceedQuotaInterval) {
+    Iterator<BulkResultIterator> iterOfFiles = fileIdList.stream().map(x ->
+        new BulkResultIterator(conn, x, retryLimit, retryInterval, retryExceedQuotaInterval)).iterator();
     iter = Iterators.<JsonElement>concat(iterOfFiles);
   }
 

--- a/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/SalesforceConfigurationKeys.java
+++ b/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/SalesforceConfigurationKeys.java
@@ -25,7 +25,7 @@ public final class SalesforceConfigurationKeys {
   }
   public static final String SOURCE_QUERYBASED_SALESFORCE_IS_SOFT_DELETES_PULL_DISABLED =
       "source.querybased.salesforce.is.soft.deletes.pull.disabled";
-  public static final int DEFAULT_FETCH_RETRY_LIMIT = 5;
+  public static final int DEFAULT_FETCH_RETRY_LIMIT = 1;
   public static final String BULK_API_USE_QUERY_ALL = "salesforce.bulkApiUseQueryAll";
 
   // pk-chunking

--- a/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/SalesforceConfigurationKeys.java
+++ b/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/SalesforceConfigurationKeys.java
@@ -28,6 +28,13 @@ public final class SalesforceConfigurationKeys {
   public static final int DEFAULT_FETCH_RETRY_LIMIT = 5;
   public static final String BULK_API_USE_QUERY_ALL = "salesforce.bulkApiUseQueryAll";
 
+  // bulk api retry sleep duration for avoid resource consuming peak.
+  public static final String RETRY_EXCEED_QUOTA_INTERVAL = "salesforce.retry.exceedQuotaInterval";
+  public static final long RETRY_EXCEED_QUOTA_INTERVAL_DEFAULT = 5 * 60 * 1000;
+
+  public static final String RETRY_INTERVAL = "salesforce.retry.interval";
+  public static final long RETRY_INTERVAL_DEFAULT = 1 * 60 * 1000;
+
   // pk-chunking
   public static final String BULK_TEST_JOB_ID = "salesforce.bulk.testJobId";
   public static final String BULK_TEST_BATCH_ID_LIST = "salesforce.bulk.testBatchIds";

--- a/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/SalesforceConfigurationKeys.java
+++ b/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/SalesforceConfigurationKeys.java
@@ -25,7 +25,7 @@ public final class SalesforceConfigurationKeys {
   }
   public static final String SOURCE_QUERYBASED_SALESFORCE_IS_SOFT_DELETES_PULL_DISABLED =
       "source.querybased.salesforce.is.soft.deletes.pull.disabled";
-  public static final int DEFAULT_FETCH_RETRY_LIMIT = 1;
+  public static final int DEFAULT_FETCH_RETRY_LIMIT = 5;
   public static final String BULK_API_USE_QUERY_ALL = "salesforce.bulkApiUseQueryAll";
 
   // pk-chunking


### PR DESCRIPTION
### JIRA
https://issues.apache.org/jira/browse/GOBBLIN-1101

### Description
1. ExceedQuota exception
If the ExceedQuota exception happens, we should let the thread sleep 5 minutes and try again. There should not be a retryLimit for this exception.
2. Except stack in log file
For example we set up retryLimit to 10, we retried 10 times,  and failed; we need to print out exception stack in log file, there are 10 of them in the exception stack. We'd better skip all the retry exception, only keep the root cause exception.

### Tests
https://ltx1-holdemaz05.grid.linkedin.com:8443/executor?execid=25014730&job=salesforce_task_full&attempt=0

