### PR TITLE
[GOBBLIN-1142] Hive Distcp support filter on partitioned or snapshot tables

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/predicates/TableTypeFilter.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/predicates/TableTypeFilter.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.data.management.copy.predicates;
+
+import java.util.Properties;
+
+import org.apache.hadoop.hive.metastore.api.Table;
+
+import com.google.common.base.Predicate;
+
+import javax.annotation.Nullable;
+
+
+/**
+ * A predicate to check if a hive {@link Table} is of a certain type in {@link TABLE_TYPE}
+ *
+ * <p> Example usage: {@link org.apache.gobblin.data.management.copy.hive.HiveDatasetFinder#TABLE_FILTER}
+ */
+public class TableTypeFilter implements Predicate<Table> {
+
+  public static final String FILTER_TYPE = "tableTypeFilter.type";
+
+  private enum TABLE_TYPE {
+    SNAPSHOT,
+    PARTITIONED
+  }
+
+  private final TABLE_TYPE tableType;
+
+  public TableTypeFilter(Properties props) {
+    tableType = TABLE_TYPE.valueOf(
+        props.getProperty(FILTER_TYPE, TABLE_TYPE.SNAPSHOT.name()).toUpperCase());
+  }
+
+  @Override
+  public boolean apply(@Nullable Table input) {
+    if (input == null) {
+      return false;
+    }
+
+    switch (tableType) {
+      case SNAPSHOT:
+        return input.getPartitionKeys() == null || input.getPartitionKeys().size() == 0;
+      case PARTITIONED:
+        return input.getPartitionKeys() != null && input.getPartitionKeys().size() > 0;
+    }
+
+    throw new UnsupportedOperationException("Invalid state");
+  }
+}

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/predicates/TableTypeFilter.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/predicates/TableTypeFilter.java
@@ -58,8 +58,8 @@ public class TableTypeFilter implements Predicate<Table> {
         return input.getPartitionKeys() == null || input.getPartitionKeys().size() == 0;
       case PARTITIONED:
         return input.getPartitionKeys() != null && input.getPartitionKeys().size() > 0;
+      default:
+        throw new UnsupportedOperationException("Invalid state");
     }
-
-    throw new UnsupportedOperationException("Invalid state");
   }
 }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/predicates/TableTypeFilter.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/predicates/TableTypeFilter.java
@@ -59,7 +59,7 @@ public class TableTypeFilter implements Predicate<Table> {
       case PARTITIONED:
         return input.getPartitionKeys() != null && input.getPartitionKeys().size() > 0;
       default:
-        throw new UnsupportedOperationException("Invalid state");
+        throw new UnsupportedOperationException("Invalid type: " + tableType);
     }
   }
 }


### PR DESCRIPTION
…table

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/GOBBLIN-1142


### Description
- [x] Here are some details about my PR:
 - The change adds support filtering a specific type of tables, e.g snapshot, partitioned, in `HiveDatasetFinder`


### Tests
- [x] My PR adds the following unit tests:
 - `HiveDatasetFinderTest.testTableFilter` configures `TableTypeFilter` and verifies all datasets found were either snapshots or partitioned tables.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

