### PR TITLE
[GOBBLIN-1181] Make parquet-proto compileOnly dependency

### DIFF
--- a/gobblin-modules/gobblin-parquet-apache/build.gradle
+++ b/gobblin-modules/gobblin-parquet-apache/build.gradle
@@ -24,7 +24,8 @@ dependencies {
   compile externalDependency.gson
   compile externalDependency.parquet
   compile externalDependency.parquetAvro
-  compile externalDependency.parquetProto
+  compileOnly externalDependency.parquetProto
+  testCompile externalDependency.parquetProto
 
   testCompile externalDependency.testng
   testCompile externalDependency.mockito


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1181


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
'org.apache.parquet:parquet-protobuf:1.10.1' is not resolvable from MavenCentral because it's missing some of its transitive dependencies. This will cause 'gobblin-apache-parquet' module also not be resolvable from Central (in the future, when it will be published to Central). To fix this, I suggest using 'compileOnly'. This will ensure that 'gobblin-parquet-apache' is cleanly resolvable from Central.

This change unblocks automated consumption of gobblin external artifact at LinkedIn


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tested by running the build and inspecting the pom files


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

