### PR TITLE
GOBBLIN-1173: Prevent propagating exceptions from the finally block i…

### DIFF
--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSource.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSource.java
@@ -17,7 +17,6 @@
 
 package org.apache.gobblin.source.extractor.extract.kafka;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -288,16 +287,18 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
       throw new RuntimeException("Unexpected throwable caught, ", t);
     } finally {
       try {
-        if (this.kafkaConsumerClient.get() != null) {
-          this.kafkaConsumerClient.get().close();
+        GobblinKafkaConsumerClient consumerClient = this.kafkaConsumerClient.get();
+        if (consumerClient != null) {
+          consumerClient.close();
         }
-
         // cleanup clients from pool
         for (GobblinKafkaConsumerClient client: kafkaConsumerClientPool) {
           client.close();
         }
-      } catch (IOException e) {
-        throw new RuntimeException("Exception closing kafkaConsumerClient", e);
+      } catch (Throwable t) {
+        //Swallow any exceptions in the finally{..} block to allow potential exceptions from the main try{..} block to be
+        //propagated
+        LOG.error("Exception {} encountered closing GobblinKafkaConsumerClient ", t);
       }
     }
   }


### PR DESCRIPTION
…n KafkaSource#getWorkUnits

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1173


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Currently, any exception in the finally block inside getWorkUnits() method will prevent the original exception from being propagated, thus making it hard to root cause the original issue. 



### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Trivial change.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

