### PR TITLE
[GOBBLIN-1119] Enable close-on-flush for quality-checker's err-file

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/qualitychecker/row/RowLevelPolicyChecker.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/qualitychecker/row/RowLevelPolicyChecker.java
@@ -90,7 +90,6 @@ public class RowLevelPolicyChecker<S, D> implements Closeable, FinalState, Recor
     this.stateId = stateId;
     this.fs = fs;
     this.errFileOpen = false;
-    this.writer = new RowLevelErrFileWriter(this.fs);
     this.results = new RowLevelPolicyCheckResults();
     this.sampler = new FrontLoadedSampler(state.getPropAsLong(ConfigurationKeys.ROW_LEVEL_ERR_FILE_RECORDS_PER_TASK,
         ConfigurationKeys.DEFAULT_ROW_LEVEL_ERR_FILE_RECORDS_PER_TASK), 1.5);
@@ -121,6 +120,7 @@ public class RowLevelPolicyChecker<S, D> implements Closeable, FinalState, Recor
       } else if (p.getType().equals(RowLevelPolicy.Type.ERR_FILE)) {
         if (this.sampler.acceptNext()) {
           if (!this.errFileOpen) {
+            this.writer = new RowLevelErrFileWriter(this.fs);
             this.writer.open(getErrFilePath(p));
             this.writer.write(record);
           } else {
@@ -208,7 +208,6 @@ public class RowLevelPolicyChecker<S, D> implements Closeable, FinalState, Recor
         if (message instanceof FlushControlMessage ) {
           try {
             RowLevelPolicyChecker.this.close();
-            RowLevelPolicyChecker.this.writer = new RowLevelErrFileWriter(RowLevelPolicyChecker.this.fs);
           } catch (IOException ioe) {
             log.error("Failed to close errFile", ioe);
           }

--- a/gobblin-core/src/test/java/org/apache/gobblin/qualitychecker/TestRowLevelPolicyFail.java
+++ b/gobblin-core/src/test/java/org/apache/gobblin/qualitychecker/TestRowLevelPolicyFail.java
@@ -28,6 +28,6 @@ public class TestRowLevelPolicyFail extends RowLevelPolicy {
 
   @Override
   public Result executePolicy(Object record) {
-    return RowLevelPolicy.Result.PASSED;
+    return RowLevelPolicy.Result.FAILED;
   }
 }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- https://issues.apache.org/jira/browse/GOBBLIN-1119


### Description
- Currently if using `RowLevelPolicyChecker.java` in long-running Gobblin-on-Yarn pipeline, the err-file will be opened when the task is initialized but not being flushed periodically. This fix is to enable close-on-flush semantics for err-file and add unit test for that. 


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

