### PR TITLE
[GOBBLIN-1136]Make LogCopier be able to refresh FileSystem for long running job use cases

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -309,6 +309,8 @@ public class ConfigurationKeys {
   /**
    * Converter configuration properties.
    */
+  public static final String CONVERTER_PRESERVE_SCHEMA_CREATION_TIME = "converter.preserve.schema.creation.time";
+  public static final Boolean DEFAULT_CONVERTER_PRESERVE_SCHEMA_CREATION_TIME = true;
   public static final String CONVERTER_AVRO_DATE_FORMAT = "converter.avro.date.format";
   public static final String CONVERTER_AVRO_DATE_TIMEZONE = "converter.avro.date.timezone";
   public static final String CONVERTER_AVRO_TIME_FORMAT = "converter.avro.time.format";
@@ -848,6 +850,7 @@ public class ConfigurationKeys {
   public static final String KAFKA_SCHEMA_REGISTRY_RETRY_TIMES = "kafka.schema.registry.retry.times";
   public static final String KAFKA_SCHEMA_REGISTRY_RETRY_INTERVAL_IN_MILLIS =
       "kafka.schema.registry.retry.interval.inMillis";
+  public static final String SCHEMA_CREATION_TIME_KEY = "CreatedOn";
 
   /**
    * Job execution info server and history store configuration properties.

--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -309,8 +309,8 @@ public class ConfigurationKeys {
   /**
    * Converter configuration properties.
    */
-  public static final String CONVERTER_PRESERVE_SCHEMA_CREATION_TIME = "converter.preserve.schema.creation.time";
-  public static final Boolean DEFAULT_CONVERTER_PRESERVE_SCHEMA_CREATION_TIME = true;
+  public static final String CONVERTER_AVRO_INCLUDE_SCHEMA_CREATION_TIME = "converter.avro.include.schema.creation.time";
+  public static final Boolean DEFAULT_CONVERTER_AVRO_INCLUDE_SCHEMA_CREATION_TIME = true;
   public static final String CONVERTER_AVRO_DATE_FORMAT = "converter.avro.date.format";
   public static final String CONVERTER_AVRO_DATE_TIMEZONE = "converter.avro.date.timezone";
   public static final String CONVERTER_AVRO_TIME_FORMAT = "converter.avro.time.format";

--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -309,7 +309,7 @@ public class ConfigurationKeys {
   /**
    * Converter configuration properties.
    */
-  public static final String CONVERTER_AVRO_INCLUDE_SCHEMA_CREATION_TIME = "converter.avro.include.schema.creation.time";
+  public static final String CONVERTER_AVRO_INCLUDE_SCHEMA_CREATION_TIME_KEY = "converter.avro.include.schema.creation.time";
   public static final Boolean DEFAULT_CONVERTER_AVRO_INCLUDE_SCHEMA_CREATION_TIME = true;
   public static final String CONVERTER_AVRO_DATE_FORMAT = "converter.avro.date.format";
   public static final String CONVERTER_AVRO_DATE_TIMEZONE = "converter.avro.date.timezone";
@@ -850,7 +850,6 @@ public class ConfigurationKeys {
   public static final String KAFKA_SCHEMA_REGISTRY_RETRY_TIMES = "kafka.schema.registry.retry.times";
   public static final String KAFKA_SCHEMA_REGISTRY_RETRY_INTERVAL_IN_MILLIS =
       "kafka.schema.registry.retry.interval.inMillis";
-  public static final String SCHEMA_CREATION_TIME_KEY = "CreatedOn";
 
   /**
    * Job execution info server and history store configuration properties.

--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -309,8 +309,6 @@ public class ConfigurationKeys {
   /**
    * Converter configuration properties.
    */
-  public static final String CONVERTER_AVRO_INCLUDE_SCHEMA_CREATION_TIME_KEY = "converter.avro.include.schema.creation.time";
-  public static final Boolean DEFAULT_CONVERTER_AVRO_INCLUDE_SCHEMA_CREATION_TIME = true;
   public static final String CONVERTER_AVRO_DATE_FORMAT = "converter.avro.date.format";
   public static final String CONVERTER_AVRO_DATE_TIMEZONE = "converter.avro.date.timezone";
   public static final String CONVERTER_AVRO_TIME_FORMAT = "converter.avro.time.format";

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/AvroUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/AvroUtils.java
@@ -128,26 +128,37 @@ public class AvroUtils {
   public static Schema preserveCreationTime(Schema inputSchema, Schema outputSchema) {
 =======
   public static Schema addSchemaCreationTime(Schema inputSchema, Schema outputSchema) {
+<<<<<<< HEAD
 >>>>>>> address commemnts
     if (inputSchema.getProp(ConfigurationKeys.SCHEMA_CREATION_TIME_KEY) != null && outputSchema.getProp(ConfigurationKeys.SCHEMA_CREATION_TIME_KEY) == null) {
       outputSchema.addProp(ConfigurationKeys.SCHEMA_CREATION_TIME_KEY, inputSchema.getProp(ConfigurationKeys.SCHEMA_CREATION_TIME_KEY));
 >>>>>>> Add configuration to preserve schema creation time in converter
+=======
+    if (inputSchema.getProp(SCHEMA_CREATION_TIME_KEY) != null && outputSchema.getProp(ConfigurationKeys.SCHEMA_CREATION_TIME_KEY) == null) {
+      outputSchema.addProp(SCHEMA_CREATION_TIME_KEY, inputSchema.getProp(ConfigurationKeys.SCHEMA_CREATION_TIME_KEY));
+>>>>>>> address comments
     }
     return outputSchema;
   }
 
 <<<<<<< HEAD
+<<<<<<< HEAD
   public static String getSchemaCreationTime(Schema inputSchema) {
     return inputSchema.getProp(SCHEMA_CREATION_TIME_KEY);
   }
 
+=======
+>>>>>>> address comments
   public static Schema setSchemaCreationTime(Schema inputSchema, String creationTime) {
     inputSchema.addProp(SCHEMA_CREATION_TIME_KEY, creationTime);
     return inputSchema;
   }
 
+<<<<<<< HEAD
 =======
 >>>>>>> Add configuration to preserve schema creation time in converter
+=======
+>>>>>>> address comments
   public static List<Field> deepCopySchemaFields(Schema readerSchema) {
     return readerSchema.getFields().stream()
         .map(field -> {

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/AvroUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/AvroUtils.java
@@ -120,11 +120,15 @@ public class AvroUtils {
   }
 
 <<<<<<< HEAD
+<<<<<<< HEAD
   public static Schema addSchemaCreationTime(Schema inputSchema, Schema outputSchema) {
     if (inputSchema.getProp(SCHEMA_CREATION_TIME_KEY) != null && outputSchema.getProp(SCHEMA_CREATION_TIME_KEY) == null) {
       outputSchema.addProp(SCHEMA_CREATION_TIME_KEY, inputSchema.getProp(SCHEMA_CREATION_TIME_KEY));
 =======
   public static Schema preserveCreationTime(Schema inputSchema, Schema outputSchema) {
+=======
+  public static Schema addSchemaCreationTime(Schema inputSchema, Schema outputSchema) {
+>>>>>>> address commemnts
     if (inputSchema.getProp(ConfigurationKeys.SCHEMA_CREATION_TIME_KEY) != null && outputSchema.getProp(ConfigurationKeys.SCHEMA_CREATION_TIME_KEY) == null) {
       outputSchema.addProp(ConfigurationKeys.SCHEMA_CREATION_TIME_KEY, inputSchema.getProp(ConfigurationKeys.SCHEMA_CREATION_TIME_KEY));
 >>>>>>> Add configuration to preserve schema creation time in converter

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/AvroUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/AvroUtils.java
@@ -130,7 +130,7 @@ public class AvroUtils {
     return inputSchema.getProp(SCHEMA_CREATION_TIME_KEY);
   }
 
-  public static Schema addSchemaCreationTime(Schema inputSchema, String creationTime) {
+  public static Schema setSchemaCreationTime(Schema inputSchema, String creationTime) {
     inputSchema.addProp(SCHEMA_CREATION_TIME_KEY, creationTime);
     return inputSchema;
   }

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/AvroUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/AvroUtils.java
@@ -130,7 +130,7 @@ public class AvroUtils {
     return inputSchema.getProp(SCHEMA_CREATION_TIME_KEY);
   }
 
-  public static Schema setSchemaCreationTime(Schema inputSchema, String creationTime) {
+  public static Schema addSchemaCreationTime(Schema inputSchema, String creationTime) {
     inputSchema.addProp(SCHEMA_CREATION_TIME_KEY, creationTime);
     return inputSchema;
   }

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/AvroUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/AvroUtils.java
@@ -119,13 +119,20 @@ public class AvroUtils {
     return SchemaCompatibility.checkReaderWriterCompatibility(readerSchema, writerSchema).getType().equals(SchemaCompatibility.SchemaCompatibilityType.COMPATIBLE);
   }
 
+<<<<<<< HEAD
   public static Schema addSchemaCreationTime(Schema inputSchema, Schema outputSchema) {
     if (inputSchema.getProp(SCHEMA_CREATION_TIME_KEY) != null && outputSchema.getProp(SCHEMA_CREATION_TIME_KEY) == null) {
       outputSchema.addProp(SCHEMA_CREATION_TIME_KEY, inputSchema.getProp(SCHEMA_CREATION_TIME_KEY));
+=======
+  public static Schema preserveCreationTime(Schema inputSchema, Schema outputSchema) {
+    if (inputSchema.getProp(ConfigurationKeys.SCHEMA_CREATION_TIME_KEY) != null && outputSchema.getProp(ConfigurationKeys.SCHEMA_CREATION_TIME_KEY) == null) {
+      outputSchema.addProp(ConfigurationKeys.SCHEMA_CREATION_TIME_KEY, inputSchema.getProp(ConfigurationKeys.SCHEMA_CREATION_TIME_KEY));
+>>>>>>> Add configuration to preserve schema creation time in converter
     }
     return outputSchema;
   }
 
+<<<<<<< HEAD
   public static String getSchemaCreationTime(Schema inputSchema) {
     return inputSchema.getProp(SCHEMA_CREATION_TIME_KEY);
   }
@@ -135,6 +142,8 @@ public class AvroUtils {
     return inputSchema;
   }
 
+=======
+>>>>>>> Add configuration to preserve schema creation time in converter
   public static List<Field> deepCopySchemaFields(Schema readerSchema) {
     return readerSchema.getFields().stream()
         .map(field -> {

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/AvroUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/AvroUtils.java
@@ -119,46 +119,22 @@ public class AvroUtils {
     return SchemaCompatibility.checkReaderWriterCompatibility(readerSchema, writerSchema).getType().equals(SchemaCompatibility.SchemaCompatibilityType.COMPATIBLE);
   }
 
-<<<<<<< HEAD
-<<<<<<< HEAD
   public static Schema addSchemaCreationTime(Schema inputSchema, Schema outputSchema) {
     if (inputSchema.getProp(SCHEMA_CREATION_TIME_KEY) != null && outputSchema.getProp(SCHEMA_CREATION_TIME_KEY) == null) {
       outputSchema.addProp(SCHEMA_CREATION_TIME_KEY, inputSchema.getProp(SCHEMA_CREATION_TIME_KEY));
-=======
-  public static Schema preserveCreationTime(Schema inputSchema, Schema outputSchema) {
-=======
-  public static Schema addSchemaCreationTime(Schema inputSchema, Schema outputSchema) {
-<<<<<<< HEAD
->>>>>>> address commemnts
-    if (inputSchema.getProp(ConfigurationKeys.SCHEMA_CREATION_TIME_KEY) != null && outputSchema.getProp(ConfigurationKeys.SCHEMA_CREATION_TIME_KEY) == null) {
-      outputSchema.addProp(ConfigurationKeys.SCHEMA_CREATION_TIME_KEY, inputSchema.getProp(ConfigurationKeys.SCHEMA_CREATION_TIME_KEY));
->>>>>>> Add configuration to preserve schema creation time in converter
-=======
-    if (inputSchema.getProp(SCHEMA_CREATION_TIME_KEY) != null && outputSchema.getProp(ConfigurationKeys.SCHEMA_CREATION_TIME_KEY) == null) {
-      outputSchema.addProp(SCHEMA_CREATION_TIME_KEY, inputSchema.getProp(ConfigurationKeys.SCHEMA_CREATION_TIME_KEY));
->>>>>>> address comments
     }
     return outputSchema;
   }
 
-<<<<<<< HEAD
-<<<<<<< HEAD
   public static String getSchemaCreationTime(Schema inputSchema) {
     return inputSchema.getProp(SCHEMA_CREATION_TIME_KEY);
   }
 
-=======
->>>>>>> address comments
   public static Schema setSchemaCreationTime(Schema inputSchema, String creationTime) {
     inputSchema.addProp(SCHEMA_CREATION_TIME_KEY, creationTime);
     return inputSchema;
   }
 
-<<<<<<< HEAD
-=======
->>>>>>> Add configuration to preserve schema creation time in converter
-=======
->>>>>>> address comments
   public static List<Field> deepCopySchemaFields(Schema readerSchema) {
     return readerSchema.getFields().stream()
         .map(field -> {
@@ -500,7 +476,7 @@ public class AvroUtils {
   }
 
   public static void writeSchemaToFile(Schema schema, Path filePath, FileSystem fs, boolean overwrite, FsPermission perm)
-    throws IOException {
+      throws IOException {
     writeSchemaToFile(schema, filePath, null, fs, overwrite, perm);
   }
 
@@ -938,7 +914,7 @@ public class AvroUtils {
     List<Field> newOutputFields = Stream.concat(outputFields.stream(), fieldList.stream()).collect(Collectors.toList());
 
     Schema outputSchema = Schema.createRecord(inputSchema.getName(), inputSchema.getDoc(),
-            inputSchema.getNamespace(), inputSchema.isError());
+        inputSchema.getNamespace(), inputSchema.isError());
     outputSchema.setFields(newOutputFields);
     copyProperties(inputSchema, outputSchema);
     return outputSchema;
@@ -956,7 +932,7 @@ public class AvroUtils {
    * @return an outputRecord that contains a union of the fields in the inputRecord and the field-values in the fieldMap
    */
   public static GenericRecord decorateRecord(GenericRecord inputRecord, @Nonnull Map<String, Object> fieldMap,
-          Schema outputSchema) {
+      Schema outputSchema) {
     GenericRecord outputRecord = new GenericData.Record(outputSchema);
     inputRecord.getSchema().getFields().forEach(f -> outputRecord.put(f.name(), inputRecord.get(f.name())));
     fieldMap.forEach((key, value) -> outputRecord.put(key, value));

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/filesystem/FileSystemSupplier.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/filesystem/FileSystemSupplier.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.util.filesystem;
+
+import java.io.IOException;
+import org.apache.hadoop.fs.FileSystem;
+
+
+/**
+ * An interface of supplier to get FileSystem
+ */
+
+public interface FileSystemSupplier {
+  /**
+   * Function to get fileSystem
+   * @return the new FileSystem for using
+   */
+  public FileSystem getFileSystem() throws IOException;
+}

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnAppMasterSecurityManager.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnAppMasterSecurityManager.java
@@ -21,6 +21,7 @@ import com.google.common.base.Throwables;
 import com.google.common.eventbus.EventBus;
 import com.typesafe.config.Config;
 import java.io.IOException;
+import org.apache.gobblin.util.logs.LogCopier;
 import org.apache.gobblin.yarn.event.DelegationTokenUpdatedEvent;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -29,8 +30,8 @@ import org.apache.hadoop.fs.Path;
 public class YarnAppMasterSecurityManager extends YarnContainerSecurityManager{
 
   private YarnService yarnService;
-  public YarnAppMasterSecurityManager(Config config, FileSystem fs, EventBus eventBus, YarnService yarnService) {
-    super(config, fs, eventBus);
+  public YarnAppMasterSecurityManager(Config config, FileSystem fs, EventBus eventBus, LogCopier logCopier, YarnService yarnService) {
+    super(config, fs, eventBus, logCopier);
     this.yarnService = yarnService;
   }
 


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1136


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Make LogCopier be able to refresh FileSystem for long running job use cases

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Run test pipeline to make sure the fs instance in LogCopier get updated

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

