### PR TITLE
Correct handling of 'special' dependencies in poms

### DIFF
--- a/gobblin-modules/gobblin-parquet/build.gradle
+++ b/gobblin-modules/gobblin-parquet/build.gradle
@@ -24,7 +24,10 @@ dependencies {
   compile externalDependency.gson
   compile externalDependency.twitterParquet
   compile externalDependency.twitterParquetAvro
-  compile externalDependency.twitterParquetProto
+
+  //parquet-protobuf dependency is not resolvable from MavenCentral
+  //compileOnly ensures that gobblin-parquet can be cleanly resolved from MavenCentral
+  compileOnly externalDependency.twitterParquetProto
 
   testCompile externalDependency.testng
   testCompile externalDependency.mockito


### PR DESCRIPTION
Dependencies declared with target configurations need extra work to get them correctly mapped to pom files. Pom files are lossy when compared to Gradle or Ivy model of dependencies.

Added 'all' module that enables customers to declare a single dependency and get all directly consumable Gobblin artifacts.

Tested by running './gradlew publishToMavenLocal' and inspecting the build output and the generated pom files.