### PR TITLE
GOBBLIN-1120: Reinitialize HelixManager when Helix participant check …

### DIFF
--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/HelixAssignedParticipantCheckTest.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/HelixAssignedParticipantCheckTest.java
@@ -84,6 +84,14 @@ public class HelixAssignedParticipantCheckTest {
     // (i.e. no exceptions thrown).
     check.execute();
 
+    //Disconnect the helixmanager used to check the assigned participant to force an Exception on the first attempt.
+    //The test should succeed on the following attempt.
+    HelixManager helixManagerOriginal = HelixAssignedParticipantCheck.getHelixManager();
+    helixManagerOriginal.disconnect();
+    check.execute();
+    //Ensure that a new HelixManager instance is created.
+    Assert.assertTrue(HelixAssignedParticipantCheck.getHelixManager() != helixManagerOriginal);
+
     //Create Helix config with invalid partition num. Ensure HelixAssignedParticipantCheck fails.
     helixConfig = helixConfig.withValue(GobblinClusterConfigurationKeys.HELIX_PARTITION_ID_KEY, ConfigValueFactory.fromAnyRef(1));
     check = new HelixAssignedParticipantCheck(helixConfig);


### PR DESCRIPTION
…throws an exception

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1120


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
When the underlying ZkClient is closed, Helix participant check throws:

Caused by: java.lang.IllegalStateException: ZkClient already closed!

In these cases, the HelixManager instance used to do the participant check needs to be re-initialized to obtain a new ZKClient. 



### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Enhanced the unit tests in HelixAssignedParticipantCheckTest.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

