### PR TITLE
[GOBBLIN-1190] Fallback to full schema if configured shuffle schema is not available

### DIFF
--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/orc/OrcValueMapper.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/orc/OrcValueMapper.java
@@ -38,7 +38,7 @@ import org.apache.orc.mapreduce.OrcMapreduceRecordReader;
 
 import lombok.extern.slf4j.Slf4j;
 
-import static org.apache.gobblin.compaction.mapreduce.orc.OrcUtils.schemaContains;
+import static org.apache.gobblin.compaction.mapreduce.orc.OrcUtils.eligibleForUpConvert;
 
 
 /**
@@ -122,7 +122,7 @@ public class OrcValueMapper extends RecordKeyMapperBase<NullWritable, OrcStruct,
    */
   private void fillDedupKey(OrcStruct originalRecord) {
     if (!originalRecord.getSchema().equals(this.shuffleKeySchema)
-        && schemaContains(originalRecord.getSchema(), this.shuffleKeySchema)) {
+        && eligibleForUpConvert(originalRecord.getSchema(), this.shuffleKeySchema)) {
       OrcUtils.upConvertOrcStruct(originalRecord, (OrcStruct) this.outKey.key, this.shuffleKeySchema);
     } else {
       this.outKey.key = originalRecord;

--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/orc/OrcValueMapper.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/orc/OrcValueMapper.java
@@ -38,6 +38,8 @@ import org.apache.orc.mapreduce.OrcMapreduceRecordReader;
 
 import lombok.extern.slf4j.Slf4j;
 
+import static org.apache.gobblin.compaction.mapreduce.orc.OrcUtils.schemaContains;
+
 
 /**
  * To keep consistent with {@link OrcMapreduceRecordReader}'s decision on implementing
@@ -119,7 +121,8 @@ public class OrcValueMapper extends RecordKeyMapperBase<NullWritable, OrcStruct,
    * Note: This method should have no side-effect on input record.
    */
   private void fillDedupKey(OrcStruct originalRecord) {
-    if (!originalRecord.getSchema().equals(this.shuffleKeySchema)) {
+    if (!originalRecord.getSchema().equals(this.shuffleKeySchema)
+        && schemaContains(originalRecord.getSchema(), this.shuffleKeySchema)) {
       OrcUtils.upConvertOrcStruct(originalRecord, (OrcStruct) this.outKey.key, this.shuffleKeySchema);
     } else {
       this.outKey.key = originalRecord;

--- a/gobblin-compaction/src/test/java/org/apache/gobblin/compaction/mapreduce/orc/OrcUtilsTest.java
+++ b/gobblin-compaction/src/test/java/org/apache/gobblin/compaction/mapreduce/orc/OrcUtilsTest.java
@@ -311,5 +311,15 @@ public class OrcUtilsTest {
     Assert.assertFalse(OrcUtils.eligibleForUpConvert(struct_4, struct_5));
     TypeDescription struct_6 = TypeDescription.fromString("struct<a:struct<a:int>,b:struct<e:int>,c:int>");
     Assert.assertFalse(OrcUtils.eligibleForUpConvert(struct_4, struct_6));
+
+    // Cases when target schema contains more
+    TypeDescription struct_7 = TypeDescription.fromString("struct<a:struct<a:int>,b:struct<e:int,f:int>,c:int>");
+    Assert.assertTrue(OrcUtils.eligibleForUpConvert(struct_6, struct_7));
+
+    // Negative case when target schema contains more but not all of the owning schema are there in the target schema.
+    // Note that struct_8 has a field "a.x".
+    TypeDescription struct_8 = TypeDescription.fromString("struct<a:struct<x:int>,b:struct<e:int>,c:int>");
+    TypeDescription struct_9 = TypeDescription.fromString("struct<a:struct<a:int>,b:struct<e:int,f:int>,c:int>");
+    Assert.assertFalse(OrcUtils.eligibleForUpConvert(struct_8, struct_9));
   }
 }

--- a/gobblin-compaction/src/test/java/org/apache/gobblin/compaction/mapreduce/orc/OrcUtilsTest.java
+++ b/gobblin-compaction/src/test/java/org/apache/gobblin/compaction/mapreduce/orc/OrcUtilsTest.java
@@ -298,18 +298,18 @@ public class OrcUtilsTest {
     // Simple case.
     TypeDescription struct_0 = TypeDescription.fromString("struct<a:int,b:int>");
     TypeDescription struct_1 = TypeDescription.fromString("struct<a:int>");
-    Assert.assertTrue(OrcUtils.schemaContains(struct_0, struct_1));
+    Assert.assertTrue(OrcUtils.eligibleForUpConvert(struct_0, struct_1));
 
     // Nested schema case.
     TypeDescription struct_2 = TypeDescription.fromString("struct<a:struct<a:int,b:int>,b:struct<c:int,d:int>,c:int>");
     TypeDescription struct_3 = TypeDescription.fromString("struct<a:struct<a:int>,b:struct<c:int>,c:int>");
-    Assert.assertTrue(OrcUtils.schemaContains(struct_2, struct_3));
+    Assert.assertTrue(OrcUtils.eligibleForUpConvert(struct_2, struct_3));
 
     // Negative case.
     TypeDescription struct_4 = TypeDescription.fromString("struct<a:struct<a:int,b:int>,b:struct<c:int,d:int>,c:int>");
     TypeDescription struct_5 = TypeDescription.fromString("struct<a:struct<a:int>,b:struct<c:int>,d:int>");
-    Assert.assertFalse(OrcUtils.schemaContains(struct_4, struct_5));
+    Assert.assertFalse(OrcUtils.eligibleForUpConvert(struct_4, struct_5));
     TypeDescription struct_6 = TypeDescription.fromString("struct<a:struct<a:int>,b:struct<e:int>,c:int>");
-    Assert.assertFalse(OrcUtils.schemaContains(struct_4, struct_6));
+    Assert.assertFalse(OrcUtils.eligibleForUpConvert(struct_4, struct_6));
   }
 }

--- a/gobblin-compaction/src/test/java/org/apache/gobblin/compaction/mapreduce/orc/OrcUtilsTest.java
+++ b/gobblin-compaction/src/test/java/org/apache/gobblin/compaction/mapreduce/orc/OrcUtilsTest.java
@@ -293,4 +293,23 @@ public class OrcUtilsTest {
     OrcUtils.upConvertOrcStruct(originalStruct, projectColumnStruct, projectedSchema);
     Assert.assertEquals(projectColumnStruct, projectedStructExpectedValue);
   }
+
+  public void testSchemaContains() throws Exception {
+    // Simple case.
+    TypeDescription struct_0 = TypeDescription.fromString("struct<a:int,b:int>");
+    TypeDescription struct_1 = TypeDescription.fromString("struct<a:int>");
+    Assert.assertTrue(OrcUtils.schemaContains(struct_0, struct_1));
+
+    // Nested schema case.
+    TypeDescription struct_2 = TypeDescription.fromString("struct<a:struct<a:int,b:int>,b:struct<c:int,d:int>,c:int>");
+    TypeDescription struct_3 = TypeDescription.fromString("struct<a:struct<a:int>,b:struct<c:int>,c:int>");
+    Assert.assertTrue(OrcUtils.schemaContains(struct_2, struct_3));
+
+    // Negative case.
+    TypeDescription struct_4 = TypeDescription.fromString("struct<a:struct<a:int,b:int>,b:struct<c:int,d:int>,c:int>");
+    TypeDescription struct_5 = TypeDescription.fromString("struct<a:struct<a:int>,b:struct<c:int>,d:int>");
+    Assert.assertFalse(OrcUtils.schemaContains(struct_4, struct_5));
+    TypeDescription struct_6 = TypeDescription.fromString("struct<a:struct<a:int>,b:struct<e:int>,c:int>");
+    Assert.assertFalse(OrcUtils.schemaContains(struct_4, struct_6));
+  }
 }

--- a/gobblin-modules/gobblin-elasticsearch/src/test/java/org/apache/gobblin/elasticsearch/writer/ElasticsearchWriterIntegrationTest.java
+++ b/gobblin-modules/gobblin-elasticsearch/src/test/java/org/apache/gobblin/elasticsearch/writer/ElasticsearchWriterIntegrationTest.java
@@ -70,7 +70,7 @@ public class ElasticsearchWriterIntegrationTest {
     _esTestServer.start(60);
   }
 
-  @AfterSuite
+  @AfterSuite(alwaysRun=true)
   public void stopServers() {
     log.error("{}: Stopping Elasticsearch Server", pid);
     _esTestServer.stop();

--- a/gobblin-modules/gobblin-kafka-09/build.gradle
+++ b/gobblin-modules/gobblin-kafka-09/build.gradle
@@ -87,6 +87,7 @@ artifacts {
 }
 
 test {
+  forkEvery = 1
   workingDir rootProject.rootDir
   systemProperty "live.newtopic", System.getProperty("live.newtopic")
   systemProperty "live.newtopic.replicationCount", System.getProperty("live.newtopic.replicationCount")


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- https://issues.apache.org/jira/browse/GOBBLIN-1190


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):

Check if the record schema contains configured shuffle-key schema: If not, keep using the whole record as shuffle key in the ORC-Compaction. 


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

