### PR TITLE
[GOBBLIN-1172] Migrate Travis build to Ubuntu 18 (bionic) with openjdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: java
 
-dist: xenial
+dist: bionic
 sudo: required
+
+jdk:
+  - openjdk8
 
 addons:
   apt:


### PR DESCRIPTION
### Description
Previously, we could not use recent LTS version of Ubuntu 18 on Travis, because openjdk8 didn't work on the build machine. So, we used Ubuntu 16 instead, which is close to end of maintenance. This issue has been resolved by Travis recently, and we can upgrade now.

### JIRA
https://issues.apache.org/jira/browse/GOBBLIN-1172
