### PR TITLE
GOBBLIN-1175: Provide an option to all GobblinYarnAppLauncher to detach from Yarn application

### DIFF
--- a/gobblin-modules/gobblin-azkaban/src/main/java/org/apache/gobblin/azkaban/AzkabanGobblinYarnAppLauncher.java
+++ b/gobblin-modules/gobblin-azkaban/src/main/java/org/apache/gobblin/azkaban/AzkabanGobblinYarnAppLauncher.java
@@ -18,20 +18,23 @@
 package org.apache.gobblin.azkaban;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.TimeoutException;
 
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 
 import com.typesafe.config.Config;
+import com.typesafe.config.ConfigValueFactory;
 
 import azkaban.jobExecutor.AbstractJob;
 import lombok.Getter;
 
-import org.apache.gobblin.metrics.kafka.SchemaRegistryException;
 import org.apache.gobblin.util.ConfigUtils;
 import org.apache.gobblin.yarn.GobblinYarnAppLauncher;
+import org.apache.gobblin.yarn.GobblinYarnConfigurationKeys;
 
 
 /**
@@ -50,7 +53,7 @@ import org.apache.gobblin.yarn.GobblinYarnAppLauncher;
  * @author Yinan Li
  */
 public class AzkabanGobblinYarnAppLauncher extends AbstractJob {
-  private static final Logger LOGGER = Logger.getLogger(AzkabanJobLauncher.class);
+  private static final Logger LOGGER = Logger.getLogger(AzkabanGobblinYarnAppLauncher.class);
 
   private final GobblinYarnAppLauncher gobblinYarnAppLauncher;
 
@@ -58,13 +61,34 @@ public class AzkabanGobblinYarnAppLauncher extends AbstractJob {
   private final YarnConfiguration yarnConfiguration;
 
   public AzkabanGobblinYarnAppLauncher(String jobId, Properties gobblinProps)
-      throws IOException, SchemaRegistryException {
+      throws IOException {
     super(jobId, LOGGER);
+
     Config gobblinConfig = ConfigUtils.propertiesToConfig(gobblinProps);
+
+    //Suppress logs from classes that emit Yarn application Id that Azkaban uses to kill the application.
+    setLogLevelForClasses(gobblinConfig);
 
     yarnConfiguration = initYarnConf(gobblinProps);
 
+    gobblinConfig = gobblinConfig.withValue(GobblinYarnAppLauncher.GOBBLIN_YARN_APP_LAUNCHER_MODE,
+        ConfigValueFactory.fromAnyRef(GobblinYarnAppLauncher.AZKABAN_APP_LAUNCHER_MODE_KEY));
     this.gobblinYarnAppLauncher = new GobblinYarnAppLauncher(gobblinConfig, this.yarnConfiguration);
+  }
+
+  /**
+   * Set Log Level for each class specified in the config. Class name and the corresponding log level can be specified
+   * as "a:INFO,b:ERROR", where logs of class "a" are set to INFO and logs from class "b" are set to ERROR.
+   * @param config
+   */
+  private void setLogLevelForClasses(Config config) {
+    List<String> classLogLevels = ConfigUtils.getStringList(config, GobblinYarnConfigurationKeys.GOBBLIN_YARN_AZKABAN_CLASS_LOG_LEVELS);
+
+    for (String classLogLevel: classLogLevels) {
+      String className = classLogLevel.split(":")[0];
+      Level level = Level.toLevel(classLogLevel.split(":")[1], Level.INFO);
+      Logger.getLogger(className).setLevel(level);
+    }
   }
 
   /**

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnAppLauncher.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnAppLauncher.java
@@ -581,8 +581,8 @@ public class GobblinYarnAppLauncher {
     for (ApplicationReport applicationReport : applicationReports) {
       if (this.applicationName.equals(applicationReport.getName())) {
         String applicationId = sanitizeApplicationId(applicationReport.getApplicationId().toString());
-
         LOGGER.info("Found reconnectable application with application ID: " + applicationId);
+        LOGGER.info("Application Tracking URL: " + applicationReport.getTrackingUrl());
         return Optional.of(applicationReport.getApplicationId());
       }
     }

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnAppLauncher.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnAppLauncher.java
@@ -639,7 +639,7 @@ public class GobblinYarnAppLauncher {
     LOGGER.info("Application successfully submitted and accepted");
     ApplicationReport applicationReport = this.yarnClient.getApplicationReport(applicationId);
     LOGGER.info("Application Name: " + applicationReport.getName());
-    //LOGGER.info("Application Tracking URL: " + applicationReport.getTrackingUrl());
+    LOGGER.info("Application Tracking URL: " + applicationReport.getTrackingUrl());
     LOGGER.info("Application User: " + applicationReport.getUser() + " Queue: " + applicationReport.getQueue());
 
     return applicationId;

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnConfigurationKeys.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnConfigurationKeys.java
@@ -113,4 +113,11 @@ public class GobblinYarnConfigurationKeys {
 
   //Configuration properties relating to container mode of execution e.g. Gobblin cluster runs on Yarn
   public static final String CONTAINER_NUM_KEY = "container.num";
+
+  //Configuration to allow GobblinYarnAppLauncher to exit without killing the Gobblin-on-Yarn application
+  public static final String GOBBLIN_YARN_DETACH_ON_EXIT_ENABLED = GOBBLIN_YARN_PREFIX + "detach.on.exit.enabled";
+  public static final boolean DEFAULT_GOBBLIN_YARN_DETACH_ON_EXIT = false;
+
+  //Configuration to set log levels for classes in Azkaban mode
+  public static final String GOBBLIN_YARN_AZKABAN_CLASS_LOG_LEVELS = GOBBLIN_YARN_PREFIX + "azkaban.class.logLevels";
 }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1175

### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
This enhancement will allow the Gobblin-on-Yarn app launcher to be killed without killing the Gobblin-on-Yarn cluster. For instance, in the case of Azkaban based app launcher, this feature allows Azkaban executors to be restarted (e.g. on deployments) without impacting the Gobblin-on-Yarn application.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

