### PR TITLE
GOBBLIN-1191: Reuse Helix instance names when containers are released…

### DIFF
--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnService.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnService.java
@@ -29,7 +29,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -82,8 +82,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Queues;
-import com.google.common.collect.Sets;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 import com.google.common.io.Closer;
@@ -192,7 +190,7 @@ public class YarnService extends AbstractIdleService {
   // A queue of unused Helix instance names. An unused Helix instance name gets put
   // into the queue if the container running the instance completes. Unused Helix
   // instance names get picked up when replacement containers get allocated.
-  private final ConcurrentLinkedQueue<String> unusedHelixInstanceNames = Queues.newConcurrentLinkedQueue();
+  private final Set<String> unusedHelixInstanceNames = ConcurrentHashMap.newKeySet();
 
   private volatile boolean shutdownInProgress = false;
 
@@ -204,7 +202,6 @@ public class YarnService extends AbstractIdleService {
   @VisibleForTesting
   @Getter(AccessLevel.PROTECTED)
   private int numRequestedContainers = 0;
-  private final Set<String> blacklistedInstances = Sets.newHashSet();
 
   public YarnService(Config config, String applicationName, String applicationId, YarnConfiguration yarnConfiguration,
       FileSystem fs, EventBus eventBus, HelixManager helixManager) throws Exception {
@@ -653,6 +650,10 @@ public class YarnService extends AbstractIdleService {
     if (containerStatus.getExitStatus() == ContainerExitStatus.ABORTED) {
       if (this.releasedContainerCache.getIfPresent(containerStatus.getContainerId()) != null) {
         LOGGER.info("Container release requested, so not spawning a replacement for containerId {}", containerStatus.getContainerId());
+        if (completedContainerEntry != null) {
+          LOGGER.info("Adding instance {} to the pool of unused instances", completedInstanceName);
+          this.unusedHelixInstanceNames.add(completedInstanceName);
+        }
         return;
       } else {
         LOGGER.info("Container {} aborted due to lost NM", containerStatus.getContainerId());
@@ -699,7 +700,8 @@ public class YarnService extends AbstractIdleService {
 
       // Add the Helix instance name of the completed container to the queue of unused
       // instance names so they can be reused by a replacement container.
-      this.unusedHelixInstanceNames.offer(completedInstanceName);
+      LOGGER.info("Adding instance {} to the pool of unused instances", completedInstanceName);
+      this.unusedHelixInstanceNames.add(completedInstanceName);
 
       if (this.eventSubmitter.isPresent()) {
         this.eventSubmitter.get()
@@ -753,8 +755,19 @@ public class YarnService extends AbstractIdleService {
 
         LOGGER.info(String.format("Container %s has been allocated", container.getId()));
 
-        String instanceName = unusedHelixInstanceNames.poll();
-        while (Strings.isNullOrEmpty(instanceName) || HelixUtils.isInstanceLive(helixManager, instanceName)) {
+        //Iterate over the (thread-safe) set of unused instances to find the first instance that is not currently live.
+        //Once we find a candidate instance, it is removed from the set.
+        String instanceName = null;
+        for (Iterator<String> iterator = unusedHelixInstanceNames.iterator(); iterator.hasNext(); ) {
+          instanceName = iterator.next();
+          if (!HelixUtils.isInstanceLive(helixManager, instanceName)) {
+            iterator.remove();
+            LOGGER.info("Found an unused instance {}", instanceName);
+            break;
+          }
+        }
+
+        if (Strings.isNullOrEmpty(instanceName)) {
           // No unused instance name, so generating a new one.
           instanceName = HelixUtils
               .getHelixInstanceName(HELIX_YARN_INSTANCE_NAME_PREFIX, helixInstanceIdGenerator.incrementAndGet());


### PR DESCRIPTION
… by Gobblin Application Master

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1191


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Currently, when containers are released by Gobblin Application Master, the Helix instance names are not released back to the pool of unused instance names. The effect of this is that the number of unique Helix instances keeps growing over time. Since Helix creates one znode per instance, this can result in the number of znodes to grow unboundedly. 



### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

