### PR TITLE
GOBBLIN-1107: Lazily initialize Helix TaskStateModelFactory in Gobbli…

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinTaskRunner.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinTaskRunner.java
@@ -139,6 +139,8 @@ public class GobblinTaskRunner implements StandardMetricsBridge {
   private boolean isTaskDriver;
   private boolean dedicatedTaskDriverCluster;
   private Collection<StandardMetricsBridge.StandardMetrics> metricsCollection;
+  @Getter
+  private volatile boolean started = false;
   private volatile boolean stopInProgress = false;
   private volatile boolean isStopped = false;
 
@@ -314,7 +316,10 @@ public class GobblinTaskRunner implements StandardMetricsBridge {
 
     if (this.serviceManager != null) {
       this.serviceManager.startAsync();
+      started = true;
       this.serviceManager.awaitStopped();
+    } else {
+      started = true;
     }
   }
 

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/ClusterIntegrationTest.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/ClusterIntegrationTest.java
@@ -80,7 +80,9 @@ public class ClusterIntegrationTest {
 
   @Test
   void testJobShouldGetCancelled() throws Exception {
-    this.suite =new IntegrationJobCancelSuite();
+    Config jobConfigOverrides = ClusterIntegrationTestUtils.buildSleepingJob(IntegrationJobCancelSuite.JOB_ID,
+        IntegrationJobCancelSuite.TASK_STATE_FILE);
+    this.suite =new IntegrationJobCancelSuite(jobConfigOverrides);
     HelixManager helixManager = getHelixManager();
     suite.startCluster();
     helixManager.connect();
@@ -121,7 +123,9 @@ public class ClusterIntegrationTest {
    */
   @Test (dependsOnMethods = { "testJobShouldGetCancelled" }, groups = {"disabledOnTravis"})
   public void testJobRestartViaSpec() throws Exception {
-    this.suite = new IntegrationJobRestartViaSpecSuite();
+    Config jobConfigOverrides = ClusterIntegrationTestUtils.buildSleepingJob(IntegrationJobCancelSuite.JOB_ID,
+        IntegrationJobCancelSuite.TASK_STATE_FILE);
+    this.suite = new IntegrationJobRestartViaSpecSuite(jobConfigOverrides);
     HelixManager helixManager = getHelixManager();
 
     IntegrationJobRestartViaSpecSuite restartViaSpecSuite = (IntegrationJobRestartViaSpecSuite) this.suite;
@@ -132,10 +136,10 @@ public class ClusterIntegrationTest {
     helixManager.connect();
 
     AssertWithBackoff.create().timeoutMs(30000).maxSleepMs(1000).backoffFactor(1).
-        assertTrue(isTaskStarted(helixManager, IntegrationJobCancelSuite.JOB_ID), "Waiting for the job to start...");
+        assertTrue(isTaskStarted(helixManager, IntegrationJobRestartViaSpecSuite.JOB_ID), "Waiting for the job to start...");
 
     AssertWithBackoff.create().maxSleepMs(100).timeoutMs(2000).backoffFactor(1).
-        assertTrue(isTaskRunning(IntegrationJobCancelSuite.TASK_STATE_FILE), "Waiting for the task to enter running state");
+        assertTrue(isTaskRunning(IntegrationJobRestartViaSpecSuite.TASK_STATE_FILE), "Waiting for the task to enter running state");
 
     ZkClient zkClient = new ZkClient(this.zkConnectString);
     PathBasedZkSerializer zkSerializer = ChainedPathZkSerializer.builder(new ZNRecordStreamingSerializer()).build();

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/ClusterIntegrationTestUtils.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/ClusterIntegrationTestUtils.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.cluster;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigValueFactory;
+
+import org.apache.gobblin.configuration.ConfigurationKeys;
+
+public class ClusterIntegrationTestUtils {
+  public static Config buildSleepingJob(String jobId, String taskStateFile) {
+    return buildSleepingJob(jobId, taskStateFile, 10L);
+  }
+
+  public static Config buildSleepingJob(String jobId, String taskStateFile, Long helixJobTimeoutSecs) {
+    Config jobConfig = ConfigFactory.empty().withValue(SleepingTask.TASK_STATE_FILE_KEY, ConfigValueFactory.fromAnyRef(taskStateFile))
+        .withValue(ConfigurationKeys.JOB_ID_KEY, ConfigValueFactory.fromAnyRef(jobId))
+        .withValue(ConfigurationKeys.SOURCE_CLASS_KEY, ConfigValueFactory.fromAnyRef(SleepingCustomTaskSource.class.getName()))
+        .withValue(GobblinClusterConfigurationKeys.HELIX_JOB_TIMEOUT_ENABLED_KEY, ConfigValueFactory.fromAnyRef(Boolean.TRUE))
+        .withValue(GobblinClusterConfigurationKeys.HELIX_JOB_TIMEOUT_SECONDS, ConfigValueFactory.fromAnyRef(10L));
+    return jobConfig;
+  }
+}

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/ClusterIntegrationTestUtils.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/ClusterIntegrationTestUtils.java
@@ -17,6 +17,11 @@
 
 package org.apache.gobblin.cluster;
 
+import org.apache.helix.HelixManager;
+import org.apache.helix.PropertyPathBuilder;
+import org.apache.helix.manager.zk.ZkClient;
+import org.testng.Assert;
+
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigValueFactory;
@@ -24,16 +29,48 @@ import com.typesafe.config.ConfigValueFactory;
 import org.apache.gobblin.configuration.ConfigurationKeys;
 
 public class ClusterIntegrationTestUtils {
+  /**
+   * A utility method to build a job that uses the {@link SleepingCustomTaskSource} with the provided config overrides.
+   * @param jobId
+   * @param taskStateFile
+   * @return job config with overrides
+   */
   public static Config buildSleepingJob(String jobId, String taskStateFile) {
     return buildSleepingJob(jobId, taskStateFile, 10L);
   }
 
+  /**
+   * A utility method to build a job that uses the {@link SleepingCustomTaskSource} with the provided config overrides.
+   * @param jobId
+   * @param taskStateFile
+   * @param helixJobTimeoutSecs
+   * @return job config with overrides
+   */
   public static Config buildSleepingJob(String jobId, String taskStateFile, Long helixJobTimeoutSecs) {
     Config jobConfig = ConfigFactory.empty().withValue(SleepingTask.TASK_STATE_FILE_KEY, ConfigValueFactory.fromAnyRef(taskStateFile))
         .withValue(ConfigurationKeys.JOB_ID_KEY, ConfigValueFactory.fromAnyRef(jobId))
         .withValue(ConfigurationKeys.SOURCE_CLASS_KEY, ConfigValueFactory.fromAnyRef(SleepingCustomTaskSource.class.getName()))
         .withValue(GobblinClusterConfigurationKeys.HELIX_JOB_TIMEOUT_ENABLED_KEY, ConfigValueFactory.fromAnyRef(Boolean.TRUE))
-        .withValue(GobblinClusterConfigurationKeys.HELIX_JOB_TIMEOUT_SECONDS, ConfigValueFactory.fromAnyRef(10L));
+        .withValue(GobblinClusterConfigurationKeys.HELIX_JOB_TIMEOUT_SECONDS, ConfigValueFactory.fromAnyRef(helixJobTimeoutSecs));
     return jobConfig;
+  }
+
+  /**
+   * A utility method that creates a partial instance structure in ZK.
+   */
+  public static void createPartialInstanceStructure(HelixManager helixManager, String zkConnectString) {
+    //Connect and disconnect the helixManager to create a Helix Instance set up.
+    try {
+      helixManager.connect();
+      helixManager.disconnect();
+    } catch (Exception e) {
+      Assert.fail("Failed to connect to ZK");
+    }
+
+    //Delete ERRORS/HISTORY/STATUSUPDATES znodes under INSTANCES to simulate partial instance set up.
+    ZkClient zkClient = new ZkClient(zkConnectString);
+    zkClient.delete(PropertyPathBuilder.instanceError(helixManager.getClusterName(), helixManager.getInstanceName()));
+    zkClient.delete(PropertyPathBuilder.instanceHistory(helixManager.getClusterName(), helixManager.getInstanceName()));
+    zkClient.delete(PropertyPathBuilder.instanceStatusUpdate(helixManager.getClusterName(), helixManager.getInstanceName()));
   }
 }

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinTaskRunnerTest.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinTaskRunnerTest.java
@@ -29,8 +29,6 @@ import org.apache.helix.HelixException;
 import org.apache.helix.HelixManager;
 import org.apache.helix.HelixManagerFactory;
 import org.apache.helix.InstanceType;
-import org.apache.helix.PropertyPathBuilder;
-import org.apache.helix.manager.zk.ZkClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
@@ -141,31 +139,13 @@ public class GobblinTaskRunnerTest {
     Assert.assertEquals(fileSystem.getConf().get(HADOOP_OVERRIDE_PROPERTY_NAME), "value");
   }
 
-  /**
-   * A helper method that creates a partial instance structure in ZK.
-   */
-  private static void createPartialInstanceStructure(HelixManager helixManager, String zkConnectString) {
-    //Connect and disconnect the helixManager to create a Helix Instance set up.
-    try {
-      helixManager.connect();
-      helixManager.disconnect();
-    } catch (Exception e) {
-      Assert.fail("Failed to connect to ZK");
-    }
-
-    //Delete ERRORS/HISTORY/STATUSUPDATES znodes under INSTANCES to simulate partial instance set up.
-    ZkClient zkClient = new ZkClient(zkConnectString);
-    zkClient.delete(PropertyPathBuilder.instanceError(helixManager.getClusterName(), helixManager.getInstanceName()));
-    zkClient.delete(PropertyPathBuilder.instanceHistory(helixManager.getClusterName(), helixManager.getInstanceName()));
-    zkClient.delete(PropertyPathBuilder.instanceStatusUpdate(helixManager.getClusterName(), helixManager.getInstanceName()));
-  }
 
   @Test
   public void testConnectHelixManagerWithRetry() {
     HelixManager instanceManager = HelixManagerFactory.getZKHelixManager(
         clusterName, corruptHelixInstance, InstanceType.PARTICIPANT, testingZKServer.getConnectString());
 
-    createPartialInstanceStructure(instanceManager, testingZKServer.getConnectString());
+    ClusterIntegrationTestUtils.createPartialInstanceStructure(instanceManager, testingZKServer.getConnectString());
 
     //Ensure that the connecting to Helix without retry will throw a HelixException
     try {
@@ -222,7 +202,7 @@ public class GobblinTaskRunnerTest {
           .getZKHelixManager(clusterName, IntegrationBasicSuite.WORKER_INSTANCE_0, InstanceType.PARTICIPANT, zkConnectString);
 
       //Create a partial instance setup
-      GobblinTaskRunnerTest.createPartialInstanceStructure(helixManager, zkConnectString);
+      ClusterIntegrationTestUtils.createPartialInstanceStructure(helixManager, zkConnectString);
     }
   }
 

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinTaskRunnerTest.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinTaskRunnerTest.java
@@ -19,6 +19,8 @@ package org.apache.gobblin.cluster;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import org.apache.curator.test.TestingServer;
 import org.apache.hadoop.fs.FileSystem;
@@ -110,6 +112,9 @@ public class GobblinTaskRunnerTest {
 
   @Test
   public void testSendReceiveShutdownMessage() throws Exception {
+    ExecutorService service = Executors.newSingleThreadExecutor();
+    service.submit(() -> GobblinTaskRunnerTest.this.gobblinTaskRunner.start());
+
     Logger log = LoggerFactory.getLogger("testSendReceiveShutdownMessage");
     this.gobblinClusterManager.sendShutdownRequest();
 
@@ -156,7 +161,10 @@ public class GobblinTaskRunnerTest {
     //Ensure that connect with retry succeeds
     corruptGobblinTaskRunner.connectHelixManagerWithRetry();
     Assert.assertTrue(true);
+
+    corruptGobblinTaskRunner.disconnectHelixManager();
   }
+
 
   @AfterClass
   public void tearDown() throws IOException {

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinTaskRunnerTest.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinTaskRunnerTest.java
@@ -243,7 +243,9 @@ public class GobblinTaskRunnerTest {
     try {
       this.gobblinClusterManager.disconnectHelixManager();
       this.gobblinTaskRunner.disconnectHelixManager();
-      this.suite.shutdownCluster();
+      if (this.suite != null) {
+        this.suite.shutdownCluster();
+      }
     } finally {
       this.testingZKServer.close();
     }

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinTaskRunnerTest.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinTaskRunnerTest.java
@@ -122,6 +122,15 @@ public class GobblinTaskRunnerTest {
     service.submit(() -> GobblinTaskRunnerTest.this.gobblinTaskRunner.start());
 
     Logger log = LoggerFactory.getLogger("testSendReceiveShutdownMessage");
+
+    // Give Helix some time to start the task runner
+    AssertWithBackoff.create().logger(log).timeoutMs(20000)
+        .assertTrue(new Predicate<Void>() {
+          @Override public boolean apply(Void input) {
+            return GobblinTaskRunnerTest.this.gobblinTaskRunner.isStarted();
+          }
+        }, "gobblinTaskRunner started");
+
     this.gobblinClusterManager.sendShutdownRequest();
 
     // Give Helix some time to handle the message

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/suite/IntegrationBasicSuite.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/suite/IntegrationBasicSuite.java
@@ -76,6 +76,8 @@ public class IntegrationBasicSuite {
   public static final String WORKER_INSTANCE_0 = "WorkerInstance_0";
   public static final String TEST_INSTANCE_NAME_KEY = "worker.instance.name";
 
+  protected final Config jobConfigOverrides;
+
   // manager and workers
   protected Config managerConfig;
   protected Collection<Config> taskDriverConfigs = Lists.newArrayList();
@@ -93,6 +95,11 @@ public class IntegrationBasicSuite {
   protected TestingServer testingZKServer;
 
   public IntegrationBasicSuite() {
+    this(ConfigFactory.empty());
+  }
+
+  public IntegrationBasicSuite(Config jobConfigOverrides) {
+    this.jobConfigOverrides = jobConfigOverrides;
     try {
       initWorkDir();
       initJobOutputDir();
@@ -163,7 +170,7 @@ public class IntegrationBasicSuite {
   }
 
   protected Map<String, Config> overrideJobConfigs(Config rawJobConfig) {
-    return ImmutableMap.of(JOB_NAME, rawJobConfig);
+    return ImmutableMap.of(JOB_NAME, this.jobConfigOverrides.withFallback(rawJobConfig));
   }
 
   private void writeJobConf(String jobName, Config jobConfig) throws IOException {

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/suite/IntegrationJobCancelSuite.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/suite/IntegrationJobCancelSuite.java
@@ -17,32 +17,17 @@
 
 package org.apache.gobblin.cluster.suite;
 
-import java.util.Map;
-
 import org.junit.Assert;
 
-import com.google.common.collect.ImmutableMap;
 import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
-
-import org.apache.gobblin.cluster.GobblinClusterConfigurationKeys;
-import org.apache.gobblin.cluster.SleepingTask;
-import org.apache.gobblin.configuration.ConfigurationKeys;
 
 
 public class IntegrationJobCancelSuite extends IntegrationBasicSuite {
   public static final String JOB_ID = "job_HelloWorldTestJob_1234";
   public static final String TASK_STATE_FILE = "/tmp/IntegrationJobCancelSuite/taskState/_RUNNING";
 
-  @Override
-  protected Map<String, Config> overrideJobConfigs(Config rawJobConfig) {
-    Config newConfig = ConfigFactory.parseMap(ImmutableMap.of(
-        ConfigurationKeys.SOURCE_CLASS_KEY, "org.apache.gobblin.cluster.SleepingCustomTaskSource",
-        ConfigurationKeys.JOB_ID_KEY, JOB_ID,
-        GobblinClusterConfigurationKeys.HELIX_JOB_TIMEOUT_ENABLED_KEY, Boolean.TRUE,
-        GobblinClusterConfigurationKeys.HELIX_JOB_TIMEOUT_SECONDS, 10L, SleepingTask.TASK_STATE_FILE_KEY, TASK_STATE_FILE))
-        .withFallback(rawJobConfig);
-    return ImmutableMap.of(JOB_NAME, newConfig);
+  public IntegrationJobCancelSuite(Config jobConfigOverrides) {
+    super(jobConfigOverrides);
   }
 
   @Override


### PR DESCRIPTION
…nTaskRunner

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1107


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Current behavior eagerly initializes the taskStateModelFactory inside the constructor. This causes Helix task assignment to be stuck when a Helix manager connection needs to be retried.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Existing unit tests.

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

