### PR TITLE
[GOBBLIN-1141] add support for common job properties in helix job scheduler

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterManager.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterManager.java
@@ -140,11 +140,11 @@ public class GobblinClusterManager implements ApplicationLauncher, StandardMetri
   @Getter
   protected final Config config;
 
-  public GobblinClusterManager(String clusterName, String applicationId, Config config,
+  public GobblinClusterManager(String clusterName, String applicationId, Config sysConfig,
       Optional<Path> appWorkDirOptional) throws Exception {
     this.clusterName = clusterName;
-    this.config = config;
-    this.isStandaloneMode = ConfigUtils.getBoolean(config, GobblinClusterConfigurationKeys.STANDALONE_CLUSTER_MODE_KEY,
+    this.config = sysConfig;
+    this.isStandaloneMode = ConfigUtils.getBoolean(sysConfig, GobblinClusterConfigurationKeys.STANDALONE_CLUSTER_MODE_KEY,
         GobblinClusterConfigurationKeys.DEFAULT_STANDALONE_CLUSTER_MODE);
 
     this.applicationId = applicationId;
@@ -152,13 +152,13 @@ public class GobblinClusterManager implements ApplicationLauncher, StandardMetri
     // Set system properties passed in via application config. As an example, Helix uses System#getProperty() for ZK configuration
     // overrides such as sessionTimeout. In this case, the overrides specified
     // in the application configuration have to be extracted and set before initializing HelixManager.
-    HelixUtils.setSystemProperties(config);
+    HelixUtils.setSystemProperties(sysConfig);
 
     initializeHelixManager();
 
-    this.fs = GobblinClusterUtils.buildFileSystem(config, new Configuration());
+    this.fs = GobblinClusterUtils.buildFileSystem(sysConfig, new Configuration());
     this.appWorkDir = appWorkDirOptional.isPresent() ? appWorkDirOptional.get()
-        : GobblinClusterUtils.getAppWorkDirPathFromConfig(config, this.fs, clusterName, applicationId);
+        : GobblinClusterUtils.getAppWorkDirPathFromConfig(sysConfig, this.fs, clusterName, applicationId);
     LOGGER.info("Configured GobblinClusterManager work dir to: {}", this.appWorkDir);
 
     initializeAppLauncherAndServices();
@@ -361,9 +361,9 @@ public class GobblinClusterManager implements ApplicationLauncher, StandardMetri
   /**
    * Build the {@link GobblinHelixJobScheduler} for the Application Master.
    */
-  private GobblinHelixJobScheduler buildGobblinHelixJobScheduler(Config config, Path appWorkDir,
+  private GobblinHelixJobScheduler buildGobblinHelixJobScheduler(Config sysConfig, Path appWorkDir,
       List<? extends Tag<?>> metadataTags, SchedulerService schedulerService) throws Exception {
-    return new GobblinHelixJobScheduler(config,
+    return new GobblinHelixJobScheduler(sysConfig,
         this.multiManager.getJobClusterHelixManager(),
         this.multiManager.getTaskDriverHelixManager(),
         this.eventBus,

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterManager.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterManager.java
@@ -149,7 +149,7 @@ public class GobblinClusterManager implements ApplicationLauncher, StandardMetri
 
     this.applicationId = applicationId;
 
-    //Set system properties passed in via application config. As an example, Helix uses System#getProperty() for ZK configuration
+    // Set system properties passed in via application config. As an example, Helix uses System#getProperty() for ZK configuration
     // overrides such as sessionTimeout. In this case, the overrides specified
     // in the application configuration have to be extracted and set before initializing HelixManager.
     HelixUtils.setSystemProperties(config);
@@ -363,8 +363,7 @@ public class GobblinClusterManager implements ApplicationLauncher, StandardMetri
    */
   private GobblinHelixJobScheduler buildGobblinHelixJobScheduler(Config config, Path appWorkDir,
       List<? extends Tag<?>> metadataTags, SchedulerService schedulerService) throws Exception {
-    Properties properties = ConfigUtils.configToProperties(config);
-    return new GobblinHelixJobScheduler(properties,
+    return new GobblinHelixJobScheduler(config,
         this.multiManager.getJobClusterHelixManager(),
         this.multiManager.getTaskDriverHelixManager(),
         this.eventBus,

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobScheduler.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobScheduler.java
@@ -110,7 +110,7 @@ public class GobblinHelixJobScheduler extends JobScheduler implements StandardMe
   private boolean startServicesCompleted;
   private final long helixJobStopTimeoutMillis;
 
-  public GobblinHelixJobScheduler(Config configs,
+  public GobblinHelixJobScheduler(Config sysConfig,
                                   HelixManager jobHelixManager,
                                   Optional<HelixManager> taskDriverHelixManager,
                                   EventBus eventBus,
@@ -118,8 +118,8 @@ public class GobblinHelixJobScheduler extends JobScheduler implements StandardMe
                                   SchedulerService schedulerService,
                                   MutableJobCatalog jobCatalog) throws Exception {
 
-    super(ConfigUtils.configToProperties(configs), schedulerService);
-    this.commonJobProperties = ConfigUtils.configToProperties(ConfigUtils.getConfigOrEmpty(configs, COMMON_JOB_PROPS));
+    super(ConfigUtils.configToProperties(sysConfig), schedulerService);
+    this.commonJobProperties = ConfigUtils.configToProperties(ConfigUtils.getConfigOrEmpty(sysConfig, COMMON_JOB_PROPS));
     this.jobHelixManager = jobHelixManager;
     this.taskDriverHelixManager = taskDriverHelixManager;
     this.eventBus = eventBus;
@@ -129,7 +129,7 @@ public class GobblinHelixJobScheduler extends JobScheduler implements StandardMe
     this.jobCatalog = jobCatalog;
     this.metricContext = Instrumented.getMetricContext(new org.apache.gobblin.configuration.State(properties), this.getClass());
 
-    int metricsWindowSizeInMin = ConfigUtils.getInt(configs,
+    int metricsWindowSizeInMin = ConfigUtils.getInt(sysConfig,
                                                     ConfigurationKeys.METRIC_TIMER_WINDOW_SIZE_IN_MINUTES,
                                                     ConfigurationKeys.DEFAULT_METRIC_TIMER_WINDOW_SIZE_IN_MINUTES);
 
@@ -155,10 +155,10 @@ public class GobblinHelixJobScheduler extends JobScheduler implements StandardMe
 
     this.startServicesCompleted = false;
 
-    this.helixJobStopTimeoutMillis = ConfigUtils.getLong(configs, GobblinClusterConfigurationKeys.HELIX_JOB_STOP_TIMEOUT_SECONDS,
+    this.helixJobStopTimeoutMillis = ConfigUtils.getLong(sysConfig, GobblinClusterConfigurationKeys.HELIX_JOB_STOP_TIMEOUT_SECONDS,
         GobblinClusterConfigurationKeys.DEFAULT_HELIX_JOB_STOP_TIMEOUT_SECONDS) * 1000;
 
-    this.helixWorkflowListingTimeoutMillis = ConfigUtils.getLong(configs, GobblinClusterConfigurationKeys.HELIX_WORKFLOW_LISTING_TIMEOUT_SECONDS,
+    this.helixWorkflowListingTimeoutMillis = ConfigUtils.getLong(sysConfig, GobblinClusterConfigurationKeys.HELIX_WORKFLOW_LISTING_TIMEOUT_SECONDS,
         GobblinClusterConfigurationKeys.DEFAULT_HELIX_WORKFLOW_LISTING_TIMEOUT_SECONDS) * 1000;
 
   }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below! @yukuai518  please review


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1141


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
 - It makes GobblinHelixJobScheduler save common job configs and apply them to every job it receives.
This way, we can handle common configs at one place.

 - does some minor codestyle changes which includes unnecessary to and fro conversions of Properties and Config

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
trivial changes

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

