### PR TITLE
[GOBBLIN-1124] Add throwable details when AsyncHttpConverter hits a failure.

### DIFF
--- a/gobblin-modules/gobblin-http/src/main/java/org/apache/gobblin/converter/AsyncHttpJoinConverter.java
+++ b/gobblin-modules/gobblin-http/src/main/java/org/apache/gobblin/converter/AsyncHttpJoinConverter.java
@@ -30,6 +30,7 @@ import com.typesafe.config.ConfigFactory;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.gobblin.async.AsyncRequest;
 import org.apache.gobblin.async.AsyncRequestBuilder;
 import org.apache.gobblin.async.BufferedRecord;
@@ -140,7 +141,8 @@ public abstract class AsyncHttpJoinConverter<SI, SO, DI, DO, RQ, RP> extends Asy
             justification = "CompletableFuture will replace null value with NIL")
         @Override
         public void onFailure(Throwable throwable) {
-          log.error ("Http converter on failure with request {}", request.getRawRequest());
+          String errorMsg = ExceptionUtils.getMessage(throwable);
+          log.error ("Http converter on failure with request {} and throwable {}", request.getRawRequest(), errorMsg);
 
           if (skipFailedRecord) {
             AsyncHttpJoinConverterContext.this.future.complete( null);


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1124


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
   Added detailed exception message in AsyncHttpJoinConverterContext's onFailure callback.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

