### PR TITLE
[GOBBLIN-1200] Fix bug when local network throttling distcp jobs

### DIFF
--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/io/ThrottledInputStream.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/io/ThrottledInputStream.java
@@ -85,6 +85,9 @@ public class ThrottledInputStream extends FilterInputStream {
       long currentCount = this.meter.getBytesProcessedMeter().getCount();
       long permitsNeeded = currentCount - this.prevCount;
       this.prevCount = currentCount;
+      if (permitsNeeded == 0L) {
+        return;
+      }
       Closeable permit = this.limiter.acquirePermits(permitsNeeded);
       if (permit == null) {
         throw new RuntimeException("Could not acquire permits.");


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1200


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

Currently when using local throttling for distcp, the first call to limiter asks for 0 permits which throws an error. It probably makes more sense for asking for 0 permits to just return and do nothing instead of throwing an error.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tested distcp job

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

