### PR TITLE
[GOBBLIN-1192] Commit suicide if Helix Task creation failed after retry

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixTask.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixTask.java
@@ -52,6 +52,10 @@ import com.typesafe.config.ConfigValueFactory;
 
 import lombok.extern.slf4j.Slf4j;
 
+import static org.apache.gobblin.cluster.HelixTaskEventMetadataGenerator.HELIX_INSTANCE_KEY;
+import static org.apache.gobblin.cluster.HelixTaskEventMetadataGenerator.HELIX_JOB_ID_KEY;
+import static org.apache.gobblin.cluster.HelixTaskEventMetadataGenerator.HELIX_TASK_ID_KEY;
+
 
 /**
  * An implementation of Helix's {@link org.apache.helix.task.Task} that wraps and runs one or more Gobblin
@@ -191,9 +195,9 @@ public class GobblinHelixTask implements Task {
         ConfigFactory.parseMap(this.taskConfig.getConfigMap()) , getClass().getName());
     event.addMetadata("jobName", this.jobName);
     event.addMetadata("AppName", this.applicationName);
-    event.addMetadata("InstanceName", this.instanceName);
-    event.addMetadata("helixJobId", this.helixJobId);
-    event.addMetadata("helixTaskId", this.helixTaskId);
+    event.addMetadata(HELIX_INSTANCE_KEY, this.instanceName);
+    event.addMetadata(HELIX_JOB_ID_KEY, this.helixJobId);
+    event.addMetadata(HELIX_TASK_ID_KEY, this.helixTaskId);
     event.addMetadata("WUPath", this.workUnitFilePath.toString());
     event.addMetadata("Phase", phase);
     return event;

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixTask.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixTask.java
@@ -17,7 +17,6 @@
 
 package org.apache.gobblin.cluster;
 
-import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
@@ -133,16 +132,16 @@ public class GobblinHelixTask implements Task {
 
       this.task = retryer.call(new Callable<SingleTask>() {
         @Override
-        public SingleTask call()
-            throws Exception {
+        public SingleTask call() {
           return new SingleTask(jobId, workUnitFilePath, jobStateFilePath, builder.getFs(), taskAttemptBuilder,
               stateStores,
               dynamicConfig);
         }
       });
     } catch (Exception e) {
-      log.error("Execution in creating a SingleTask-with-retry failed, container will suicide ...", e);
-      eventBus.post(createTaskCreationEvent("Task Creation"));
+      log.error("Execution in creating a SingleTask-with-retry failed, will create a failing task", e);
+      this.task = new SingleFailInCreationTask(jobId, workUnitFilePath, jobStateFilePath, builder.getFs(), taskAttemptBuilder,
+          stateStores, dynamicConfig);
     }
   }
 

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/InMemoryWuFailedSingleTask.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/InMemoryWuFailedSingleTask.java
@@ -38,7 +38,7 @@ import com.typesafe.config.Config;
  */
 public class InMemoryWuFailedSingleTask extends SingleTask {
   public InMemoryWuFailedSingleTask(String jobId, Path workUnitFilePath, Path jobStateFilePath, FileSystem fs,
-      TaskAttemptBuilder taskAttemptBuilder, StateStores stateStores, Config dynamicConfig) throws IOException {
+      TaskAttemptBuilder taskAttemptBuilder, StateStores stateStores, Config dynamicConfig) {
     super(jobId, workUnitFilePath, jobStateFilePath, fs, taskAttemptBuilder, stateStores, dynamicConfig);
   }
 

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/InMemoryWuSingleTask.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/InMemoryWuSingleTask.java
@@ -41,7 +41,7 @@ import com.typesafe.config.Config;
  */
 public class InMemoryWuSingleTask extends SingleTask {
   public InMemoryWuSingleTask(String jobId, Path workUnitFilePath, Path jobStateFilePath, FileSystem fs,
-      TaskAttemptBuilder taskAttemptBuilder, StateStores stateStores, Config dynamicConfig) throws IOException {
+      TaskAttemptBuilder taskAttemptBuilder, StateStores stateStores, Config dynamicConfig) {
     super(jobId, workUnitFilePath, jobStateFilePath, fs, taskAttemptBuilder, stateStores, dynamicConfig);
   }
 

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SingleFailInCreationTask.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SingleFailInCreationTask.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.cluster;
+
+import java.io.IOException;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import com.typesafe.config.Config;
+
+import org.apache.gobblin.runtime.TaskCreationException;
+import org.apache.gobblin.runtime.util.StateStores;
+
+
+/**
+ * A simple extension for {@link SingleTask} to directly throw exception for the case of task-creation failure.
+ * We need this since Helix couldn't handle failure before startTask call as part of state transition and trigger
+ * task reassignment.
+ */
+public class SingleFailInCreationTask extends SingleTask {
+  public SingleFailInCreationTask(String jobId, Path workUnitFilePath, Path jobStateFilePath, FileSystem fs,
+      TaskAttemptBuilder taskAttemptBuilder, StateStores stateStores, Config dynamicConfig) {
+    super(jobId, workUnitFilePath, jobStateFilePath, fs, taskAttemptBuilder, stateStores, dynamicConfig);
+  }
+
+  @Override
+  public void run()
+      throws IOException, InterruptedException {
+    throw new TaskCreationException("Failing task directly due to fatal issue in task-creation");
+  }
+}

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinHelixTaskTest.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinHelixTaskTest.java
@@ -32,6 +32,7 @@ import org.apache.gobblin.example.simplejson.SimpleJsonSource;
 import org.apache.gobblin.metastore.FsStateStore;
 import org.apache.gobblin.runtime.AbstractJobLauncher;
 import org.apache.gobblin.runtime.JobState;
+import org.apache.gobblin.runtime.TaskCreationException;
 import org.apache.gobblin.runtime.TaskExecutor;
 import org.apache.gobblin.source.workunit.WorkUnit;
 import org.apache.gobblin.util.Id;
@@ -202,9 +203,13 @@ public class GobblinHelixTaskTest {
             ConfigFactory.empty(),
             Optional.of(taskDriver));
 
-    // Expecting the eventBus containing the failure signal.
-    gobblinHelixTaskFactory.createNewTask(taskCallbackContext);
-    Assert.assertEquals(countDownLatchForFailInTaskCreation.getCount(), 0);
+    // Expecting the eventBus containing the failure signal when run is called
+    try {
+      gobblinHelixTaskFactory.createNewTask(taskCallbackContext).run();
+    } catch (Throwable t){
+      return;
+    }
+    Assert.fail();
   }
 
   @Subscribe


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- https://issues.apache.org/jira/browse/GOBBLIN-1192


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
When creating a Helix Task, if creation failed after retrying, will post a event to result in container suicide.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

