### PR TITLE
Fixed resolution problems of gobblin-parquet

### DIFF
--- a/gobblin-modules/gobblin-parquet/build.gradle
+++ b/gobblin-modules/gobblin-parquet/build.gradle
@@ -24,7 +24,10 @@ dependencies {
   compile externalDependency.gson
   compile externalDependency.twitterParquet
   compile externalDependency.twitterParquetAvro
-  compile externalDependency.twitterParquetProto
+
+  //parquet-protobuf dependency is not resolvable from MavenCentral
+  //compileOnly ensures that gobblin-parquet can be cleanly resolved from MavenCentral
+  compileOnly externalDependency.twitterParquetProto
 
   testCompile externalDependency.testng
   testCompile externalDependency.mockito


### PR DESCRIPTION
'com.twitter:parquet-protobuf:1.5.0' (including higher versions) is not resolvable from MavenCentral because it's missing some of its transitive dependencies. This makes the 'gobblin-parquet' module *also not resolvable* from MavenCentral (e.g. 'org.apache.gobblin:gobblin-parquet:0.14.0' does not resolve from Central as of today). To fix this, I suggest making parquet-protobuf dependency 'compileOnly'. This will ensure that 'gobblin-parquet' is cleanly resolvable from Central.

This also unblocks consumption of gobblin at LinkedIn