### PR TITLE
[GOBBLIN-1152] enable helix instance only if it is a participant

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinTaskRunner.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinTaskRunner.java
@@ -418,8 +418,10 @@ public class GobblinTaskRunner implements StandardMetricsBridge {
   @VisibleForTesting
   void connectHelixManager() throws Exception {
     this.jobHelixManager.connect();
-    //Ensure the instance is enabled.
-    this.jobHelixManager.getClusterManagmentTool().enableInstance(clusterName, helixInstanceName, true);
+    if (!(this.isTaskDriver && this.dedicatedTaskDriverCluster)) {
+      // Ensure the instance is enabled when jobHelixManager is a PARTICIPANT
+      this.jobHelixManager.getClusterManagmentTool().enableInstance(clusterName, helixInstanceName, true);
+    }
     this.jobHelixManager.getMessagingService()
         .registerMessageHandlerFactory(GobblinHelixConstants.SHUTDOWN_MESSAGE_TYPE,
             new ParticipantShutdownMessageHandlerFactory());


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1152


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
enable Helix Instance only if is a participant.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
existing test cases

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

