### PR TITLE
[GOBBLIN-1135] added back flow remove feature for spec executors when dag manager is disabled

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/runtime/api/SpecExecutor.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/runtime/api/SpecExecutor.java
@@ -53,7 +53,7 @@ public interface SpecExecutor {
 
   /** A communication socket for generating spec to assigned physical executors, paired with
    * a consumer on the physical executor side. */
-  Future<? extends SpecProducer> getProducer();
+  Future<? extends SpecProducer<Spec>> getProducer();
 
   public static enum Verb {
     ADD(1, "add"),

--- a/gobblin-modules/gobblin-azkaban/src/main/java/org/apache/gobblin/service/modules/orchestration/AzkabanSpecExecutor.java
+++ b/gobblin-modules/gobblin-azkaban/src/main/java/org/apache/gobblin/service/modules/orchestration/AzkabanSpecExecutor.java
@@ -70,7 +70,7 @@ public class AzkabanSpecExecutor extends AbstractSpecExecutor {
 
 
   @Override
-  public Future<? extends SpecProducer> getProducer() {
+  public Future<? extends SpecProducer<Spec>> getProducer() {
     return new CompletedFuture<>(this.azkabanSpecProducer, null);
   }
 

--- a/gobblin-modules/gobblin-service-kafka/src/main/java/org/apache/gobblin/service/SimpleKafkaSpecExecutor.java
+++ b/gobblin-modules/gobblin-service-kafka/src/main/java/org/apache/gobblin/service/SimpleKafkaSpecExecutor.java
@@ -58,7 +58,7 @@ public class SimpleKafkaSpecExecutor extends AbstractSpecExecutor {
   }
 
   @Override
-  public Future<? extends SpecProducer> getProducer() {
+  public Future<? extends SpecProducer<Spec>> getProducer() {
     return new CompletedFuture<>(this.specProducer, null);
   }
 

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_executorInstance/AbstractSpecExecutor.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_executorInstance/AbstractSpecExecutor.java
@@ -31,6 +31,7 @@ import com.google.common.io.Closer;
 import com.google.common.util.concurrent.AbstractIdleService;
 import com.typesafe.config.Config;
 
+import org.apache.gobblin.runtime.api.Spec;
 import org.apache.gobblin.runtime.api.SpecConsumer;
 import org.apache.gobblin.service.ServiceConfigKeys;
 import org.apache.gobblin.util.ConfigUtils;
@@ -182,7 +183,7 @@ public abstract class AbstractSpecExecutor extends AbstractIdleService implement
 
   abstract protected void shutDown() throws Exception;
 
-  abstract public Future<? extends SpecProducer> getProducer();
+  abstract public Future<? extends SpecProducer<Spec>> getProducer();
 
   abstract public Future<String> getDescription();
 }

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_executorInstance/InMemorySpecExecutor.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_executorInstance/InMemorySpecExecutor.java
@@ -76,8 +76,8 @@ public class InMemorySpecExecutor extends AbstractSpecExecutor {
   }
 
   @Override
-  public Future<? extends SpecProducer> getProducer(){
-    return new CompletedFuture(this.inMemorySpecProducer, null);
+  public Future<? extends SpecProducer<Spec>> getProducer(){
+    return new CompletedFuture<>(this.inMemorySpecProducer, null);
   }
 
   @Override

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_executorInstance/LocalFsSpecExecutor.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_executorInstance/LocalFsSpecExecutor.java
@@ -52,8 +52,8 @@ public class LocalFsSpecExecutor extends AbstractSpecExecutor {
   }
 
   @Override
-  public Future<? extends SpecProducer> getProducer(){
-    return new CompletedFuture(this.specProducer, null);
+  public Future<? extends SpecProducer<Spec>> getProducer(){
+    return new CompletedFuture<>(this.specProducer, null);
   }
 
   @Override

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_executorInstance/MockedSpecExecutor.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/spec_executorInstance/MockedSpecExecutor.java
@@ -54,7 +54,7 @@ public class MockedSpecExecutor extends InMemorySpecExecutor {
   }
 
   @Override
-  public Future<? extends SpecProducer> getProducer(){
-    return new CompletedFuture(this.mockedSpecProducer, null);
+  public Future<? extends SpecProducer<Spec>> getProducer(){
+    return new CompletedFuture<>(this.mockedSpecProducer, null);
   }
 }

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/flow/MultiHopFlowCompilerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/flow/MultiHopFlowCompilerTest.java
@@ -761,7 +761,7 @@ public class MultiHopFlowCompilerTest {
     }
 
     @Override
-    public Future<? extends SpecProducer> getProducer() {
+    public Future<? extends SpecProducer<Spec>> getProducer() {
       return new CompletedFuture<>(this.azkabanSpecProducer, null);
     }
 


### PR DESCRIPTION

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1135


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

added back flow remove feature for spec executors when dag manager is disabled. this is a partial rollback of PR # 2674

some codestyle changes

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
trivial changes, just a partial roll back of PR # 2674

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

