### PR TITLE
GOBBLIN-1127: Provide an option to make metric reporting instantiatio…

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterConfigurationKeys.java
@@ -197,4 +197,11 @@ public class GobblinClusterConfigurationKeys {
   public static final String CONTAINER_ID_KEY = GOBBLIN_HELIX_PREFIX + "containerId";
 
   public static final String GOBBLIN_CLUSTER_SYSTEM_PROPERTY_PREFIX = GOBBLIN_CLUSTER_PREFIX + "sysProps";
+
+  //Gobblin TaskRunner configuration keys
+  public static final String GOBBLIN_CLUSTER_TASK_RUNNER_METRIC_REPORTING_FAILURE_FATAL = "gobblin.cluster.taskRunner.isMetricReportingFailureFatal";
+  public static final boolean DEFAULT_GOBBLIN_CLUSTER_TASK_RUNNER_METRIC_REPORTING_FAILURE_FATAL = false;
+
+  public static final String GOBBLIN_CLUSTER_TASK_RUNNER_EVENT_REPORTING_FAILURE_FATAL = "gobblin.cluster.taskRunner.isEventReportingFailureFatal";
+  public static final boolean DEFAULT_GOBBLIN_CLUSTER_TASK_RUNNER_EVENT_REPORTING_FAILURE_FATAL = false;
 }

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinTaskRunnerTest.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinTaskRunnerTest.java
@@ -43,6 +43,7 @@ import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigValueFactory;
 
 import org.apache.gobblin.cluster.suite.IntegrationBasicSuite;
+import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.testing.AssertWithBackoff;
 
 
@@ -71,6 +72,7 @@ public class GobblinTaskRunnerTest {
 
   private GobblinClusterManager gobblinClusterManager;
   private GobblinTaskRunner corruptGobblinTaskRunner;
+  private GobblinTaskRunner gobblinTaskRunnerFailedReporter;
   private String clusterName;
   private String corruptHelixInstance;
   private TaskAssignmentAfterConnectionRetry suite;
@@ -102,6 +104,18 @@ public class GobblinTaskRunnerTest {
         new GobblinTaskRunner(TestHelper.TEST_APPLICATION_NAME, TestHelper.TEST_HELIX_INSTANCE_NAME,
             TestHelper.TEST_APPLICATION_ID, TestHelper.TEST_TASK_RUNNER_ID, config, Optional.<Path>absent());
     this.gobblinTaskRunner.connectHelixManager();
+
+    // Participant that fails to start due to metric reporter failures
+    String instanceName = HelixUtils.getHelixInstanceName("MetricReporterFailureInstance", 0);
+
+    Config metricConfig = config.withValue(ConfigurationKeys.METRICS_ENABLED_KEY, ConfigValueFactory.fromAnyRef(true))
+        .withValue(ConfigurationKeys.METRICS_REPORTING_KAFKA_ENABLED_KEY, ConfigValueFactory.fromAnyRef(true))
+        .withValue(ConfigurationKeys.METRICS_KAFKA_TOPIC_METRICS, ConfigValueFactory.fromAnyRef("metricTopic"))
+        .withValue(GobblinClusterConfigurationKeys.GOBBLIN_CLUSTER_TASK_RUNNER_METRIC_REPORTING_FAILURE_FATAL, ConfigValueFactory.fromAnyRef(true));
+
+    this.gobblinTaskRunnerFailedReporter =
+        new GobblinTaskRunner(TestHelper.TEST_APPLICATION_NAME, instanceName,
+            TestHelper.TEST_APPLICATION_ID, TestHelper.TEST_TASK_RUNNER_ID, metricConfig, Optional.<Path>absent());
 
     // Participant with a partial Instance set up on Helix/ZK
     this.corruptHelixInstance = HelixUtils.getHelixInstanceName("CorruptHelixInstance", 0);
@@ -140,6 +154,11 @@ public class GobblinTaskRunnerTest {
           return GobblinTaskRunnerTest.this.gobblinTaskRunner.isStopped();
         }
       }, "gobblinTaskRunner stopped");
+  }
+
+  @Test (expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = ".*Missing Kafka configuration.*")
+  public void testStartUpFailsDueToMetricReporterFailure() {
+      GobblinTaskRunnerTest.this.gobblinTaskRunnerFailedReporter.start();
   }
 
   @Test

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinTaskRunnerTest.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinTaskRunnerTest.java
@@ -156,7 +156,7 @@ public class GobblinTaskRunnerTest {
       }, "gobblinTaskRunner stopped");
   }
 
-  @Test (expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = ".*Missing Kafka configuration.*")
+  @Test (expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = ".*Could not create metric reporter.*")
   public void testStartUpFailsDueToMetricReporterFailure() {
       GobblinTaskRunnerTest.this.gobblinTaskRunnerFailedReporter.start();
   }

--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/MRCompactor.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/MRCompactor.java
@@ -68,7 +68,9 @@ import org.apache.gobblin.compaction.verify.DataCompletenessVerifier;
 import org.apache.gobblin.compaction.verify.DataCompletenessVerifier.Results;
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.State;
+import org.apache.gobblin.metrics.EventReporterException;
 import org.apache.gobblin.metrics.GobblinMetrics;
+import org.apache.gobblin.metrics.MetricReporterException;
 import org.apache.gobblin.metrics.Tag;
 import org.apache.gobblin.metrics.event.EventSubmitter;
 import org.apache.gobblin.util.ClassAliasResolver;
@@ -364,7 +366,13 @@ public class MRCompactor implements Compactor {
     tags.addAll(Tag.fromMap(ClusterNameTags.getClusterNameTags()));
     GobblinMetrics gobblinMetrics =
         GobblinMetrics.get(this.state.getProp(ConfigurationKeys.JOB_NAME_KEY), null, tags.build());
-    gobblinMetrics.startMetricReporting(this.state.getProperties());
+    try {
+      gobblinMetrics.startMetricReporting(this.state.getProperties());
+    } catch (MetricReporterException e) {
+      LOG.error("Failed to start {} metric reporter.", e.getType().name(), e);
+    } catch (EventReporterException e) {
+      LOG.error("Failed to start {} event reporter.", e.getType().name(), e);
+    }
     return gobblinMetrics;
   }
 

--- a/gobblin-metrics-libs/gobblin-metrics/src/main/java/org/apache/gobblin/metrics/EventReporterException.java
+++ b/gobblin-metrics-libs/gobblin-metrics/src/main/java/org/apache/gobblin/metrics/EventReporterException.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gobblin.metrics;
+
+import java.io.IOException;
+
+import lombok.Getter;
+
+public class EventReporterException extends IOException {
+  @Getter
+  private final ReporterSinkType type;
+
+  public EventReporterException(Throwable t, ReporterSinkType type) {
+    super(t);
+    this.type = type;
+  }
+
+  public EventReporterException(String message, ReporterSinkType type) {
+    super(message);
+    this.type = type;
+  }
+
+  public EventReporterException(String message, Throwable t, ReporterSinkType type) {
+    super(message, t);
+    this.type = type;
+  }
+}

--- a/gobblin-metrics-libs/gobblin-metrics/src/main/java/org/apache/gobblin/metrics/GobblinMetrics.java
+++ b/gobblin-metrics-libs/gobblin-metrics/src/main/java/org/apache/gobblin/metrics/GobblinMetrics.java
@@ -27,7 +27,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang.exception.ExceptionUtils;
-import org.apache.gobblin.metrics.reporter.FileFailureEventReporter;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -48,6 +47,8 @@ import com.google.common.collect.Lists;
 import com.google.common.io.Closer;
 import com.typesafe.config.Config;
 
+import lombok.Getter;
+
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.metrics.graphite.GraphiteConnectionType;
@@ -56,13 +57,12 @@ import org.apache.gobblin.metrics.graphite.GraphiteReporter;
 import org.apache.gobblin.metrics.influxdb.InfluxDBConnectionType;
 import org.apache.gobblin.metrics.influxdb.InfluxDBEventReporter;
 import org.apache.gobblin.metrics.influxdb.InfluxDBReporter;
+import org.apache.gobblin.metrics.reporter.FileFailureEventReporter;
 import org.apache.gobblin.metrics.reporter.OutputStreamEventReporter;
 import org.apache.gobblin.metrics.reporter.OutputStreamReporter;
 import org.apache.gobblin.metrics.reporter.ScheduledReporter;
 import org.apache.gobblin.password.PasswordManager;
 import org.apache.gobblin.util.PropertiesUtils;
-
-import lombok.Getter;
 
 
 /**
@@ -354,7 +354,8 @@ public class GobblinMetrics {
    * Starts metric reporting and appends the given metrics file suffix to the current value of
    * {@link ConfigurationKeys#METRICS_FILE_SUFFIX}.
    */
-  public void startMetricReportingWithFileSuffix(State state, String metricsFileSuffix) {
+  public void startMetricReportingWithFileSuffix(State state, String metricsFileSuffix)
+      throws MetricReporterException, EventReporterException {
     Properties metricsReportingProps = new Properties();
     metricsReportingProps.putAll(state.getProperties());
 
@@ -374,7 +375,8 @@ public class GobblinMetrics {
    *
    * @param configuration configuration properties
    */
-  public void startMetricReporting(Configuration configuration) {
+  public void startMetricReporting(Configuration configuration)
+      throws MetricReporterException, EventReporterException {
     Properties props = new Properties();
     for (Map.Entry<String, String> entry : configuration) {
       props.put(entry.getKey(), entry.getValue());
@@ -387,7 +389,8 @@ public class GobblinMetrics {
    *
    * @param properties configuration properties
    */
-  public void startMetricReporting(Properties properties) {
+  public void startMetricReporting(Properties properties)
+      throws MetricReporterException, EventReporterException {
     if (this.metricsReportingStarted) {
       LOGGER.warn("Metric reporting has already started");
       return;
@@ -473,7 +476,8 @@ public class GobblinMetrics {
     LOGGER.info("Metrics reporting stopped successfully");
   }
 
-  private void buildFileMetricReporter(Properties properties) {
+  private void buildFileMetricReporter(Properties properties)
+      throws MetricReporterException {
     if (!Boolean.valueOf(properties.getProperty(ConfigurationKeys.METRICS_REPORTING_FILE_ENABLED_KEY,
         ConfigurationKeys.DEFAULT_METRICS_REPORTING_FILE_ENABLED))) {
       return;
@@ -481,9 +485,8 @@ public class GobblinMetrics {
     LOGGER.info("Reporting metrics to log files");
 
     if (!properties.containsKey(ConfigurationKeys.METRICS_LOG_DIR_KEY)) {
-      LOGGER.error(
-          "Not reporting metrics to log files because " + ConfigurationKeys.METRICS_LOG_DIR_KEY + " is undefined");
-      return;
+      throw new MetricReporterException(
+          "Not reporting metrics to log files because " + ConfigurationKeys.METRICS_LOG_DIR_KEY + " is undefined", ReporterSinkType.FILE);
     }
 
     try {
@@ -493,8 +496,7 @@ public class GobblinMetrics {
       // Each job gets its own metric log subdirectory
       Path metricsLogDir = new Path(properties.getProperty(ConfigurationKeys.METRICS_LOG_DIR_KEY), this.getName());
       if (!fs.exists(metricsLogDir) && !fs.mkdirs(metricsLogDir)) {
-        LOGGER.error("Failed to create metric log directory for metrics " + this.getName());
-        return;
+        throw new MetricReporterException("Failed to create metric log directory for metrics " + this.getName(), ReporterSinkType.FILE);
       }
 
       // Add a suffix to file name if specified in properties.
@@ -523,11 +525,12 @@ public class GobblinMetrics {
 
       LOGGER.info("Will start reporting metrics to directory " + metricsLogDir);
     } catch (IOException ioe) {
-      LOGGER.error("Failed to build file metric reporter for job " + this.id, ioe);
+      throw new MetricReporterException("Failed to build file metric reporter for job " + this.id, ioe, ReporterSinkType.FILE);
     }
   }
 
-  private void buildFileFailureEventReporter(Properties properties) {
+  private void buildFileFailureEventReporter(Properties properties)
+      throws EventReporterException {
     if (!Boolean.valueOf(properties.getProperty(ConfigurationKeys.FAILURE_REPORTING_FILE_ENABLED_KEY,
         ConfigurationKeys.DEFAULT_FAILURE_REPORTING_FILE_ENABLED))) {
       return;
@@ -535,9 +538,8 @@ public class GobblinMetrics {
     LOGGER.info("Reporting failure to log files");
 
     if (!properties.containsKey(ConfigurationKeys.FAILURE_LOG_DIR_KEY)) {
-      LOGGER.error(
-          "Not reporting failure to log files because " + ConfigurationKeys.FAILURE_LOG_DIR_KEY + " is undefined");
-      return;
+      throw new EventReporterException(
+          "Not reporting failure to log files because " + ConfigurationKeys.FAILURE_LOG_DIR_KEY + " is undefined", ReporterSinkType.FILE);
     }
 
     try {
@@ -547,8 +549,7 @@ public class GobblinMetrics {
       // Each job gets its own log subdirectory
       Path failureLogDir = new Path(properties.getProperty(ConfigurationKeys.FAILURE_LOG_DIR_KEY), this.getName());
       if (!fs.exists(failureLogDir) && !fs.mkdirs(failureLogDir)) {
-        LOGGER.error("Failed to create failure log directory for metrics " + this.getName());
-        return;
+        throw new EventReporterException("Failed to create failure log directory for metrics " + this.getName(), ReporterSinkType.FILE);
       }
 
       // Add a suffix to file name if specified in properties.
@@ -566,7 +567,7 @@ public class GobblinMetrics {
 
       LOGGER.info("Will start reporting failure to directory " + failureLogDir);
     } catch (IOException ioe) {
-      LOGGER.error("Failed to build file failure event reporter for job " + this.id, ioe);
+      throw new EventReporterException("Failed to build file failure event reporter for job " + this.id, ioe, ReporterSinkType.FILE);
     }
   }
 
@@ -581,7 +582,8 @@ public class GobblinMetrics {
         convertRatesTo(TimeUnit.SECONDS).convertDurationsTo(TimeUnit.MILLISECONDS).build()));
   }
 
-  private void buildKafkaMetricReporter(Properties properties) {
+  private void buildKafkaMetricReporter(Properties properties)
+      throws MetricReporterException, EventReporterException {
     if (!Boolean.valueOf(properties.getProperty(ConfigurationKeys.METRICS_REPORTING_KAFKA_ENABLED_KEY,
         ConfigurationKeys.DEFAULT_METRICS_REPORTING_KAFKA_ENABLED))) {
       return;
@@ -589,7 +591,8 @@ public class GobblinMetrics {
     buildScheduledReporter(properties, ConfigurationKeys.DEFAULT_METRICS_REPORTING_KAFKA_REPORTER_CLASS, Optional.of("Kafka"));
   }
 
-  private void buildGraphiteMetricReporter(Properties properties) {
+  private void buildGraphiteMetricReporter(Properties properties)
+      throws MetricReporterException, EventReporterException {
     boolean metricsEnabled = PropertiesUtils
         .getPropAsBoolean(properties, ConfigurationKeys.METRICS_REPORTING_GRAPHITE_METRICS_ENABLED_KEY,
             ConfigurationKeys.DEFAULT_METRICS_REPORTING_GRAPHITE_METRICS_ENABLED);
@@ -612,8 +615,7 @@ public class GobblinMetrics {
       Preconditions.checkArgument(properties.containsKey(ConfigurationKeys.METRICS_REPORTING_GRAPHITE_HOSTNAME),
           "Graphite hostname is missing.");
     } catch (IllegalArgumentException exception) {
-      LOGGER.error("Not reporting to Graphite due to missing Graphite configuration(s).", exception);
-      return;
+      throw new MetricReporterException("Missing Graphite configuration(s).", exception, ReporterSinkType.GRAPHITE);
     }
 
     String hostname = properties.getProperty(ConfigurationKeys.METRICS_REPORTING_GRAPHITE_HOSTNAME);
@@ -641,7 +643,7 @@ public class GobblinMetrics {
             .withMetricsPrefix(prefix)
             .build(properties);
       } catch (IOException e) {
-        LOGGER.error("Failed to create Graphite metrics reporter. Will not report metrics to Graphite.", e);
+        throw new MetricReporterException("Failed to create Graphite metrics reporter.", e, ReporterSinkType.GRAPHITE);
       }
     }
 
@@ -663,12 +665,13 @@ public class GobblinMetrics {
         this.codahaleScheduledReporters.add(this.codahaleReportersCloser.register(eventReporter));
       }
       catch (IOException e) {
-        LOGGER.error("Failed to create Graphite event reporter. Will not report events to Graphite.", e);
+        throw new EventReporterException("Failed to create Graphite event reporter.", e, ReporterSinkType.GRAPHITE);
       }
     }
   }
 
-  private void buildInfluxDBMetricReporter(Properties properties) {
+  private void buildInfluxDBMetricReporter(Properties properties)
+      throws MetricReporterException, EventReporterException {
     boolean metricsEnabled = PropertiesUtils
         .getPropAsBoolean(properties, ConfigurationKeys.METRICS_REPORTING_INFLUXDB_METRICS_ENABLED_KEY,
             ConfigurationKeys.DEFAULT_METRICS_REPORTING_INFLUXDB_METRICS_ENABLED);
@@ -691,8 +694,7 @@ public class GobblinMetrics {
       Preconditions.checkArgument(properties.containsKey(ConfigurationKeys.METRICS_REPORTING_INFLUXDB_DATABASE),
           "InfluxDB database name is missing.");
     } catch (IllegalArgumentException exception) {
-      LOGGER.error("Not reporting to InfluxDB due to missing InfluxDB configuration(s).", exception);
-      return;
+      throw new MetricReporterException("Missing InfluxDB configuration(s)", exception, ReporterSinkType.INFLUXDB);
     }
 
     String url = properties.getProperty(ConfigurationKeys.METRICS_REPORTING_INFLUXDB_URL);
@@ -719,7 +721,7 @@ public class GobblinMetrics {
             this.metricContext.getName()) // contains the current job id
             .build(properties);
       } catch (IOException e) {
-        LOGGER.error("Failed to create InfluxDB metrics reporter. Will not report metrics to InfluxDB.", e);
+        throw new MetricReporterException("Failed to create InfluxDB metrics reporter.", e, ReporterSinkType.INFLUXDB);
       }
     }
 
@@ -735,7 +737,7 @@ public class GobblinMetrics {
         this.codahaleScheduledReporters.add(this.codahaleReportersCloser.register(eventReporter));
       }
       catch (IOException e) {
-        LOGGER.error("Failed to create InfluxDB event reporter. Will not report events to InfluxDB.", e);
+        throw new EventReporterException("Failed to create InfluxDB event reporter.", e, ReporterSinkType.INFLUXDB);
       }
     }
   }
@@ -745,7 +747,8 @@ public class GobblinMetrics {
    * {@link org.apache.gobblin.configuration.ConfigurationKeys#METRICS_CUSTOM_BUILDERS}. This allows users to specify custom
    * reporters for Gobblin runtime without having to modify the code.
    */
-  private void buildCustomMetricReporters(Properties properties) {
+  private void buildCustomMetricReporters(Properties properties)
+      throws MetricReporterException, EventReporterException {
     String reporterClasses = properties.getProperty(ConfigurationKeys.METRICS_CUSTOM_BUILDERS);
 
     if (Strings.isNullOrEmpty(reporterClasses)) {
@@ -757,7 +760,8 @@ public class GobblinMetrics {
     }
   }
 
-  private void buildScheduledReporter(Properties properties, String reporterClass, Optional<String> reporterSink) {
+  private void buildScheduledReporter(Properties properties, String reporterClass, Optional<String> reporterSink)
+      throws MetricReporterException, EventReporterException {
     try {
       Class<?> clazz = Class.forName(reporterClass);
 
@@ -779,19 +783,21 @@ public class GobblinMetrics {
         customReporterFactory.newScheduledReporter(properties);
         LOGGER.info("Will start reporting metrics using " + reporterClass);
       } else {
-        throw new IllegalArgumentException("Class " + reporterClass +
+        throw new MetricReporterException("Class " + reporterClass +
             " specified by key " + ConfigurationKeys.METRICS_CUSTOM_BUILDERS + " must implement: "
-            + CustomCodahaleReporterFactory.class + " or " + CustomReporterFactory.class);
+            + CustomCodahaleReporterFactory.class + " or " + CustomReporterFactory.class, ReporterSinkType.CUSTOM);
       }
     } catch (ClassNotFoundException exception) {
-      LOGGER.warn(String
+      throw new MetricReporterException(String
           .format("Failed to create metric reporter: requested CustomReporterFactory %s not found.", reporterClass),
-          exception);
+          exception, ReporterSinkType.CUSTOM);
     } catch (NoSuchMethodException exception) {
-      LOGGER.warn(String.format("Failed to create metric reporter: requested CustomReporterFactory %s "
-          + "does not have parameterless constructor.", reporterClass), exception);
+      throw new MetricReporterException(String.format("Failed to create metric reporter: requested CustomReporterFactory %s "
+          + "does not have parameterless constructor.", reporterClass), exception, ReporterSinkType.CUSTOM);
+    } catch (EventReporterException exception) {
+      throw exception;
     } catch (Exception exception) {
-      LOGGER.warn("Could not create metric reporter from builder " + reporterClass + ".", exception);
+      throw new MetricReporterException("Could not create metric reporter from builder " + reporterClass + ".", exception, ReporterSinkType.CUSTOM);
     }
   }
 }

--- a/gobblin-metrics-libs/gobblin-metrics/src/main/java/org/apache/gobblin/metrics/MetricReporterException.java
+++ b/gobblin-metrics-libs/gobblin-metrics/src/main/java/org/apache/gobblin/metrics/MetricReporterException.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gobblin.metrics;
+
+import java.io.IOException;
+
+import lombok.Getter;
+
+public class MetricReporterException extends IOException {
+  @Getter
+  private final ReporterSinkType type;
+
+  public MetricReporterException(Throwable t, ReporterSinkType type) {
+    super(t);
+    this.type = type;
+  }
+
+  public MetricReporterException(String message, ReporterSinkType type) {
+    super(message);
+    this.type = type;
+  }
+
+  public MetricReporterException(String message, Throwable t, ReporterSinkType type) {
+    super(message, t);
+    this.type = type;
+  }
+}

--- a/gobblin-metrics-libs/gobblin-metrics/src/main/java/org/apache/gobblin/metrics/ReporterSinkType.java
+++ b/gobblin-metrics-libs/gobblin-metrics/src/main/java/org/apache/gobblin/metrics/ReporterSinkType.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gobblin.metrics;
+
+public enum ReporterSinkType {
+  GRAPHITE,
+  FILE,
+  KAFKA,
+  INFLUXDB,
+  CONSOLE,
+  CUSTOM
+}

--- a/gobblin-metrics-libs/gobblin-metrics/src/test/java/org/apache/gobblin/metrics/GobblinMetricsTest.java
+++ b/gobblin-metrics-libs/gobblin-metrics/src/test/java/org/apache/gobblin/metrics/GobblinMetricsTest.java
@@ -22,21 +22,74 @@ import java.util.Properties;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigValueFactory;
+
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.util.ConfigUtils;
+
 
 @Test
 public class GobblinMetricsTest {
-
   /**
    * Test the {@link GobblinMetrics} instance is removed from {@link GobblinMetricsRegistry} when
    * it stops metrics reporting
    */
-  public void testStopReportingMetrics() {
+  public void testStopReportingMetrics()
+      throws MetricReporterException, EventReporterException {
     String id = getClass().getSimpleName() + "-" + System.currentTimeMillis();
     GobblinMetrics gobblinMetrics = GobblinMetrics.get(id);
-    gobblinMetrics.startMetricReporting(new Properties());
+
+    Properties properties = new Properties();
+    properties.put(ConfigurationKeys.FAILURE_REPORTING_FILE_ENABLED_KEY, "false");
+
+    gobblinMetrics.startMetricReporting(properties);
     Assert.assertEquals(GobblinMetricsRegistry.getInstance().get(id).get(), gobblinMetrics);
 
     gobblinMetrics.stopMetricsReporting();
     Assert.assertFalse(GobblinMetricsRegistry.getInstance().get(id).isPresent());
   }
+
+  public void testMetricFileReporterThrowsException() {
+    String id = getClass().getSimpleName() + "-" + System.currentTimeMillis();
+    GobblinMetrics gobblinMetrics = GobblinMetrics.get(id);
+
+    //Enable file reporter without specifying metrics.log.dir.
+    Config config = ConfigFactory.empty()
+        .withValue(ConfigurationKeys.METRICS_REPORTING_FILE_ENABLED_KEY, ConfigValueFactory.fromAnyRef(true));
+
+    Properties properties = ConfigUtils.configToProperties(config);
+    //Ensure MetricReporterException is thrown
+    try {
+      gobblinMetrics.startMetricReporting(properties);
+      Assert.fail("Metric reporting unexpectedly succeeded.");
+    } catch (MetricReporterException e) {
+      //Do nothing. Expected to be here.
+    } catch (EventReporterException e) {
+      Assert.fail("Unexpected exception " + e.getMessage());
+    }
+  }
+
+  public void testMetricFileReporterSuccessful() {
+    String id = getClass().getSimpleName() + "-" + System.currentTimeMillis();
+    GobblinMetrics gobblinMetrics = GobblinMetrics.get(id);
+
+    //Enable file reporter without specifying metrics.log.dir.
+    Config config = ConfigFactory.empty()
+        .withValue(ConfigurationKeys.METRICS_REPORTING_FILE_ENABLED_KEY, ConfigValueFactory.fromAnyRef(true))
+        .withValue(ConfigurationKeys.METRICS_LOG_DIR_KEY, ConfigValueFactory.fromAnyRef("/tmp"))
+        .withValue(ConfigurationKeys.FAILURE_LOG_DIR_KEY, ConfigValueFactory.fromAnyRef("/tmp"));
+
+    Properties properties = ConfigUtils.configToProperties(config);
+    //Ensure MetricReporterException is thrown
+    try {
+      gobblinMetrics.startMetricReporting(properties);
+    } catch (MetricReporterException e) {
+      Assert.fail("Unexpected exception " + e.getMessage());
+    } catch (EventReporterException e) {
+      Assert.fail("Unexpected exception " + e.getMessage());
+    }
+  }
+
 }

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/metrics/kafka/KafkaReporterFactory.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/metrics/kafka/KafkaReporterFactory.java
@@ -29,7 +29,10 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.metrics.CustomCodahaleReporterFactory;
+import org.apache.gobblin.metrics.EventReporterException;
 import org.apache.gobblin.metrics.KafkaReportingFormats;
+import org.apache.gobblin.metrics.MetricReporterException;
+import org.apache.gobblin.metrics.ReporterSinkType;
 import org.apache.gobblin.metrics.RootMetricContext;
 import org.apache.gobblin.metrics.reporter.util.KafkaReporterUtils;
 
@@ -37,7 +40,8 @@ import org.apache.gobblin.metrics.reporter.util.KafkaReporterUtils;
 @Slf4j
 public class KafkaReporterFactory implements CustomCodahaleReporterFactory {
   @Override
-  public ScheduledReporter newScheduledReporter(MetricRegistry registry, Properties properties) {
+  public ScheduledReporter newScheduledReporter(MetricRegistry registry, Properties properties)
+      throws IOException {
     if (!Boolean.valueOf(properties.getProperty(ConfigurationKeys.METRICS_REPORTING_KAFKA_ENABLED_KEY,
         ConfigurationKeys.DEFAULT_METRICS_REPORTING_KAFKA_ENABLED))) {
       return null;
@@ -63,8 +67,7 @@ public class KafkaReporterFactory implements CustomCodahaleReporterFactory {
           "Kafka metrics brokers missing.");
       Preconditions.checkArgument(KafkaReporterUtils.getMetricsTopic(properties).or(eventsTopic).or(defaultTopic).isPresent(), "Kafka topic missing.");
     } catch (IllegalArgumentException exception) {
-      log.error("Not reporting metrics to Kafka due to missing Kafka configuration(s).", exception);
-      return null;
+      throw new MetricReporterException("Missing Kafka configuration(s).", exception, ReporterSinkType.KAFKA);
     }
 
     String brokers = properties.getProperty(ConfigurationKeys.METRICS_KAFKA_BROKERS);
@@ -87,7 +90,7 @@ public class KafkaReporterFactory implements CustomCodahaleReporterFactory {
       try {
         formatEnum.buildMetricsReporter(brokers, metricsTopic.or(defaultTopic).get(), properties);
       } catch (IOException exception) {
-        log.error("Failed to create Kafka metrics reporter. Will not report metrics to Kafka.", exception);
+        throw new MetricReporterException("Failed to create Kafka metrics reporter.", exception, ReporterSinkType.KAFKA);
       }
     }
 
@@ -115,7 +118,7 @@ public class KafkaReporterFactory implements CustomCodahaleReporterFactory {
 
         return reporter;
       } catch (IOException exception) {
-        log.error("Failed to create Kafka events reporter. Will not report events to Kafka.", exception);
+        throw new EventReporterException("Failed to create Kafka events reporter.", exception, ReporterSinkType.KAFKA);
       }
     }
 

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/mapreduce/MRJobLauncher.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/mapreduce/MRJobLauncher.java
@@ -73,7 +73,9 @@ import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.fsm.FiniteStateMachine;
 import org.apache.gobblin.metastore.FsStateStore;
 import org.apache.gobblin.metastore.StateStore;
+import org.apache.gobblin.metrics.EventReporterException;
 import org.apache.gobblin.metrics.GobblinMetrics;
+import org.apache.gobblin.metrics.MetricReporterException;
 import org.apache.gobblin.metrics.Tag;
 import org.apache.gobblin.metrics.event.CountEventBuilder;
 import org.apache.gobblin.metrics.event.JobEvent;
@@ -783,8 +785,14 @@ public class MRJobLauncher extends AbstractJobLauncher {
       if (Boolean.valueOf(
           configuration.get(ConfigurationKeys.METRICS_ENABLED_KEY, ConfigurationKeys.DEFAULT_METRICS_ENABLED))) {
         this.jobMetrics = Optional.of(JobMetrics.get(this.jobState));
-        this.jobMetrics.get()
-            .startMetricReportingWithFileSuffix(gobblinJobState, context.getTaskAttemptID().toString());
+        try {
+          this.jobMetrics.get()
+              .startMetricReportingWithFileSuffix(gobblinJobState, context.getTaskAttemptID().toString());
+        } catch (MetricReporterException e) {
+          LOG.error("Failed to start {} metric reporter.", e.getType().name(), e);
+        } catch (EventReporterException e) {
+          LOG.error("Failed to start {} event reporter.", e.getType().name(), e);
+        }
       }
     }
 

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/services/MetricsReportingService.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/services/MetricsReportingService.java
@@ -21,12 +21,17 @@ import java.util.Properties;
 
 import com.google.common.util.concurrent.AbstractIdleService;
 
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.gobblin.metrics.EventReporterException;
 import org.apache.gobblin.metrics.GobblinMetrics;
+import org.apache.gobblin.metrics.MetricReporterException;
 
 
 /**
  * A {@link com.google.common.util.concurrent.Service} for handling life cycle events around {@link GobblinMetrics}.
  */
+@Slf4j
 public class MetricsReportingService extends AbstractIdleService {
 
   private final Properties properties;
@@ -39,7 +44,13 @@ public class MetricsReportingService extends AbstractIdleService {
 
   @Override
   protected void startUp() throws Exception {
-    GobblinMetrics.get(this.appId).startMetricReporting(this.properties);
+    try {
+      GobblinMetrics.get(this.appId).startMetricReporting(this.properties);
+    } catch (MetricReporterException e) {
+      log.error("Failed to start {} metric reporter", e.getType().name(), e);
+    } catch (EventReporterException e) {
+      log.error("Failed to start {} event reporter", e.getType().name(), e);
+    }
   }
 
   @Override

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnService.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnService.java
@@ -99,7 +99,9 @@ import org.apache.gobblin.cluster.GobblinClusterUtils;
 import org.apache.gobblin.cluster.HelixUtils;
 import org.apache.gobblin.cluster.event.ClusterManagerShutdownRequest;
 import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.metrics.EventReporterException;
 import org.apache.gobblin.metrics.GobblinMetrics;
+import org.apache.gobblin.metrics.MetricReporterException;
 import org.apache.gobblin.metrics.Tag;
 import org.apache.gobblin.metrics.event.EventSubmitter;
 import org.apache.gobblin.util.ConfigUtils;
@@ -402,7 +404,13 @@ public class YarnService extends AbstractIdleService {
 
     // Intialize Gobblin metrics and start reporters
     GobblinMetrics gobblinMetrics = GobblinMetrics.get(this.applicationId, null, tags.build());
-    gobblinMetrics.startMetricReporting(ConfigUtils.configToProperties(config));
+    try {
+      gobblinMetrics.startMetricReporting(ConfigUtils.configToProperties(config));
+    } catch (MetricReporterException  e) {
+      LOGGER.error("Failed to start {} metric reporter.", e.getType().name(), e);
+    } catch (EventReporterException e) {
+      LOGGER.error("Failed to start {} event reporter.", e.getType().name(), e);
+    }
 
     return gobblinMetrics;
   }


### PR DESCRIPTION
…n failures fatal

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1127


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
This option allows GobblinTaskRunner to "fail-fast" on metric reporting instantiation failures. This is particularly sseful in scenarios where pipeline monitoring depends on metrics and tracking events being emitted.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Added unit tests.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

