### PR TITLE
[GOBBLIN-1174] Fail job on FileBasedSource ls invalid source directory

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/filebased/FileBasedSource.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/filebased/FileBasedSource.java
@@ -264,7 +264,7 @@ public abstract class FileBasedSource<S, D> extends AbstractSource<S, D> {
    * directory
    */
   public List<String> getcurrentFsSnapshot(State state) {
-    List<String> results = new ArrayList<>();
+    List<String> results;
     String path = getLsPattern(state);
 
     try {

--- a/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/filebased/FileBasedSource.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/filebased/FileBasedSource.java
@@ -280,8 +280,10 @@ public abstract class FileBasedSource<S, D> extends AbstractSource<S, D> {
         results.set(i, filePath + this.splitPattern + this.fsHelper.getFileMTime(filePath));
       }
     } catch (FileBasedHelperException | URISyntaxException e) {
-      log.error("Not able to fetch the filename/file modified time to " + e.getMessage() + " will not pull any files",
-          e);
+      String errMsg = String.format(
+          "Not able to fetch the filename/file modified time to %s. Will not pull any files", e.getMessage());
+      log.error(errMsg, e);
+      throw new RuntimeException(errMsg, e);
     }
     return results;
   }

--- a/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/hadoop/AvroFileSource.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/hadoop/AvroFileSource.java
@@ -17,16 +17,11 @@
 
 package org.apache.gobblin.source.extractor.hadoop;
 
-import org.apache.gobblin.source.extractor.filebased.FileBasedHelperException;
 import java.io.IOException;
 import java.util.List;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.google.common.collect.Lists;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -34,12 +29,12 @@ import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.configuration.WorkUnitState;
 import org.apache.gobblin.source.extractor.Extractor;
+import org.apache.gobblin.source.extractor.filebased.FileBasedHelperException;
 import org.apache.gobblin.source.extractor.filebased.FileBasedSource;
 
 
 @Slf4j
 public class AvroFileSource extends FileBasedSource<Schema, GenericRecord> {
-  private static final Logger LOGGER = LoggerFactory.getLogger(AvroFileSource.class);
 
   @Override
   public Extractor<Schema, GenericRecord> getExtractor(WorkUnitState state) throws IOException {
@@ -58,7 +53,7 @@ public class AvroFileSource extends FileBasedSource<Schema, GenericRecord> {
     String path = state.getProp(ConfigurationKeys.SOURCE_FILEBASED_DATA_DIRECTORY);
 
     try {
-      LOGGER.info("Running ls command with input " + path);
+      log.info("Running ls command with input " + path);
       results = this.fsHelper.ls(path);
     } catch (FileBasedHelperException e) {
       String errMsg = String.format(

--- a/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/hadoop/AvroFileSource.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/hadoop/AvroFileSource.java
@@ -28,6 +28,8 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Lists;
 
+import lombok.extern.slf4j.Slf4j;
+
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.configuration.WorkUnitState;
@@ -35,6 +37,7 @@ import org.apache.gobblin.source.extractor.Extractor;
 import org.apache.gobblin.source.extractor.filebased.FileBasedSource;
 
 
+@Slf4j
 public class AvroFileSource extends FileBasedSource<Schema, GenericRecord> {
   private static final Logger LOGGER = LoggerFactory.getLogger(AvroFileSource.class);
 
@@ -58,7 +61,10 @@ public class AvroFileSource extends FileBasedSource<Schema, GenericRecord> {
       LOGGER.info("Running ls command with input " + path);
       results = this.fsHelper.ls(path);
     } catch (FileBasedHelperException e) {
-      LOGGER.error("Not able to run ls command due to " + e.getMessage() + " will not pull any files", e);
+      String errMsg = String.format(
+          "Not able to run ls command due to %s. Will not pull any files", e.getMessage());
+      log.error(errMsg, e);
+      throw new RuntimeException(errMsg, e);
     }
     return results;
   }

--- a/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/hadoop/AvroFileSource.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/hadoop/AvroFileSource.java
@@ -54,7 +54,7 @@ public class AvroFileSource extends FileBasedSource<Schema, GenericRecord> {
 
   @Override
   public List<String> getcurrentFsSnapshot(State state) {
-    List<String> results = Lists.newArrayList();
+    List<String> results;
     String path = state.getProp(ConfigurationKeys.SOURCE_FILEBASED_DATA_DIRECTORY);
 
     try {

--- a/gobblin-core/src/test/java/org/apache/gobblin/source/extractor/filebased/FileBasedSourceTest.java
+++ b/gobblin-core/src/test/java/org/apache/gobblin/source/extractor/filebased/FileBasedSourceTest.java
@@ -104,6 +104,17 @@ public class FileBasedSourceTest {
     Assert.assertEquals(3, workUnits.size());
   }
 
+  @Test(expectedExceptions = RuntimeException.class)
+  public void testFailOnInvalidSourceDirectory() {
+    SourceState sourceState = new SourceState();
+    sourceState.setBroker(jobBroker);
+    AvroFileSource source = new AvroFileSource();
+    initState(sourceState);
+    Path path = new Path(sourceDir, "testFailOnInvalidSourceDirectory");
+    sourceState.setProp(ConfigurationKeys.SOURCE_FILEBASED_DATA_DIRECTORY, path.toString());
+    source.getWorkunits(sourceState);
+  }
+
   @Test
   public void testSourceLineage() {
     String dataset = Path.getPathWithoutSchemeAndAuthority(sourceDir).toString();


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/GOBBLIN-1174


### Description
- [x] Here are some details about my PR:
  - Today, a gobblin job that uses a FileBasedSource will succeed on an invalid `ConfigurationKeys.SOURCE_FILEBASED_DATA_DIRECTORY`, for example the path doesn't exist. In this case, the job should fail to signal wrong configuration.

### Tests
- [x] My PR adds the following unit tests:
  - `FileBasedSourceTest.testFailOnInvalidSourceDirectory` verifies that a `RuntimeException` was thrown with an invalid path

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

