### PR TITLE
[GOBBLIN-1126] Make ORC compaction shuffle key configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@
 **/*.ipr
 .shelf/
 
+# VS Code related 
+.vscode
+
 **/.classpath
 **/.project
 **/.settings

--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/CompactionOrcJobConfigurator.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/CompactionOrcJobConfigurator.java
@@ -64,7 +64,7 @@ public class CompactionOrcJobConfigurator extends CompactionJobConfigurator {
 
     job.getConfiguration().set(OrcConf.MAPRED_INPUT_SCHEMA.getAttribute(), schema.toString());
     job.getConfiguration().set(OrcConf.MAPRED_SHUFFLE_KEY_SCHEMA.getAttribute(),
-        orcMapperShuffleSchemaString.isEmpty() ? orcMapperShuffleSchemaString : schema.toString());
+        orcMapperShuffleSchemaString.isEmpty() ? schema.toString() : orcMapperShuffleSchemaString);
     job.getConfiguration().set(OrcConf.MAPRED_SHUFFLE_VALUE_SCHEMA.getAttribute(), schema.toString());
     job.getConfiguration().set(OrcConf.MAPRED_OUTPUT_SCHEMA.getAttribute(), schema.toString());
   }

--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/CompactionOrcJobConfigurator.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/CompactionOrcJobConfigurator.java
@@ -39,7 +39,10 @@ import static org.apache.gobblin.compaction.mapreduce.CompactorOutputCommitter.*
 
 public class CompactionOrcJobConfigurator extends CompactionJobConfigurator {
 
-  public static final String ORC_MAPPER_SHUFFLE_SCHEMA_KEY = "orcMapperShuffleSchema";
+  /**
+   * The key schema for the shuffle output. 
+   */
+  public static final String ORC_MAPPER_SHUFFLE_KEY_SCHEMA = "orcMapperShuffleSchema";
   private String orcMapperShuffleSchemaString;
 
   public static class Factory implements CompactionJobConfigurator.ConfiguratorFactory {
@@ -51,7 +54,7 @@ public class CompactionOrcJobConfigurator extends CompactionJobConfigurator {
 
   public CompactionOrcJobConfigurator(State state) throws IOException {
     super(state);
-    this.orcMapperShuffleSchemaString = state.getProp(ORC_MAPPER_SHUFFLE_SCHEMA_KEY, StringUtils.EMPTY);
+    this.orcMapperShuffleSchemaString = state.getProp(ORC_MAPPER_SHUFFLE_KEY_SCHEMA, StringUtils.EMPTY);
   }
 
   @Override

--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/CompactionOrcJobConfigurator.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/CompactionOrcJobConfigurator.java
@@ -18,6 +18,8 @@
 package org.apache.gobblin.compaction.mapreduce;
 
 import java.io.IOException;
+
+import org.apache.commons.lang3.StringUtils;
 import org.apache.gobblin.compaction.mapreduce.orc.OrcKeyCompactorOutputFormat;
 import org.apache.gobblin.compaction.mapreduce.orc.OrcKeyComparator;
 import org.apache.gobblin.compaction.mapreduce.orc.OrcKeyDedupReducer;
@@ -36,6 +38,10 @@ import static org.apache.gobblin.compaction.mapreduce.CompactorOutputCommitter.*
 
 
 public class CompactionOrcJobConfigurator extends CompactionJobConfigurator {
+
+  public static final String ORC_MAPPER_SHUFFLE_SCHEMA_KEY = "orcMapperShuffleSchema";
+  private String orcMapperShuffleSchemaString;
+
   public static class Factory implements CompactionJobConfigurator.ConfiguratorFactory {
     @Override
     public CompactionJobConfigurator createConfigurator(State state) throws IOException {
@@ -45,6 +51,7 @@ public class CompactionOrcJobConfigurator extends CompactionJobConfigurator {
 
   public CompactionOrcJobConfigurator(State state) throws IOException {
     super(state);
+    this.orcMapperShuffleSchemaString = state.getProp(ORC_MAPPER_SHUFFLE_SCHEMA_KEY, StringUtils.EMPTY);
   }
 
   @Override
@@ -56,7 +63,8 @@ public class CompactionOrcJobConfigurator extends CompactionJobConfigurator {
     TypeDescription schema = OrcUtils.getNewestSchemaFromSource(job, this.fs);
 
     job.getConfiguration().set(OrcConf.MAPRED_INPUT_SCHEMA.getAttribute(), schema.toString());
-    job.getConfiguration().set(OrcConf.MAPRED_SHUFFLE_KEY_SCHEMA.getAttribute(), schema.toString());
+    job.getConfiguration().set(OrcConf.MAPRED_SHUFFLE_KEY_SCHEMA.getAttribute(),
+        orcMapperShuffleSchemaString.isEmpty() ? orcMapperShuffleSchemaString : schema.toString());
     job.getConfiguration().set(OrcConf.MAPRED_SHUFFLE_VALUE_SCHEMA.getAttribute(), schema.toString());
     job.getConfiguration().set(OrcConf.MAPRED_OUTPUT_SCHEMA.getAttribute(), schema.toString());
   }

--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/RecordKeyDedupReducerBase.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/RecordKeyDedupReducerBase.java
@@ -88,7 +88,7 @@ public abstract class RecordKeyDedupReducerBase<KI, VI, KO, VO> extends Reducer<
     }
 
     writeRetainValue(valueToRetain, context);
-    updateCounter(numVals, context);
+    updateCounters(numVals, context);
   }
 
   protected void writeRetainValue(VI valueToRetain, Context context)
@@ -108,7 +108,7 @@ public abstract class RecordKeyDedupReducerBase<KI, VI, KO, VO> extends Reducer<
    * Update the MR counter based on input {@param numDuplicates}, which indicates the times of duplication of a
    * record seen in a reducer call.
    */
-  protected void updateCounter(int numDuplicates, Context context) {
+  protected void updateCounters(int numDuplicates, Context context) {
     if (numDuplicates > 1) {
       context.getCounter(EVENT_COUNTER.MORE_THAN_1).increment(1);
       context.getCounter(EVENT_COUNTER.DEDUPED).increment(numDuplicates - 1);

--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/RecordKeyDedupReducerBase.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/RecordKeyDedupReducerBase.java
@@ -87,11 +87,11 @@ public abstract class RecordKeyDedupReducerBase<KI, VI, KO, VO> extends Reducer<
       numVals++;
     }
 
-    writeRetainValue(valueToRetain, context);
+    writeRetainedValue(valueToRetain, context);
     updateCounters(numVals, context);
   }
 
-  protected void writeRetainValue(VI valueToRetain, Context context)
+  protected void writeRetainedValue(VI valueToRetain, Context context)
       throws IOException, InterruptedException {
     setOutKey(valueToRetain);
     setOutValue(valueToRetain);

--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/orc/OrcKeyDedupReducer.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/orc/OrcKeyDedupReducer.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.commons.math3.util.Pair;
 import org.apache.gobblin.compaction.mapreduce.RecordKeyDedupReducerBase;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.NullWritable;
@@ -73,7 +72,7 @@ public class OrcKeyDedupReducer extends RecordKeyDedupReducerBase<OrcKey, OrcVal
 
     /* At this point, keyset of valuesToRetain should contains all different OrcValue. */
     for (Map.Entry<Integer, Integer> entry : valuesToRetain.entrySet()) {
-      updateCounter(entry.getValue(), context);
+      updateCounters(entry.getValue(), context);
     }
   }
 

--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/orc/OrcKeyDedupReducer.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/orc/OrcKeyDedupReducer.java
@@ -17,15 +17,24 @@
 
 package org.apache.gobblin.compaction.mapreduce.orc;
 
+import java.util.Comparator;
+
 import com.google.common.base.Optional;
+
 import org.apache.gobblin.compaction.mapreduce.RecordKeyDedupReducerBase;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.NullWritable;
+import org.apache.orc.TypeDescription;
 import org.apache.orc.mapred.OrcKey;
+import org.apache.orc.mapred.OrcStruct;
 import org.apache.orc.mapred.OrcValue;
 
 
 public class OrcKeyDedupReducer extends RecordKeyDedupReducerBase<OrcKey, OrcValue, NullWritable, OrcValue> {
+  private static final String ORC_DELTA_SCHEMA_PROVIDER =
+      "org.apache.gobblin.compaction." + OrcKeyDedupReducer.class.getSimpleName() + ".deltaFieldsProvider";
+  private static final String USING_WHOLE_RECORD_FOR_COMPARE = "usingWholeRecordForCompareInReducer";
+
   @Override
   protected void setOutValue(OrcValue valueToRetain) {
     // Better to copy instead reassigning reference.
@@ -40,11 +49,43 @@ public class OrcKeyDedupReducer extends RecordKeyDedupReducerBase<OrcKey, OrcVal
   @Override
   protected void initDeltaComparator(Configuration conf) {
     deltaComparatorOptional = Optional.absent();
+    String compareSchemaString = conf.get(ORC_DELTA_SCHEMA_PROVIDER);
+    boolean compareWholeRecord = conf.getBoolean(USING_WHOLE_RECORD_FOR_COMPARE, true);
+    if (compareSchemaString != null) {
+      deltaComparatorOptional =
+          Optional.of(new OrcStructComparator(TypeDescription.fromString(compareSchemaString), compareWholeRecord));
+    }
   }
 
   @Override
   protected void initReusableObject() {
     outKey = NullWritable.get();
     outValue = new OrcValue();
+  }
+
+  protected static class OrcStructComparator implements Comparator<OrcValue> {
+    private final TypeDescription compareSchema;
+    private final boolean compareWholeRecord;
+    private OrcStruct projectedStruct1;
+    private OrcStruct projectedStruct2;
+
+    public OrcStructComparator(TypeDescription compareSchema, boolean compareWholeRecord) {
+      this.compareSchema = compareSchema;
+      this.compareWholeRecord = compareWholeRecord;
+      projectedStruct1 = (OrcStruct) OrcUtils.createValueRecursively(compareSchema);
+      projectedStruct2 = (OrcStruct) OrcUtils.createValueRecursively(compareSchema);
+    }
+
+    @Override
+    public int compare(OrcValue o1, OrcValue o2) {
+      // Avoid unnecessary copy of value by calling upConvertOrcStruct
+      if (compareWholeRecord) {
+        return ((OrcStruct) o1.value).compareTo((OrcStruct) o2.value);
+      } else {
+        OrcUtils.upConvertOrcStruct((OrcStruct) o1.value, projectedStruct1, compareSchema);
+        OrcUtils.upConvertOrcStruct((OrcStruct) o2.value, projectedStruct2, compareSchema);
+        return projectedStruct1.compareTo(projectedStruct2);
+      }
+    }
   }
 }

--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/orc/OrcKeyDedupReducer.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/orc/OrcKeyDedupReducer.java
@@ -66,7 +66,7 @@ public class OrcKeyDedupReducer extends RecordKeyDedupReducerBase<OrcKey, OrcVal
         valuesToRetain.put(valueHash, valuesToRetain.get(valueHash) + 1);
       } else {
         valuesToRetain.put(valueHash, 1);
-        writeRetainValue(value, context);
+        writeRetainedValue(value, context);
       }
     }
 

--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/orc/OrcUtils.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/orc/OrcUtils.java
@@ -370,7 +370,6 @@ public class OrcUtils {
 
     // If target schema is not equal to newStruct's schema, it is a illegal state and doesn't make sense to work through.
     Preconditions.checkArgument(newStruct.getSchema().equals(targetSchema));
-    log.info("There's schema mismatch identified from reader's schema and writer's schema");
 
     int indexInNewSchema = 0;
     List<String> oldSchemaFieldNames = oldStruct.getSchema().getFieldNames();

--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/orc/OrcUtils.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/orc/OrcUtils.java
@@ -356,7 +356,8 @@ public class OrcUtils {
    * This serves similar purpose like GenericDatumReader for Avro, which accepts an reader schema and writer schema
    * to allow users convert bytes into reader's schema in a compatible approach.
    * Calling this method SHALL NOT cause any side-effect for {@param oldStruct}, also it will copy value of each fields
-   * in {@param oldStruct} into {@param newStruct} recursively. Please ensure avoiding unnecessary call.
+   * in {@param oldStruct} into {@param newStruct} recursively. Please ensure avoiding unnecessary call as it could
+   * be pretty expensive if the struct schema is complicated, or contains container objects like array/map.
    *
    * Note that if newStruct containing things like List/Map (container-type), the up-conversion is doing two things:
    * 1. Clear all elements in original containers.

--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/orc/OrcValueMapper.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/orc/OrcValueMapper.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import org.apache.gobblin.compaction.mapreduce.RecordKeyMapperBase;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.io.WritableComparable;
+import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.orc.OrcConf;
 import org.apache.orc.TypeDescription;
@@ -37,6 +38,7 @@ import org.apache.orc.mapred.OrcValue;
 import org.apache.orc.mapreduce.OrcMapreduceRecordReader;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -49,8 +51,11 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class OrcValueMapper extends RecordKeyMapperBase<NullWritable, OrcStruct, Object, OrcValue> {
 
+  // This key will only be initialized lazily when dedup is enabled.
+  private OrcKey outKey;
   private OrcValue outValue;
-  private TypeDescription mapperSchema;
+  private TypeDescription mrOutputSchema;
+  private JobConf jobConf;
 
   // This is added mostly for debuggability.
   private static int writeCount = 0;
@@ -59,21 +64,23 @@ public class OrcValueMapper extends RecordKeyMapperBase<NullWritable, OrcStruct,
   protected void setup(Context context)
       throws IOException, InterruptedException {
     super.setup(context);
+    this.jobConf = new JobConf(context.getConfiguration());
+    this.outKey.configure(jobConf);
     this.outValue = new OrcValue();
-    this.mapperSchema =
+    this.mrOutputSchema =
         TypeDescription.fromString(context.getConfiguration().get(OrcConf.MAPRED_INPUT_SCHEMA.getAttribute()));
   }
 
   @Override
   protected void map(NullWritable key, OrcStruct orcStruct, Context context)
       throws IOException, InterruptedException {
-    OrcStruct upConvertedStruct = upConvertOrcStruct(orcStruct, mapperSchema);
-    this.outValue.value = upConvertedStruct;
+    upConvertOrcStruct(orcStruct, (OrcStruct) outValue.value, mrOutputSchema);
     try {
       if (context.getNumReduceTasks() == 0) {
         context.write(NullWritable.get(), this.outValue);
       } else {
-        context.write(getDedupKey(upConvertedStruct), this.outValue);
+//        fillDedupKey(upConvertedOrcStruct);
+        context.write(this.outKey, this.outValue);
       }
     } catch (Exception e) {
       throw new RuntimeException("Failure in write record no." + writeCount, e);
@@ -84,50 +91,51 @@ public class OrcValueMapper extends RecordKeyMapperBase<NullWritable, OrcStruct,
   }
 
   /**
-   * Recursively up-convert the {@link OrcStruct} into {@link #mapperSchema}
+   * Recursively up-convert the {@link OrcStruct} into newStruct's schema which is {@link #mrOutputSchema}.
    * Limitation:
    * 1. Does not support up-conversion of key types in Maps
    * 2. Conversion only happens if org.apache.gobblin.compaction.mapreduce.orc.OrcValueMapper#isEvolutionValid return true.
    */
   @VisibleForTesting
-  OrcStruct upConvertOrcStruct(OrcStruct orcStruct, TypeDescription mapperSchema) {
+  void upConvertOrcStruct(OrcStruct oldStruct, OrcStruct newStruct, TypeDescription targetSchema) {
+
+    // If target schema is not equal to newStruct's schema, it is a illegal state and doesn't make sense to work through.
+    Preconditions.checkArgument(newStruct.getSchema().equals(targetSchema));
+
     // For ORC schema, if schema object differs that means schema itself is different while for Avro,
     // there are chances that documentation or attributes' difference lead to the schema object difference.
-    if (!orcStruct.getSchema().equals(mapperSchema)) {
+    if (!oldStruct.getSchema().equals(targetSchema)) {
       log.info("There's schema mismatch identified from reader's schema and writer's schema");
-      OrcStruct newStruct = new OrcStruct(mapperSchema);
 
       int indexInNewSchema = 0;
-      List<String> oldSchemaFieldNames = orcStruct.getSchema().getFieldNames();
-      List<TypeDescription> oldSchemaTypes = orcStruct.getSchema().getChildren();
-      List<TypeDescription> newSchemaTypes = mapperSchema.getChildren();
+      List<String> oldSchemaFieldNames = oldStruct.getSchema().getFieldNames();
+      List<TypeDescription> oldSchemaTypes = oldStruct.getSchema().getChildren();
+      List<TypeDescription> newSchemaTypes = targetSchema.getChildren();
 
-      for (String field : mapperSchema.getFieldNames()) {
-        if (oldSchemaFieldNames.contains(field)) {
-          int fieldIndex = oldSchemaFieldNames.indexOf(field);
+      for (String fieldName : targetSchema.getFieldNames()) {
+        if (oldSchemaFieldNames.contains(fieldName)) {
+          int fieldIndex = oldSchemaFieldNames.indexOf(fieldName);
 
           TypeDescription fileType = oldSchemaTypes.get(fieldIndex);
           TypeDescription readerType = newSchemaTypes.get(indexInNewSchema);
 
           if (OrcUtils.isEvolutionValid(fileType, readerType)) {
-            WritableComparable oldField = orcStruct.getFieldValue(field);
-            oldField = structConversionHelper(oldField, mapperSchema.getChildren().get(fieldIndex));
-            newStruct.setFieldValue(field, oldField);
+            WritableComparable oldField = oldStruct.getFieldValue(fieldName);
+            WritableComparable newField = newStruct.getFieldValue(fieldName);
+            structConversionHelper(oldField, newField, targetSchema.getChildren().get(fieldIndex));
+            newStruct.setFieldValue(fieldName, oldField);
           } else {
             throw new SchemaEvolution.IllegalEvolutionException(String
                 .format("ORC does not support type conversion from file" + " type %s to reader type %s ",
                     fileType.toString(), readerType.toString()));
           }
         } else {
-          newStruct.setFieldValue(field, null);
+          newStruct.setFieldValue(fieldName, null);
         }
 
         indexInNewSchema++;
       }
 
-      return newStruct;
-    } else {
-      return orcStruct;
     }
   }
 
@@ -136,50 +144,40 @@ public class OrcValueMapper extends RecordKeyMapperBase<NullWritable, OrcStruct,
    * Check failure will trigger Cast exception and blow up the process.
    */
   @SuppressWarnings("unchecked")
-  private WritableComparable structConversionHelper(WritableComparable w, TypeDescription mapperSchema) {
+  private void structConversionHelper(WritableComparable w, WritableComparable v, TypeDescription mapperSchema) {
     if (w instanceof OrcStruct) {
-      return upConvertOrcStruct((OrcStruct) w, mapperSchema);
+      upConvertOrcStruct((OrcStruct) w, (OrcStruct) v, mapperSchema);
     } else if (w instanceof OrcList) {
       OrcList castedList = (OrcList) w;
+      OrcList targetList = (OrcList) v;
       TypeDescription elementType = mapperSchema.getChildren().get(0);
       for (int i = 0; i < castedList.size(); i++) {
-        castedList.set(i, structConversionHelper((WritableComparable) castedList.get(i), elementType));
+        structConversionHelper((WritableComparable) castedList.get(i), (WritableComparable) targetList.get(i), elementType);
       }
     } else if (w instanceof OrcMap) {
       OrcMap castedMap = (OrcMap) w;
+      OrcMap targetMap = (OrcMap) v;
       for (Object entry : castedMap.entrySet()) {
         Map.Entry<WritableComparable, WritableComparable> castedEntry =
             (Map.Entry<WritableComparable, WritableComparable>) entry;
-        castedMap.put(castedEntry.getKey(),
-            structConversionHelper(castedEntry.getValue(), mapperSchema.getChildren().get(1)));
+        structConversionHelper(castedEntry.getValue(),(WritableComparable) targetMap.get(((Map.Entry<WritableComparable, WritableComparable>) entry).getKey()) , mapperSchema.getChildren().get(1));
       }
-      return castedMap;
     } else if (w instanceof OrcUnion) {
       OrcUnion castedUnion = (OrcUnion) w;
+      OrcUnion targetUnion = (OrcUnion) v;
       byte tag = castedUnion.getTag();
-      castedUnion.set(tag,
-          structConversionHelper((WritableComparable) castedUnion.getObject(), mapperSchema.getChildren().get(tag)));
+      structConversionHelper((WritableComparable) castedUnion.getObject(),
+          (WritableComparable) targetUnion.getObject(), mapperSchema.getChildren().get(tag));
     }
 
-    // Directly return if primitive object.
-    return w;
+    // Do nothing if primitive object.
   }
 
   /**
    * By default, dedup key contains the whole ORC record, except MAP since {@link org.apache.orc.mapred.OrcMap} is
    * an implementation of {@link java.util.TreeMap} which doesn't accept difference of records within the map in comparison.
    */
-  protected OrcKey getDedupKey(OrcStruct originalRecord) {
-    return convertOrcStructToOrcKey(originalRecord);
-  }
-
-  /**
-   * The output key of mapper needs to be comparable. In the scenarios that we need the orc record itself
-   * to be the output key, this conversion will be necessary.
-   */
-  protected OrcKey convertOrcStructToOrcKey(OrcStruct struct) {
-    OrcKey orcKey = new OrcKey();
-    orcKey.key = struct;
-    return orcKey;
+  protected void fillDedupKey(OrcStruct originalRecord) {
+    // TODO: Should leverage upconvert method.
   }
 }

--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/orc/OrcValueMapper.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/orc/OrcValueMapper.java
@@ -18,27 +18,17 @@
 package org.apache.gobblin.compaction.mapreduce.orc;
 
 import java.io.IOException;
-import java.util.List;
-import java.util.Map;
 
 import org.apache.gobblin.compaction.mapreduce.RecordKeyMapperBase;
 import org.apache.hadoop.io.NullWritable;
-import org.apache.hadoop.io.WritableComparable;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.orc.OrcConf;
 import org.apache.orc.TypeDescription;
-import org.apache.orc.impl.SchemaEvolution;
 import org.apache.orc.mapred.OrcKey;
-import org.apache.orc.mapred.OrcList;
-import org.apache.orc.mapred.OrcMap;
 import org.apache.orc.mapred.OrcStruct;
-import org.apache.orc.mapred.OrcUnion;
 import org.apache.orc.mapred.OrcValue;
 import org.apache.orc.mapreduce.OrcMapreduceRecordReader;
-
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -55,6 +45,7 @@ public class OrcValueMapper extends RecordKeyMapperBase<NullWritable, OrcStruct,
   private OrcKey outKey;
   private OrcValue outValue;
   private TypeDescription mrOutputSchema;
+  private TypeDescription shuffleKeySchema;
   private JobConf jobConf;
 
   // This is added mostly for debuggability.
@@ -69,21 +60,25 @@ public class OrcValueMapper extends RecordKeyMapperBase<NullWritable, OrcStruct,
     this.outValue = new OrcValue();
     this.mrOutputSchema =
         TypeDescription.fromString(context.getConfiguration().get(OrcConf.MAPRED_INPUT_SCHEMA.getAttribute()));
+    this.shuffleKeySchema =
+        TypeDescription.fromString(context.getConfiguration().get(OrcConf.MAPRED_SHUFFLE_KEY_SCHEMA.getAttribute()));
   }
 
   @Override
   protected void map(NullWritable key, OrcStruct orcStruct, Context context)
       throws IOException, InterruptedException {
-    upConvertOrcStruct(orcStruct, (OrcStruct) outValue.value, mrOutputSchema);
+
+    // Note that outValue.value is being re-used.
+    OrcUtils.upConvertOrcStruct(orcStruct, (OrcStruct) outValue.value, mrOutputSchema);
     try {
       if (context.getNumReduceTasks() == 0) {
         context.write(NullWritable.get(), this.outValue);
       } else {
-//        fillDedupKey(upConvertedOrcStruct);
+        fillDedupKey((OrcStruct) outKey.key);
         context.write(this.outKey, this.outValue);
       }
-    } catch (Exception e) {
-      throw new RuntimeException("Failure in write record no." + writeCount, e);
+    } catch (IOException e) {
+      throw new IOException("Failure in write record no." + writeCount, e);
     }
     writeCount += 1;
 
@@ -91,93 +86,10 @@ public class OrcValueMapper extends RecordKeyMapperBase<NullWritable, OrcStruct,
   }
 
   /**
-   * Recursively up-convert the {@link OrcStruct} into newStruct's schema which is {@link #mrOutputSchema}.
-   * Limitation:
-   * 1. Does not support up-conversion of key types in Maps
-   * 2. Conversion only happens if org.apache.gobblin.compaction.mapreduce.orc.OrcValueMapper#isEvolutionValid return true.
-   */
-  @VisibleForTesting
-  void upConvertOrcStruct(OrcStruct oldStruct, OrcStruct newStruct, TypeDescription targetSchema) {
-
-    // If target schema is not equal to newStruct's schema, it is a illegal state and doesn't make sense to work through.
-    Preconditions.checkArgument(newStruct.getSchema().equals(targetSchema));
-
-    // For ORC schema, if schema object differs that means schema itself is different while for Avro,
-    // there are chances that documentation or attributes' difference lead to the schema object difference.
-    if (!oldStruct.getSchema().equals(targetSchema)) {
-      log.info("There's schema mismatch identified from reader's schema and writer's schema");
-
-      int indexInNewSchema = 0;
-      List<String> oldSchemaFieldNames = oldStruct.getSchema().getFieldNames();
-      List<TypeDescription> oldSchemaTypes = oldStruct.getSchema().getChildren();
-      List<TypeDescription> newSchemaTypes = targetSchema.getChildren();
-
-      for (String fieldName : targetSchema.getFieldNames()) {
-        if (oldSchemaFieldNames.contains(fieldName)) {
-          int fieldIndex = oldSchemaFieldNames.indexOf(fieldName);
-
-          TypeDescription fileType = oldSchemaTypes.get(fieldIndex);
-          TypeDescription readerType = newSchemaTypes.get(indexInNewSchema);
-
-          if (OrcUtils.isEvolutionValid(fileType, readerType)) {
-            WritableComparable oldField = oldStruct.getFieldValue(fieldName);
-            WritableComparable newField = newStruct.getFieldValue(fieldName);
-            structConversionHelper(oldField, newField, targetSchema.getChildren().get(fieldIndex));
-            newStruct.setFieldValue(fieldName, oldField);
-          } else {
-            throw new SchemaEvolution.IllegalEvolutionException(String
-                .format("ORC does not support type conversion from file" + " type %s to reader type %s ",
-                    fileType.toString(), readerType.toString()));
-          }
-        } else {
-          newStruct.setFieldValue(fieldName, null);
-        }
-
-        indexInNewSchema++;
-      }
-
-    }
-  }
-
-  /**
-   * Suppress the warning of type checking: All casts are clearly valid as they are all (sub)elements Orc types.
-   * Check failure will trigger Cast exception and blow up the process.
-   */
-  @SuppressWarnings("unchecked")
-  private void structConversionHelper(WritableComparable w, WritableComparable v, TypeDescription mapperSchema) {
-    if (w instanceof OrcStruct) {
-      upConvertOrcStruct((OrcStruct) w, (OrcStruct) v, mapperSchema);
-    } else if (w instanceof OrcList) {
-      OrcList castedList = (OrcList) w;
-      OrcList targetList = (OrcList) v;
-      TypeDescription elementType = mapperSchema.getChildren().get(0);
-      for (int i = 0; i < castedList.size(); i++) {
-        structConversionHelper((WritableComparable) castedList.get(i), (WritableComparable) targetList.get(i), elementType);
-      }
-    } else if (w instanceof OrcMap) {
-      OrcMap castedMap = (OrcMap) w;
-      OrcMap targetMap = (OrcMap) v;
-      for (Object entry : castedMap.entrySet()) {
-        Map.Entry<WritableComparable, WritableComparable> castedEntry =
-            (Map.Entry<WritableComparable, WritableComparable>) entry;
-        structConversionHelper(castedEntry.getValue(),(WritableComparable) targetMap.get(((Map.Entry<WritableComparable, WritableComparable>) entry).getKey()) , mapperSchema.getChildren().get(1));
-      }
-    } else if (w instanceof OrcUnion) {
-      OrcUnion castedUnion = (OrcUnion) w;
-      OrcUnion targetUnion = (OrcUnion) v;
-      byte tag = castedUnion.getTag();
-      structConversionHelper((WritableComparable) castedUnion.getObject(),
-          (WritableComparable) targetUnion.getObject(), mapperSchema.getChildren().get(tag));
-    }
-
-    // Do nothing if primitive object.
-  }
-
-  /**
    * By default, dedup key contains the whole ORC record, except MAP since {@link org.apache.orc.mapred.OrcMap} is
    * an implementation of {@link java.util.TreeMap} which doesn't accept difference of records within the map in comparison.
    */
   protected void fillDedupKey(OrcStruct originalRecord) {
-    // TODO: Should leverage upconvert method.
+    OrcUtils.upConvertOrcStruct(originalRecord, (OrcStruct) this.outKey.key, this.shuffleKeySchema);
   }
 }

--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/orc/OrcValueMapper.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/orc/OrcValueMapper.java
@@ -99,7 +99,7 @@ public class OrcValueMapper extends RecordKeyMapperBase<NullWritable, OrcStruct,
    * an implementation of {@link java.util.TreeMap} which doesn't accept difference of records within the map in comparison.
    * Note: This method should have no side-effect on input record.
    */
-  protected void fillDedupKey(OrcStruct originalRecord) {
+  private void fillDedupKey(OrcStruct originalRecord) {
     if (!originalRecord.getSchema().equals(this.shuffleKeySchema)) {
       OrcUtils.upConvertOrcStruct(originalRecord, (OrcStruct) this.outKey.key, this.shuffleKeySchema);
     } else {

--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/orc/OrcValueMapper.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/orc/OrcValueMapper.java
@@ -92,9 +92,9 @@ public class OrcValueMapper extends RecordKeyMapperBase<NullWritable, OrcStruct,
         fillDedupKey(orcStruct);
         context.write(this.outKey, this.outValue);
       }
-    } catch (IOException e) {
+    } catch (Exception e) {
       String inputPathInString = getInputsplitHelper(context);
-      throw new IOException("Failure in write record no." + writeCount + " the processing split is:" + inputPathInString, e);
+      throw new RuntimeException("Failure in write record no." + writeCount + " the processing split is:" + inputPathInString, e);
     }
     writeCount += 1;
 

--- a/gobblin-compaction/src/test/java/org/apache/gobblin/compaction/mapreduce/AvroCompactionTaskTest.java
+++ b/gobblin-compaction/src/test/java/org/apache/gobblin/compaction/mapreduce/AvroCompactionTaskTest.java
@@ -56,6 +56,7 @@ import org.apache.gobblin.runtime.embedded.EmbeddedGobblin;
 
 
 @Slf4j
+@Test(groups = {"gobblin.compaction"})
 public class AvroCompactionTaskTest {
 
   protected FileSystem getFileSystem()

--- a/gobblin-compaction/src/test/java/org/apache/gobblin/compaction/mapreduce/KeyDedupReducerTest.java
+++ b/gobblin-compaction/src/test/java/org/apache/gobblin/compaction/mapreduce/KeyDedupReducerTest.java
@@ -47,6 +47,7 @@ import static org.mockito.Mockito.when;
  * Test class for {@link org.apache.gobblin.compaction.mapreduce.RecordKeyDedupReducerBase}.
  * Will have test separately in both avro and orc.
  */
+@Test(groups = {"gobblin.compaction"})
 public class KeyDedupReducerTest {
   private static final String AVRO_KEY_SCHEMA =
       "{ \"type\" : \"record\",  \"name\" : \"etl\",\"namespace\" : \"reducerTest\",  \"fields\" : [ { \"name\" : "

--- a/gobblin-compaction/src/test/java/org/apache/gobblin/compaction/mapreduce/OrcCompactionTaskTest.java
+++ b/gobblin-compaction/src/test/java/org/apache/gobblin/compaction/mapreduce/OrcCompactionTaskTest.java
@@ -86,7 +86,7 @@ public class OrcCompactionTaskTest {
   }
 
   @Test
-  public void basicTestWithRecompaction() throws Exception {
+  public void basicTestWithRecompactionAndBasicSchemaEvolution() throws Exception {
     File basePath = Files.createTempDir();
     basePath.deleteOnExit();
 
@@ -98,7 +98,7 @@ public class OrcCompactionTaskTest {
     // Writing some basic ORC files
     createTestingData(jobDir);
 
-    // Writing an additional file with evolved schema.
+    // Writing an additional file with ** evolved schema **.
     TypeDescription evolvedSchema = TypeDescription.fromString("struct<i:int,j:int,k:int>");
     OrcStruct orcStruct_4 = (OrcStruct) OrcStruct.createValue(evolvedSchema);
     orcStruct_4.setFieldValue("i", new IntWritable(5));

--- a/gobblin-compaction/src/test/java/org/apache/gobblin/compaction/mapreduce/OrcCompactionTaskTest.java
+++ b/gobblin-compaction/src/test/java/org/apache/gobblin/compaction/mapreduce/OrcCompactionTaskTest.java
@@ -173,7 +173,7 @@ public class OrcCompactionTaskTest {
     File jobDir = new File(basePath, minutelyPath);
     Assert.assertTrue(jobDir.mkdirs());
 
-    TypeDescription nestedSchema = TypeDescription.fromString("struct<a:struct<a:int,b:string,c:int>,b:string>");
+    TypeDescription nestedSchema = TypeDescription.fromString("struct<a:struct<a:int,b:string,c:int>,b:string,c:uniontype<int,string>>");
     // Create three records with same value except "b" column in the top-level.
     OrcStruct nested_struct_1 = (OrcStruct) OrcUtils.createValueRecursively(nestedSchema);
     OrcTestUtils.fillOrcStructWithFixedValue(nested_struct_1, nestedSchema, 1, "test1", true);

--- a/gobblin-compaction/src/test/java/org/apache/gobblin/compaction/mapreduce/OrcCompactionTaskTest.java
+++ b/gobblin-compaction/src/test/java/org/apache/gobblin/compaction/mapreduce/OrcCompactionTaskTest.java
@@ -209,6 +209,9 @@ public class OrcCompactionTaskTest {
     List<OrcStruct> result = readOrcFile(statuses.get(0).getPath());
     // Should still contain original 3 records since they have different value in columns not included in shuffle key.
     Assert.assertEquals(result.size(), 3);
+    Assert.assertTrue(result.contains(nested_struct_1));
+    Assert.assertTrue(result.contains(nested_struct_2));
+    Assert.assertTrue(result.contains(nested_struct_3));
   }
 
   // A helper method to load all files in the output directory for compaction-result inspection.

--- a/gobblin-compaction/src/test/java/org/apache/gobblin/compaction/mapreduce/OrcCompactionTaskTest.java
+++ b/gobblin-compaction/src/test/java/org/apache/gobblin/compaction/mapreduce/OrcCompactionTaskTest.java
@@ -292,25 +292,13 @@ public class OrcCompactionTaskTest {
     OrcMapreduceRecordReader recordReader = new OrcMapreduceRecordReader(orcReader, options);
     List<OrcStruct> result = new ArrayList<>();
 
+    OrcStruct recordContainer;
     while (recordReader.nextKeyValue()) {
-      OrcStruct recordContainer = (OrcStruct) OrcUtils.createValueRecursively(orcReader.getSchema());
+      recordContainer = (OrcStruct) OrcUtils.createValueRecursively(orcReader.getSchema());
       OrcUtils.upConvertOrcStruct((OrcStruct) recordReader.getCurrentValue(), recordContainer, orcReader.getSchema());
       result.add(recordContainer);
     }
 
-    return result;
-  }
-
-  private OrcStruct copyIntOrcStruct(OrcStruct record) {
-    OrcStruct result = new OrcStruct(record.getSchema());
-    for (int i = 0 ; i < record.getNumFields() ; i ++ ) {
-      if (record.getFieldValue(i) != null) {
-        IntWritable newCopy = new IntWritable(((IntWritable) record.getFieldValue(i)).get());
-        result.setFieldValue(i, newCopy);
-      } else {
-        result.setFieldValue(i, null);
-      }
-    }
     return result;
   }
 

--- a/gobblin-compaction/src/test/java/org/apache/gobblin/compaction/mapreduce/OrcCompactionTaskTest.java
+++ b/gobblin-compaction/src/test/java/org/apache/gobblin/compaction/mapreduce/OrcCompactionTaskTest.java
@@ -58,7 +58,7 @@ import static org.apache.gobblin.compaction.mapreduce.CompactorOutputCommitter.*
 import static org.apache.gobblin.compaction.mapreduce.MRCompactor.COMPACTION_LATEDATA_THRESHOLD_FOR_RECOMPACT_PER_DATASET;
 import static org.apache.gobblin.compaction.mapreduce.MRCompactor.COMPACTION_SHOULD_DEDUPLICATE;
 
-
+@Test(groups = {"gobblin.compaction"})
 public class OrcCompactionTaskTest {
   final String extensionName = "orc";
 

--- a/gobblin-compaction/src/test/java/org/apache/gobblin/compaction/mapreduce/orc/OrcTestUtils.java
+++ b/gobblin-compaction/src/test/java/org/apache/gobblin/compaction/mapreduce/orc/OrcTestUtils.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.compaction.mapreduce.orc;
+
+import java.util.Map;
+
+import org.apache.hadoop.io.BooleanWritable;
+import org.apache.hadoop.io.ByteWritable;
+import org.apache.hadoop.io.DoubleWritable;
+import org.apache.hadoop.io.FloatWritable;
+import org.apache.hadoop.io.IntWritable;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.ShortWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.WritableComparable;
+import org.apache.orc.TypeDescription;
+import org.apache.orc.mapred.OrcList;
+import org.apache.orc.mapred.OrcMap;
+import org.apache.orc.mapred.OrcStruct;
+import org.apache.orc.mapred.OrcUnion;
+
+
+public class OrcTestUtils {
+  /**
+   * Fill in value in OrcStruct with given schema, assuming {@param w} contains the same schema as {@param schema}.
+   * {@param schema} is still necessary to given given {@param w} do contains schema information itself, because the
+   * actual value type is only available in {@link TypeDescription} but not {@link org.apache.orc.mapred.OrcValue}.
+   *
+   * For simplicity here are some assumptions:
+   * - We only give 3 primitive values and use them to construct compound values. To make it work for different types that
+   * can be widened or shrunk to each other, please use value within small range.
+   * - For List, Map or Union, make sure there's at least one entry within the record-container.
+   * you may want to try createValueRecursively(TypeDescription) instead of {@link OrcStruct#createValue(TypeDescription)}
+   */
+  public static void fillOrcStructWithFixedValue(WritableComparable w, TypeDescription schema, int unionTag,
+      int intValue, String stringValue, boolean booleanValue) {
+    switch (schema.getCategory()) {
+      case BOOLEAN:
+        ((BooleanWritable) w).set(booleanValue);
+        break;
+      case BYTE:
+        ((ByteWritable) w).set((byte) intValue);
+        break;
+      case SHORT:
+        ((ShortWritable) w).set((short) intValue);
+        break;
+      case INT:
+        ((IntWritable) w).set(intValue);
+        break;
+      case LONG:
+        ((LongWritable) w).set(intValue);
+        break;
+      case FLOAT:
+        ((FloatWritable) w).set(intValue * 1.0f);
+        break;
+      case DOUBLE:
+        ((DoubleWritable) w).set(intValue * 1.0);
+        break;
+      case STRING:
+      case CHAR:
+      case VARCHAR:
+        ((Text) w).set(stringValue);
+        break;
+      case BINARY:
+        throw new UnsupportedOperationException("Binary type is not supported in random orc data filler");
+      case DECIMAL:
+        throw new UnsupportedOperationException("Decimal type is not supported in random orc data filler");
+      case DATE:
+      case TIMESTAMP:
+      case TIMESTAMP_INSTANT:
+        throw new UnsupportedOperationException(
+            "Timestamp and its derived types is not supported in random orc data filler");
+      case LIST:
+        OrcList castedList = (OrcList) w;
+        // Here it is not trivial to create typed-object in element-type. So this method expect the value container
+        // to at least contain one element, or the traversing within the list will be skipped.
+        for (Object i : castedList) {
+          fillOrcStructWithFixedValue((WritableComparable) i, schema.getChildren().get(0), unionTag, intValue,
+              stringValue, booleanValue);
+        }
+        break;
+      case MAP:
+        OrcMap castedMap = (OrcMap) w;
+        for (Object entry : castedMap.entrySet()) {
+          Map.Entry<WritableComparable, WritableComparable> castedEntry =
+              (Map.Entry<WritableComparable, WritableComparable>) entry;
+          fillOrcStructWithFixedValue(castedEntry.getKey(), schema.getChildren().get(0), unionTag, intValue,
+              stringValue, booleanValue);
+          fillOrcStructWithFixedValue(castedEntry.getValue(), schema.getChildren().get(1), unionTag, intValue,
+              stringValue, booleanValue);
+        }
+        break;
+      case STRUCT:
+        OrcStruct castedStruct = (OrcStruct) w;
+        int fieldIdx = 0;
+        for (TypeDescription child : schema.getChildren()) {
+          fillOrcStructWithFixedValue(castedStruct.getFieldValue(fieldIdx), child, unionTag, intValue, stringValue,
+              booleanValue);
+          fieldIdx += 1;
+        }
+        break;
+      case UNION:
+        OrcUnion castedUnion = (OrcUnion) w;
+        TypeDescription targetMemberSchema = schema.getChildren().get(unionTag);
+        castedUnion.set(unionTag, OrcUtils.createValueRecursively(targetMemberSchema));
+        fillOrcStructWithFixedValue((WritableComparable) castedUnion.getObject(), targetMemberSchema, unionTag,
+            intValue, stringValue, booleanValue);
+        break;
+      default:
+        throw new IllegalArgumentException("Unknown type " + schema.toString());
+    }
+  }
+
+  /**
+   * The simple API: Union tag by default set to 0.
+   */
+  public static void fillOrcStructWithFixedValue(WritableComparable w, TypeDescription schema, int intValue,
+      String stringValue, boolean booleanValue) {
+    fillOrcStructWithFixedValue(w, schema, 0, intValue, stringValue, booleanValue);
+  }
+}

--- a/gobblin-compaction/src/test/java/org/apache/gobblin/compaction/mapreduce/orc/OrcUtilsTest.java
+++ b/gobblin-compaction/src/test/java/org/apache/gobblin/compaction/mapreduce/orc/OrcUtilsTest.java
@@ -1,0 +1,87 @@
+package org.apache.gobblin.compaction.mapreduce.orc;
+
+import org.apache.hadoop.io.BooleanWritable;
+import org.apache.hadoop.io.IntWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.orc.TypeDescription;
+import org.apache.orc.mapred.OrcList;
+import org.apache.orc.mapred.OrcStruct;
+import org.apache.orc.mapred.OrcUnion;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+public class OrcUtilsTest {
+
+  @Test
+  public void testRandomFillOrcStructWithAnySchema() {
+    // 1. Basic case
+    TypeDescription schema_1 = TypeDescription.fromString("struct<i:int,j:int,k:int>");
+    OrcStruct expectedStruct = (OrcStruct) OrcStruct.createValue(schema_1);
+    expectedStruct.setFieldValue("i", new IntWritable(3));
+    expectedStruct.setFieldValue("j", new IntWritable(3));
+    expectedStruct.setFieldValue("k", new IntWritable(3));
+
+    OrcStruct actualStruct = (OrcStruct) OrcStruct.createValue(schema_1);
+    OrcUtils.orcStructFillerWithFixedValue(actualStruct, schema_1, 3, "", false);
+    Assert.assertEquals(actualStruct, expectedStruct);
+
+    TypeDescription schema_2 = TypeDescription.fromString("struct<i:boolean,j:int,k:string>");
+    expectedStruct = (OrcStruct) OrcStruct.createValue(schema_2);
+    expectedStruct.setFieldValue("i", new BooleanWritable(false));
+    expectedStruct.setFieldValue("j", new IntWritable(3));
+    expectedStruct.setFieldValue("k", new Text(""));
+    actualStruct = (OrcStruct) OrcStruct.createValue(schema_2);
+
+    OrcUtils.orcStructFillerWithFixedValue(actualStruct, schema_2, 3, "", false);
+    Assert.assertEquals(actualStruct, expectedStruct);
+
+    // 2. Some simple nested cases: struct within struct
+    TypeDescription schema_3 = TypeDescription.fromString("struct<i:boolean,j:struct<i:boolean,j:int,k:string>>");
+    OrcStruct expectedStruct_nested_1 = (OrcStruct) OrcStruct.createValue(schema_3);
+    expectedStruct_nested_1.setFieldValue("i", new BooleanWritable(false));
+    expectedStruct_nested_1.setFieldValue("j", expectedStruct);
+    actualStruct = (OrcStruct) OrcStruct.createValue(schema_3);
+
+    OrcUtils.orcStructFillerWithFixedValue(actualStruct, schema_3, 3, "", false);
+    Assert.assertEquals(actualStruct, expectedStruct_nested_1);
+
+    // 3. array of struct within struct
+    TypeDescription schema_4 = TypeDescription.fromString("struct<i:boolean,j:array<struct<i:boolean,j:int,k:string>>>");
+    // Note that this will not create any elements in the array.
+    expectedStruct_nested_1 = (OrcStruct) OrcStruct.createValue(schema_4);
+    expectedStruct_nested_1.setFieldValue("i", new BooleanWritable(false));
+    OrcList list = new OrcList(schema_2, 1);
+    list.add(expectedStruct);
+    expectedStruct_nested_1.setFieldValue("j", list);
+
+    // Constructing actualStruct: make sure the list is non-Empty. There's any meaningful value within placeholder struct.
+    actualStruct = (OrcStruct) OrcStruct.createValue(schema_4);
+    OrcList placeHolderList = new OrcList(schema_2, 1);
+    OrcStruct placeHolderStruct = (OrcStruct) OrcStruct.createValue(schema_2);
+    placeHolderList.add(placeHolderStruct);
+    actualStruct.setFieldValue("j", placeHolderList);
+
+    OrcUtils.orcStructFillerWithFixedValue(actualStruct, schema_4, 3, "", false);
+    Assert.assertEquals(actualStruct, expectedStruct_nested_1);
+
+    // 4. union of struct within struct
+    TypeDescription schema_5 = TypeDescription.fromString("struct<i:boolean,j:uniontype<struct<i:boolean,j:int,k:string>>>");
+    expectedStruct_nested_1 = (OrcStruct) OrcStruct.createValue(schema_5);
+    expectedStruct_nested_1.setFieldValue("i", new BooleanWritable(false));
+    OrcUnion union = new OrcUnion(schema_2);
+    union.set(0, expectedStruct);
+    expectedStruct_nested_1.setFieldValue("j", union);
+
+    // Construct actualStruct: make sure there's a struct-placeholder within the union.
+    actualStruct = (OrcStruct) OrcStruct.createValue(schema_5);
+    OrcUnion placeHolderUnion = new OrcUnion(schema_2);
+    placeHolderUnion.set(0, placeHolderStruct);
+    actualStruct.setFieldValue("j", placeHolderUnion);
+
+    OrcUtils.orcStructFillerWithFixedValue(actualStruct, schema_5, 3, "", false);
+    Assert.assertEquals(actualStruct, expectedStruct_nested_1);
+  }
+}

--- a/gobblin-compaction/src/test/java/org/apache/gobblin/compaction/mapreduce/orc/OrcUtilsTest.java
+++ b/gobblin-compaction/src/test/java/org/apache/gobblin/compaction/mapreduce/orc/OrcUtilsTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.gobblin.compaction.mapreduce.orc;
 
 import org.apache.hadoop.io.BooleanWritable;
@@ -12,7 +29,6 @@ import org.apache.orc.mapred.OrcUnion;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.*;
 
 
 public class OrcUtilsTest {
@@ -192,6 +208,7 @@ public class OrcUtilsTest {
     // Check in the tag 0(Default from value-filler) within evolvedUnionInStruct, the value is becoming type-widened with correct value.
     Assert.assertEquals(((OrcUnion) evolvedUnionInStruct.getFieldValue("a")).getTag(), 0);
     Assert.assertEquals(((OrcUnion) evolvedUnionInStruct.getFieldValue("a")).getObject(), new LongWritable(intValue));
+    // Check the case when union field is created in different tag.
 
     // Complex: List<Struct> within struct among others and evolution happens on multiple places, also type-widening in deeply nested level.
     TypeDescription complexOrcSchema =

--- a/gobblin-compaction/src/test/java/org/apache/gobblin/compaction/mapreduce/orc/OrcUtilsTest.java
+++ b/gobblin-compaction/src/test/java/org/apache/gobblin/compaction/mapreduce/orc/OrcUtilsTest.java
@@ -2,9 +2,11 @@ package org.apache.gobblin.compaction.mapreduce.orc;
 
 import org.apache.hadoop.io.BooleanWritable;
 import org.apache.hadoop.io.IntWritable;
+import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.mapred.OrcList;
+import org.apache.orc.mapred.OrcMap;
 import org.apache.orc.mapred.OrcStruct;
 import org.apache.orc.mapred.OrcUnion;
 import org.testng.Assert;
@@ -83,5 +85,129 @@ public class OrcUtilsTest {
 
     OrcUtils.orcStructFillerWithFixedValue(actualStruct, schema_5, 3, "", false);
     Assert.assertEquals(actualStruct, expectedStruct_nested_1);
+  }
+
+  @Test
+  public void testUpConvertOrcStruct() {
+    int intValue = 10;
+    String stringValue = "testString";
+    boolean boolValue = true;
+
+    // Basic case, all primitives, newly added value will be set to null
+    TypeDescription baseStructSchema = TypeDescription.fromString("struct<a:int,b:string>");
+    // This would be re-used in the following tests as the actual record using the schema.
+    OrcStruct baseStruct = (OrcStruct) OrcStruct.createValue(baseStructSchema);
+    // Fill in the baseStruct with specified value.
+    OrcUtils.orcStructFillerWithFixedValue(baseStruct, baseStructSchema, intValue, stringValue, boolValue);
+    TypeDescription evolved_baseStructSchema = TypeDescription.fromString("struct<a:int,b:string,c:int>");
+    OrcStruct evolvedStruct = (OrcStruct) OrcStruct.createValue(evolved_baseStructSchema);
+    // This should be equivalent to deserialize(baseStruct).serialize(evolvedStruct, evolvedSchema);
+    OrcUtils.upConvertOrcStruct(baseStruct, evolvedStruct, evolved_baseStructSchema);
+    // Check if all value in baseStruct is populated and newly created column in evolvedStruct is filled with null.
+    org.junit.Assert.assertEquals(((IntWritable) evolvedStruct.getFieldValue("a")).get(), intValue);
+    org.junit.Assert.assertEquals(((Text) evolvedStruct.getFieldValue("b")).toString(), stringValue);
+    org.junit.Assert.assertNull(evolvedStruct.getFieldValue("c"));
+
+    // Base case: Reverse direction, which is column projection on top-level columns.
+    OrcStruct baseStruct_shadow = (OrcStruct) OrcStruct.createValue(baseStructSchema);
+    OrcUtils.upConvertOrcStruct(evolvedStruct, baseStruct_shadow, baseStructSchema);
+    org.junit.Assert.assertEquals(baseStruct, baseStruct_shadow);
+
+    // Simple Nested: List/Map/Union within Struct.
+    // The element type of list contains a new field.
+    // Prepare two ListInStructs with different size ( the list field contains different number of members)
+    TypeDescription listInStructSchema = TypeDescription.fromString("struct<a:array<struct<a:int,b:string>>>");
+    OrcStruct listInStruct = (OrcStruct) OrcUtils.createValueRecursively(listInStructSchema);
+    OrcUtils.orcStructFillerWithFixedValue(listInStruct, listInStructSchema, intValue, stringValue, boolValue);
+    TypeDescription evolved_listInStructSchema =
+        TypeDescription.fromString("struct<a:array<struct<a:int,b:string,c:int>>>");
+    OrcStruct evolved_listInStruct = (OrcStruct) OrcUtils.createValueRecursively(evolved_listInStructSchema);
+    // Convert and verify contents.
+    OrcUtils.upConvertOrcStruct(listInStruct, evolved_listInStruct, evolved_listInStructSchema);
+    org.junit.Assert.assertEquals(
+        ((IntWritable) ((OrcStruct) ((OrcList) evolved_listInStruct.getFieldValue("a")).get(0)).getFieldValue("a"))
+            .get(), intValue);
+    org.junit.Assert.assertEquals(
+        ((Text) ((OrcStruct) ((OrcList) evolved_listInStruct.getFieldValue("a")).get(0)).getFieldValue("b")).toString(),
+        stringValue);
+    org.junit.Assert.assertNull((((OrcStruct) ((OrcList) evolved_listInStruct.getFieldValue("a")).get(0)).getFieldValue("c")));
+    // Add cases when original OrcStruct has its list member having different number of elements then the destination OrcStruct.
+    // original has list.size() = 2, target has list.size() = 1
+    listInStruct = (OrcStruct) OrcUtils.createValueRecursively(listInStructSchema, 2);
+    OrcUtils.orcStructFillerWithFixedValue(listInStruct, listInStructSchema, intValue, stringValue, boolValue);
+    org.junit.Assert.assertNotEquals(((OrcList)listInStruct.getFieldValue("a")).size(),
+        ((OrcList)evolved_listInStruct.getFieldValue("a")).size());
+    OrcUtils.upConvertOrcStruct(listInStruct, evolved_listInStruct, evolved_listInStructSchema);
+    org.junit.Assert.assertEquals(((OrcList) evolved_listInStruct.getFieldValue("a")).size(), 2);
+    // Original has lise.size()=0, target has list.size() = 1
+    ((OrcList)listInStruct.getFieldValue("a")).clear();
+    OrcUtils.upConvertOrcStruct(listInStruct, evolved_listInStruct, evolved_listInStructSchema);
+    org.junit.Assert.assertEquals(((OrcList) evolved_listInStruct.getFieldValue("a")).size(), 0);
+
+    // Map within Struct, contains a type-widening in the map-value type.
+    TypeDescription mapInStructSchema = TypeDescription.fromString("struct<a:map<string,int>>");
+    OrcStruct mapInStruct = (OrcStruct) OrcStruct.createValue(mapInStructSchema);
+    TypeDescription mapSchema = TypeDescription.createMap(TypeDescription.createString(), TypeDescription.createInt());
+    OrcMap mapEntry = new OrcMap(mapSchema);
+    mapEntry.put(new Text(""), new IntWritable());
+    mapInStruct.setFieldValue("a", mapEntry);
+    OrcUtils.orcStructFillerWithFixedValue(mapEntry, mapSchema, intValue, stringValue, boolValue);
+    // Create the target struct with evolved schema
+    TypeDescription evolved_mapInStructSchema = TypeDescription.fromString("struct<a:map<string,bigint>>");
+    OrcStruct evolved_mapInStruct = (OrcStruct) OrcStruct.createValue(evolved_mapInStructSchema);
+    OrcMap evolvedMapEntry =
+        new OrcMap(TypeDescription.createMap(TypeDescription.createString(), TypeDescription.createInt()));
+    evolvedMapEntry.put(new Text(""), new LongWritable(2L));
+    evolvedMapEntry.put(new Text(""), new LongWritable(3L));
+    evolved_mapInStruct.setFieldValue("a", evolvedMapEntry);
+    // convert and verify: Type-widening is correct, and size of output file is correct.
+    OrcUtils.upConvertOrcStruct(mapInStruct, evolved_mapInStruct, evolved_mapInStructSchema);
+
+    org.junit.Assert.assertEquals(((OrcMap) evolved_mapInStruct.getFieldValue("a")).get(new Text(stringValue)),
+        new LongWritable(intValue));
+    org.junit.Assert.assertEquals(((OrcMap) evolved_mapInStruct.getFieldValue("a")).size(), 1);
+    // re-use the same object but the source struct has fewer member in the map entry.
+    mapEntry.put(new Text(""), new IntWritable(1));
+    // sanity check
+    org.junit.Assert.assertEquals(((OrcMap) mapInStruct.getFieldValue("a")).size(), 2);
+    OrcUtils.upConvertOrcStruct(mapInStruct, evolved_mapInStruct, evolved_mapInStructSchema);
+    org.junit.Assert.assertEquals(((OrcMap) evolved_mapInStruct.getFieldValue("a")).size(), 2);
+    org.junit.Assert.assertEquals(((OrcMap) evolved_mapInStruct.getFieldValue("a")).get(new Text(stringValue)),
+        new LongWritable(intValue));
+
+    // Union in struct, type widening within the union's member field.
+    TypeDescription unionInStructSchema = TypeDescription.fromString("struct<a:uniontype<int,string>>");
+    OrcStruct unionInStruct = (OrcStruct) OrcStruct.createValue(unionInStructSchema);
+    OrcUnion placeHolderUnion = new OrcUnion(TypeDescription.fromString("uniontype<int,string>"));
+    placeHolderUnion.set(0, new IntWritable(1));
+    unionInStruct.setFieldValue("a", placeHolderUnion);
+    OrcUtils.orcStructFillerWithFixedValue(unionInStruct, unionInStructSchema, intValue, stringValue, boolValue);
+    // Create new structWithUnion
+    TypeDescription evolved_unionInStructSchema = TypeDescription.fromString("struct<a:uniontype<bigint,string>>");
+    OrcStruct evolvedUnionInStruct = (OrcStruct) OrcStruct.createValue(evolved_unionInStructSchema);
+    OrcUnion evolvedPlaceHolderUnion = new OrcUnion(TypeDescription.fromString("uniontype<bigint,string>"));
+    evolvedPlaceHolderUnion.set(0, new LongWritable(1L));
+    evolvedUnionInStruct.setFieldValue("a", evolvedPlaceHolderUnion);
+    OrcUtils.upConvertOrcStruct(unionInStruct, evolvedUnionInStruct, evolved_unionInStructSchema);
+    // Check in the tag 0(Default from value-filler) within evolvedUnionInStruct, the value is becoming type-widened with correct value.
+    org.junit.Assert.assertEquals(((OrcUnion) evolvedUnionInStruct.getFieldValue("a")).getTag(), 0);
+    org.junit.Assert.assertEquals(((OrcUnion) evolvedUnionInStruct.getFieldValue("a")).getObject(), new LongWritable(intValue));
+
+    // Complex: List<Struct> within struct among others and evolution happens on multiple places, also type-widening in deeply nested level.
+    TypeDescription complexOrcSchema =
+        TypeDescription.fromString("struct<a:array<struct<a:string,b:int>>,b:struct<a:uniontype<int,string>>>");
+    OrcStruct complexOrcStruct = (OrcStruct) OrcUtils.createValueRecursively(complexOrcSchema);
+    OrcUtils.orcStructFillerWithFixedValue(complexOrcStruct, complexOrcSchema, intValue, stringValue, boolValue);
+    TypeDescription evolvedComplexOrcSchema = TypeDescription
+        .fromString("struct<a:array<struct<a:string,b:bigint,c:string>>,b:struct<a:uniontype<bigint,string>,b:int>>");
+    OrcStruct evolvedComplexStruct = (OrcStruct) OrcUtils.createValueRecursively(evolvedComplexOrcSchema);
+    OrcUtils.orcStructFillerWithFixedValue(evolvedComplexStruct, evolvedComplexOrcSchema, intValue, stringValue, boolValue);
+    // Check if new columns are assigned with null value and type widening is working fine.
+    OrcUtils.upConvertOrcStruct(complexOrcStruct, evolvedComplexStruct, evolvedComplexOrcSchema);
+    org.junit.Assert
+        .assertEquals(((OrcStruct)((OrcList)evolvedComplexStruct.getFieldValue("a")).get(0)).getFieldValue("b"), new LongWritable(intValue));
+    org.junit.Assert.assertNull(((OrcStruct)((OrcList)evolvedComplexStruct.getFieldValue("a")).get(0)).getFieldValue("c"));
+    org.junit.Assert.assertEquals(((OrcUnion) ((OrcStruct)evolvedComplexStruct.getFieldValue("b")).getFieldValue("a")).getObject(), new LongWritable(intValue));
+    org.junit.Assert.assertNull(((OrcStruct)evolvedComplexStruct.getFieldValue("b")).getFieldValue("b"));
   }
 }

--- a/gobblin-compaction/src/test/java/org/apache/gobblin/compaction/mapreduce/orc/OrcValueMapperTest.java
+++ b/gobblin-compaction/src/test/java/org/apache/gobblin/compaction/mapreduce/orc/OrcValueMapperTest.java
@@ -17,21 +17,7 @@
 
 package org.apache.gobblin.compaction.mapreduce.orc;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Map;
-import java.util.Random;
-
-import org.apache.hadoop.io.BooleanWritable;
-import org.apache.hadoop.io.DoubleWritable;
-import org.apache.hadoop.io.FloatWritable;
-import org.apache.hadoop.io.IntWritable;
-import org.apache.hadoop.io.Text;
-import org.apache.hadoop.io.WritableComparable;
 import org.apache.orc.TypeDescription;
-import org.apache.orc.mapred.OrcList;
-import org.apache.orc.mapred.OrcMap;
-import org.apache.orc.mapred.OrcStruct;
-import org.apache.orc.mapred.OrcUnion;
 import org.junit.Assert;
 import org.testng.annotations.Test;
 
@@ -47,67 +33,5 @@ public class OrcValueMapperTest {
     Assert.assertTrue(OrcUtils.isEvolutionValid(schema_1, schema_3));
     Assert.assertTrue(OrcUtils.isEvolutionValid(schema_1, schema_4));
     Assert.assertTrue(OrcUtils.isEvolutionValid(schema_4, schema_1));
-  }
-
-  @Test
-  public void testUpConvertOrcStruct() {
-    OrcValueMapper mapper = new OrcValueMapper();
-    int intValue = 10;
-    String stringValue = "testString";
-    boolean boolValue = true;
-
-    // Basic case, all primitives, newly added value will be set to null
-    TypeDescription baseStructSchema = TypeDescription.fromString("struct<a:int,b:string>");
-    OrcStruct baseStruct = (OrcStruct) OrcStruct.createValue(baseStructSchema);
-    OrcUtils.orcStructFillerWithFixedValue(baseStruct, baseStructSchema, intValue, stringValue, boolValue);
-    TypeDescription evolved_baseStructSchema = TypeDescription.fromString("struct<a:int,b:string,c:int>");
-    OrcStruct evolvedStruct = (OrcStruct) OrcStruct.createValue(evolved_baseStructSchema);
-    mapper.upConvertOrcStruct(baseStruct, evolvedStruct, evolved_baseStructSchema);
-    Assert.assertEquals(((IntWritable)evolvedStruct.getFieldValue("a")).get(), intValue);
-    Assert.assertEquals(((Text) evolvedStruct.getFieldValue("b")).toString(), stringValue);
-    Assert.assertNull(evolvedStruct.getFieldValue("c"));
-
-//
-//    // Base case: Reverse direction.
-//    OrcStruct baseStruct_shadow = (OrcStruct) OrcStruct.createValue(baseStructSchema);
-//    mapper.upConvertOrcStruct(evolvedStruct, baseStruct_shadow, baseStructSchema);
-//    Assert.assertEquals(baseStruct, baseStructSchema);
-//
-//    // Simple Nested: List/Map/Union/Struct within Struct.
-//    TypeDescription listInStructSchema = TypeDescription.fromString("struct<a:array<struct<a:int,b:string>>>");
-//    OrcStruct listInStruct = (OrcStruct) OrcStruct.createValue(listInStructSchema);
-//    TypeDescription evolved_listInStructSchema = TypeDescription.fromString("struct<a:array<struct<a:int,b:string,c:string>>>");
-//    OrcStruct evolved_listInStruct = (OrcStruct) OrcStruct.createValue(evolved_listInStructSchema);
-//    resultStruct = mapper.upConvertOrcStruct(listInStruct, evolved_listInStructSchema);
-//    Assert.assertEquals(resultStruct.getSchema(), evolved_listInStructSchema);
-//    resultStruct = mapper.upConvertOrcStruct(evolved_listInStruct, listInStructSchema);
-//    Assert.assertEquals(resultStruct.getSchema(), listInStructSchema);
-//
-//    TypeDescription mapInStructSchema = TypeDescription.fromString("struct<a:map<string,int>>");
-//    OrcStruct mapInStruct = (OrcStruct) OrcStruct.createValue(mapInStructSchema);
-//    TypeDescription evolved_mapInStructSchema = TypeDescription.fromString("struct<a:map<string,bigint>>");
-//    OrcStruct evolved_mapInStruct = (OrcStruct) OrcStruct.createValue(evolved_mapInStructSchema);
-//    resultStruct = mapper.upConvertOrcStruct(mapInStruct, evolved_mapInStructSchema);
-//    Assert.assertEquals(resultStruct.getSchema(), evolved_mapInStructSchema);
-//    resultStruct = mapper.upConvertOrcStruct(evolved_mapInStruct, mapInStructSchema);
-//    // Evolution not valid, no up-conversion happened.
-//    try {
-//      resultStruct.getSchema().equals(evolved_mapInStructSchema);
-//    } catch (SchemaEvolution.IllegalEvolutionException ie) {
-//      Assert.assertTrue(true);
-//    }
-//
-//    TypeDescription unionInStructSchema = TypeDescription.fromString("struct<a:uniontype<int,string>>");
-//    OrcStruct unionInStruct = (OrcStruct) OrcStruct.createValue(unionInStructSchema);
-//    TypeDescription evolved_unionInStructSchema = TypeDescription.fromString("struct<a:uniontype<bigint,string>>");
-//    resultStruct = mapper.upConvertOrcStruct(unionInStruct, evolved_unionInStructSchema);
-//    Assert.assertEquals(resultStruct.getSchema(), evolved_unionInStructSchema);
-//
-//    // Complex: List<Struct> within struct among others and evolution happens on multiple places.
-//    TypeDescription complex_1 = TypeDescription.fromString("struct<a:array<struct<a:string,b:int>>,b:struct<a:uniontype<int,string>>>");
-//    OrcStruct complex_struct = (OrcStruct) OrcStruct.createValue(complex_1);
-//    TypeDescription evolved_complex_1 = TypeDescription.fromString("struct<a:array<struct<a:string,b:int,c:string>>,b:struct<a:uniontype<bigint,string>,b:int>>");
-//    resultStruct = mapper.upConvertOrcStruct(complex_struct, evolved_complex_1);
-//    Assert.assertEquals(resultStruct.getSchema(), evolved_complex_1);
   }
 }

--- a/travis/test-groups.inc
+++ b/travis/test-groups.inc
@@ -1,1 +1,1 @@
-TEST_GROUP1=gobbin.yarn,gobblin.runtime
+TEST_GROUP1=gobbin.yarn,gobblin.runtime,gobblin.cluster,gobblin.compaction


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- https://issues.apache.org/jira/browse/GOBBLIN-1126

### Description
The contribution of this PR contains: 
- Refactored `upConvertOrcStruct` which was used specifically for handling schema evolution. The downside of the original implementation is, it creates new OrcStruct for each map call which is usually considered as an anti-pattern in MR execution. The fix makes it possible to reuse the same `OrcStruct` object by making this method only generating side-effect but return void. 
- The refactored `upConvertOrcStruct` can be reused in column projection of `OrcStruct` so that if we want to have an arbitrary subset of columns to form a shuffle key (we used to use the whole record for shuffle key which is unnecessarily burdensome and harm the performance). 
- To accommodate with tests I created a bunch of tools in `OrcUtils`: 
-- `orcStructFillerWithFixedValue`: Given a schema, generate a `OrcStruct` with some value. This would be useful to randomly generate some record in row-manner and we could write them into a ORC file easily. 
-- `writableComparableTypeWidening`: The original `upConvertOrcStruct` cannot handle this. Added for correctness. 
-- `createValueRecursively`: The ORC API to create a `OrcStruct`, `OrcStruct.createValue` has a problem: If there's nested type within a contain-type like List/MAP, `createValue` call doesn't create any instance within the container, so that any nested-type information within the container's element type is lost. It might be worthwhile to contribute this back to ORC upstream. 

The test might be hard to read, but given all the tools mentioned above, what I really do is mostly following this sequence: 

1. create a ORC schema by: `schema = TypeDescription.createFromString(schemaString);` 
2. create a OrcStruct by `orcStruct = OrcUtils.createValueRecursively(schema)`. 
3. Fill in the value by `OrcUtils.orcStructFillerWithFixedValue(orcStruct, schema, valueForDifferntTypes ...)` 
4. Do this for two different schema: writer schema and reader schema with certain evolution. 
5. `upConvertOrcStruct(recordInWriterSchema, recordInReaderSchema, readerSchema); `
6. Examine if `recordInReaderSchema`'s result is expected. 




### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

