### PR TITLE
GOBBLIN-1193: Ensure that ingestion latency is 0 when no records are …

### DIFF
--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaExtractorStatsTracker.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaExtractorStatsTracker.java
@@ -327,19 +327,30 @@ public class KafkaExtractorStatsTracker {
     if (partitionStats.getStopFetchEpochTime() > aggregateExtractorStats.getMaxStopFetchEpochTime()) {
       aggregateExtractorStats.setMaxStopFetchEpochTime(partitionStats.getStopFetchEpochTime());
     }
-    long partitionLatency = partitionStats.getStopFetchEpochTime() - partitionStats.getMinLogAppendTime();
+
+    long partitionLatency = 0L;
+    if (partitionStats.getMinLogAppendTime() > 0) {
+      partitionLatency = partitionStats.getStopFetchEpochTime() - partitionStats.getMinLogAppendTime();
+    }
+
     if (aggregateExtractorStats.getMaxIngestionLatency() < partitionLatency) {
       aggregateExtractorStats.setMaxIngestionLatency(partitionLatency);
     }
+
     if (aggregateExtractorStats.getMinLogAppendTime() > partitionStats.getMinLogAppendTime()) {
       aggregateExtractorStats.setMinLogAppendTime(partitionStats.getMinLogAppendTime());
     }
+
     if (aggregateExtractorStats.getMaxLogAppendTime() < partitionStats.getMaxLogAppendTime()) {
       aggregateExtractorStats.setMaxLogAppendTime(partitionStats.getMaxLogAppendTime());
     }
+
     aggregateExtractorStats.setProcessedRecordCount(aggregateExtractorStats.getProcessedRecordCount() + partitionStats.getProcessedRecordCount());
     aggregateExtractorStats.setNumBytesConsumed(aggregateExtractorStats.getNumBytesConsumed() + partitionStats.getPartitionTotalSize());
-    aggregateExtractorStats.setSlaMissedRecordCount(aggregateExtractorStats.getSlaMissedRecordCount() + partitionStats.getSlaMissedRecordCount());
+
+    if (partitionStats.getSlaMissedRecordCount() > 0) {
+      aggregateExtractorStats.setSlaMissedRecordCount(aggregateExtractorStats.getSlaMissedRecordCount() + partitionStats.getSlaMissedRecordCount());
+    }
   }
 
   private Map<String, String> createTagsForPartition(int partitionId, MultiLongWatermark lowWatermark, MultiLongWatermark highWatermark, MultiLongWatermark nextWatermark) {

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaExtractorStatsTracker.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaExtractorStatsTracker.java
@@ -329,6 +329,7 @@ public class KafkaExtractorStatsTracker {
     }
 
     long partitionLatency = 0L;
+    //Check if there are any records consumed from this KafkaPartition.
     if (partitionStats.getMinLogAppendTime() > 0) {
       partitionLatency = partitionStats.getStopFetchEpochTime() - partitionStats.getMinLogAppendTime();
     }


### PR DESCRIPTION
…consumed by Kafka Extractor

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1193


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
When no records are consumed by Kafka Extractor during an epoch, KafkaExtractorStatsTracker incorrectly returns a non-zero value for ingestion latency. 



### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Added unit test in KafkaExtractorStatsTrackerTest

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

