### PR TITLE
[GOBBLIN-1154] Improve gaas error messages

### DIFF
--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/TimingEvent.java
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/TimingEvent.java
@@ -70,6 +70,7 @@ public class TimingEvent extends GobblinEventBuilder implements Closeable {
     public static final String FLOW_SUCCEEDED = "FlowSucceeded";
     public static final String FLOW_FAILED = "FlowFailed";
     public static final String FLOW_RUNNING = "FlowRunning";
+    public static final String FLOW_CANCELLED = "FlowCancelled";
   }
 
   public static class FlowEventConstants {

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-client/src/test/java/org/apache/gobblin/service/FlowStatusTest.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-client/src/test/java/org/apache/gobblin/service/FlowStatusTest.java
@@ -28,7 +28,6 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import com.google.common.base.Joiner;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.inject.Binder;
@@ -38,7 +37,6 @@ import com.google.inject.Module;
 import com.google.inject.name.Names;
 import com.linkedin.restli.server.resources.BaseResource;
 
-import org.apache.gobblin.config.ConfigBuilder;
 import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.metastore.StateStore;
 import org.apache.gobblin.restli.EmbeddedRestliServer;
@@ -50,7 +48,6 @@ public class FlowStatusTest {
   private FlowStatusClient _client;
   private EmbeddedRestliServer _server;
   private List<List<org.apache.gobblin.service.monitoring.JobStatus>> _listOfJobStatusLists;
-  private Joiner messageJoiner;
 
   class TestJobStatusRetriever extends JobStatusRetriever {
     @Override
@@ -85,8 +82,6 @@ public class FlowStatusTest {
 
   @BeforeClass
   public void setUp() throws Exception {
-    ConfigBuilder configBuilder = ConfigBuilder.create();
-
     JobStatusRetriever jobStatusRetriever = new TestJobStatusRetriever();
     final FlowStatusGenerator flowStatusGenerator =
         FlowStatusGenerator.builder().jobStatusRetriever(jobStatusRetriever).build();
@@ -107,8 +102,6 @@ public class FlowStatusTest {
 
     _client =
         new FlowStatusClient(String.format("http://localhost:%s/", _server.getPort()));
-
-    messageJoiner = Joiner.on(FlowStatusResource.MESSAGE_SEPARATOR);
   }
 
   /**
@@ -134,7 +127,7 @@ public class FlowStatusTest {
         .processedCount(200).jobExecutionId(2).lowWatermark("watermark:2").highWatermark("watermark:3").build();
     org.apache.gobblin.service.monitoring.JobStatus fs2 = org.apache.gobblin.service.monitoring.JobStatus.builder().flowGroup("fgroup1")
         .flowName("flow1").jobGroup(JobStatusRetriever.NA_KEY).jobName(JobStatusRetriever.NA_KEY).endTime(7000L)
-        .eventName(ExecutionStatus.COMPLETE.name()).flowExecutionId(1).build();
+        .eventName(ExecutionStatus.COMPLETE.name()).flowExecutionId(1).message("Flow message").build();
     List<org.apache.gobblin.service.monitoring.JobStatus> jobStatusList1 = Lists.newArrayList(js1, fs1);
     List<org.apache.gobblin.service.monitoring.JobStatus> jobStatusList2 = Lists.newArrayList(js2, js3, fs2);
     _listOfJobStatusLists = Lists.newArrayList();
@@ -148,7 +141,7 @@ public class FlowStatusTest {
     Assert.assertEquals(flowStatus.getId().getFlowName(), "flow1");
     Assert.assertEquals(flowStatus.getExecutionStatistics().getExecutionStartTime().longValue(), 1L);
     Assert.assertEquals(flowStatus.getExecutionStatistics().getExecutionEndTime().longValue(), 7000L);
-    Assert.assertEquals(flowStatus.getMessage(), messageJoiner.join(js2.getMessage(), js3.getMessage()));
+    Assert.assertEquals(flowStatus.getMessage(), fs2.getMessage());
     Assert.assertEquals(flowStatus.getExecutionStatus(), ExecutionStatus.COMPLETE);
 
     JobStatusArray jobStatuses = flowStatus.getJobStatuses();
@@ -189,7 +182,7 @@ public class FlowStatusTest {
         .processedCount(200).jobExecutionId(2).lowWatermark("watermark:2").highWatermark("watermark:3").build();
     org.apache.gobblin.service.monitoring.JobStatus fs1 = org.apache.gobblin.service.monitoring.JobStatus.builder().flowGroup("fgroup1")
         .flowName("flow1").jobGroup(JobStatusRetriever.NA_KEY).jobName(JobStatusRetriever.NA_KEY).endTime(7000L)
-        .eventName(ExecutionStatus.COMPLETE.name()).flowExecutionId(0).build();
+        .eventName(ExecutionStatus.COMPLETE.name()).flowExecutionId(0).message("Flow message").build();
     List<org.apache.gobblin.service.monitoring.JobStatus> jobStatusList = Lists.newArrayList(js1, js2, fs1);
     _listOfJobStatusLists = Lists.newArrayList();
     _listOfJobStatusLists.add(jobStatusList);
@@ -201,7 +194,7 @@ public class FlowStatusTest {
     Assert.assertEquals(flowStatus.getId().getFlowName(), "flow1");
     Assert.assertEquals(flowStatus.getExecutionStatistics().getExecutionStartTime().longValue(), 0L);
     Assert.assertEquals(flowStatus.getExecutionStatistics().getExecutionEndTime().longValue(), 7000L);
-    Assert.assertEquals(flowStatus.getMessage(), messageJoiner.join(js1.getMessage(), js2.getMessage()));
+    Assert.assertEquals(flowStatus.getMessage(), fs1.getMessage());
     Assert.assertEquals(flowStatus.getExecutionStatus(), ExecutionStatus.COMPLETE);
 
     JobStatusArray jobStatuses = flowStatus.getJobStatuses();
@@ -232,7 +225,7 @@ public class FlowStatusTest {
         .processedCount(200).jobExecutionId(2).lowWatermark("watermark:2").highWatermark("watermark:3").build();
     org.apache.gobblin.service.monitoring.JobStatus fs1 = org.apache.gobblin.service.monitoring.JobStatus.builder().flowGroup("fgroup1")
         .flowName("flow1").jobGroup(JobStatusRetriever.NA_KEY).jobName(JobStatusRetriever.NA_KEY)
-        .eventName(ExecutionStatus.RUNNING.name()).flowExecutionId(0).build();
+        .eventName(ExecutionStatus.RUNNING.name()).flowExecutionId(0).message("Flow message").build();
     List<org.apache.gobblin.service.monitoring.JobStatus> jobStatusList = Lists.newArrayList(js1, js2, fs1);
     _listOfJobStatusLists = Lists.newArrayList();
     _listOfJobStatusLists.add(jobStatusList);
@@ -244,7 +237,7 @@ public class FlowStatusTest {
     Assert.assertEquals(flowStatus.getId().getFlowName(), "flow1");
     Assert.assertEquals(flowStatus.getExecutionStatistics().getExecutionStartTime().longValue(), 0L);
     Assert.assertEquals(flowStatus.getExecutionStatistics().getExecutionEndTime().longValue(), 0L);
-    Assert.assertEquals(flowStatus.getMessage(), messageJoiner.join(js1.getMessage(), js2.getMessage()));
+    Assert.assertEquals(flowStatus.getMessage(), fs1.getMessage());
     Assert.assertEquals(flowStatus.getExecutionStatus(), ExecutionStatus.RUNNING);
 
     JobStatusArray jobStatuses = flowStatus.getJobStatuses();
@@ -275,7 +268,7 @@ public class FlowStatusTest {
         .processedCount(200).jobExecutionId(2).lowWatermark("watermark:2").highWatermark("watermark:3").build();
     org.apache.gobblin.service.monitoring.JobStatus fs1 = org.apache.gobblin.service.monitoring.JobStatus.builder().flowGroup("fgroup1")
         .flowName("flow1").jobGroup(JobStatusRetriever.NA_KEY).jobName(JobStatusRetriever.NA_KEY).endTime(7000L)
-        .eventName(ExecutionStatus.FAILED.name()).flowExecutionId(0).build();
+        .eventName(ExecutionStatus.FAILED.name()).flowExecutionId(0).message("Flow message").build();
     List<org.apache.gobblin.service.monitoring.JobStatus> jobStatusList = Lists.newArrayList(js1, js2, fs1);
     _listOfJobStatusLists = Lists.newArrayList();
     _listOfJobStatusLists.add(jobStatusList);
@@ -287,7 +280,7 @@ public class FlowStatusTest {
     Assert.assertEquals(flowStatus.getId().getFlowName(), "flow1");
     Assert.assertEquals(flowStatus.getExecutionStatistics().getExecutionStartTime().longValue(), 0L);
     Assert.assertEquals(flowStatus.getExecutionStatistics().getExecutionEndTime().longValue(), 7000L);
-    Assert.assertEquals(flowStatus.getMessage(), messageJoiner.join(js1.getMessage(), js2.getMessage()));
+    Assert.assertEquals(flowStatus.getMessage(), fs1.getMessage());
     Assert.assertEquals(flowStatus.getExecutionStatus(), ExecutionStatus.FAILED);
 
     JobStatusArray jobStatuses = flowStatus.getJobStatuses();

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/Dag.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/Dag.java
@@ -31,8 +31,10 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
 import lombok.Getter;
+import lombok.Setter;
 
 import org.apache.gobblin.annotation.Alpha;
+import org.apache.gobblin.service.ExecutionStatus;
 
 
 /**
@@ -47,6 +49,11 @@ public class Dag<T> {
   // Map to maintain parent to children mapping.
   private Map<DagNode, List<DagNode<T>>> parentChildMap;
   private List<DagNode<T>> nodes;
+
+  @Setter
+  private String message;
+  @Setter
+  private String flowEvent;
 
   public Dag(List<DagNode<T>> dagNodes) {
     this.nodes = dagNodes;

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagerUtils.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagerUtils.java
@@ -31,6 +31,7 @@ import com.typesafe.config.Config;
 
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.metrics.event.EventSubmitter;
+import org.apache.gobblin.metrics.event.TimingEvent;
 import org.apache.gobblin.runtime.api.JobSpec;
 import org.apache.gobblin.runtime.api.SpecProducer;
 import org.apache.gobblin.service.ExecutionStatus;
@@ -295,6 +296,14 @@ public class DagManagerUtils {
       // Every dag node will contain the same flow metadata
       Config config = dag.getNodes().get(0).getValue().getJobSpec().getConfig();
       Map<String, String> flowMetadata = TimingEventUtils.getFlowMetadata(config);
+
+      if (dag.getFlowEvent() != null) {
+        flowEvent = dag.getFlowEvent();
+      }
+      if (dag.getMessage() != null) {
+        flowMetadata.put(TimingEvent.METADATA_MESSAGE, dag.getMessage());
+      }
+
       eventSubmitter.get().getTimingEvent(flowEvent).stop(flowMetadata);
     }
   }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/Orchestrator.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/Orchestrator.java
@@ -259,6 +259,13 @@ public class Orchestrator implements SpecCatalogListener, Instrumentable {
         // In this case, the current time is used as the flow executionId.
         flowMetadata.putIfAbsent(TimingEvent.FlowEventConstants.FLOW_EXECUTION_ID_FIELD,
             Long.toString(System.currentTimeMillis()));
+
+        String message = "Flow was not compiled successfully. It may be due to no path being found";
+        if (!((FlowSpec) spec).getCompilationErrors().isEmpty()) {
+          message = message + " or due to " + ((FlowSpec) spec).getCompilationErrors();
+        }
+        flowMetadata.put(TimingEvent.METADATA_MESSAGE, message);
+
         TimingEvent flowCompileFailedTimer = this.eventSubmitter.isPresent() ? this.eventSubmitter.get()
             .getTimingEvent(TimingEvent.FlowTimings.FLOW_COMPILE_FAILED) : null;
         Instrumented.markMeter(this.flowOrchestrationFailedMeter);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaAvroJobStatusMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaAvroJobStatusMonitor.java
@@ -148,6 +148,7 @@ public class KafkaAvroJobStatusMonitor extends KafkaJobStatusMonitor {
         properties.put(JobStatusRetriever.EVENT_NAME_FIELD, ExecutionStatus.FAILED.name());
         properties.put(TimingEvent.JOB_END_TIME, properties.getProperty(TimingEvent.METADATA_END_TIME));
         break;
+      case TimingEvent.FlowTimings.FLOW_CANCELLED:
       case TimingEvent.LauncherTimings.JOB_CANCEL:
         properties.put(JobStatusRetriever.EVENT_NAME_FIELD, ExecutionStatus.CANCELLED.name());
         properties.put(TimingEvent.JOB_END_TIME, properties.getProperty(TimingEvent.METADATA_END_TIME));


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1154


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):

Variety of improvements to GaaS error returning:

- When creating flowConfig, in case of error throw it instead of returning 4xx along with flowConfig. Returning the `CreateKVResponse` means that the the status is only seen if using `--verbose`, and there is no clear error message
- Similarly return a more clear error message when calling get for a flowExecution that doesn't exist
- Instead of concatenating execution links in the message field of flowStatus (this is not useful since they are already in the jobStatus list), use the message field to return a flow level error message
- Added a `FlowCancelled` event so that flows that were SLA killed or manually killed will have a `CANCELLED` status instead of `FAILED`

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

