### PR TITLE
Fixed resolution problems of gobblin-apache-parquet

### DIFF
--- a/gobblin-modules/gobblin-parquet-apache/build.gradle
+++ b/gobblin-modules/gobblin-parquet-apache/build.gradle
@@ -24,7 +24,11 @@ dependencies {
   compile externalDependency.gson
   compile externalDependency.parquet
   compile externalDependency.parquetAvro
-  compile externalDependency.parquetProto
+
+  //parquet 1.10.1 is not resolvable from Central
+  //to make gobblin-parquet-apache resolvable from Central we need to use compileOnly declaration:
+  compileOnly externalDependency.parquetProto
+  testCompile configurations.compileOnly
 
   testCompile externalDependency.testng
   testCompile externalDependency.mockito


### PR DESCRIPTION
'org.apache.parquet:parquet-protobuf:1.10.1' is not resolvable from MavenCentral because it's missing some of its transitive dependencies. This will cause 'gobblin-apache-parquet' module *also not be resolvable* from Central (in the future, when it will be published to Central). To fix this, I suggest using 'compileOnly'. This will ensure that 'gobblin-parquet-apache' is cleanly resolvable from Central.

This change unblocks automated consumption of gobblin external artifact at LinkedIn

Tested by running the build and inspecting the pom files