### PR TITLE
[GOBBLIN-1157] handle non string type config values in ConfigUtils

### DIFF
--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/ConfigUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/ConfigUtils.java
@@ -341,14 +341,21 @@ public class ConfigUtils {
 
   /**
    * Return string value at <code>path</code> if <code>config</code> has path. If not return <code>def</code>
-   *
+   * If the config value is not of String type, it will try to get it as a generic Object type
+   * using {@see com.typesafe.config.Config#getAnyRef()} and then try to return its json representation as a string
    * @param config in which the path may be present
    * @param path key to look for in the config object
    * @return string value at <code>path</code> if <code>config</code> has path. If not return <code>def</code>
    */
   public static String getString(Config config, String path, String def) {
     if (config.hasPath(path)) {
-      return config.getString(path);
+      String value;
+      try {
+        value = config.getString(path);
+      } catch (ConfigException.WrongType wrongType) {
+        value = new Gson().toJson(config.getAnyRef(path));
+      }
+      return value;
     }
     return def;
   }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1157


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
when the value is not of string type ConfigUtils now will try to dereference it as a generic object and return its json representation

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
trivial changes, which are copied from existing code of ConfigUtils

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

