### PR TITLE
[GOBBLIN-1203] Adding configurations for staging directory in Distcp template

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -207,6 +207,8 @@ public class ConfigurationKeys {
   public static final String CLEANUP_OLD_JOBS_DATA = "cleanup.old.job.data";
   public static final boolean DEFAULT_CLEANUP_OLD_JOBS_DATA = false;
   public static final String MAXIMUM_JAR_COPY_RETRY_TIMES_KEY = JOB_JAR_FILES_KEY + ".uploading.retry.maximum";
+  public static final String USER_DEFINED_STATIC_STAGING_DIR = "user.defined.static.staging.dir";
+  public static final String USER_DEFINED_STAGING_DIR_FLAG = "user.defined.staging.dir.flag";
 
   public static final String QUEUED_TASK_TIME_MAX_SIZE = "taskexecutor.queued_task_time.history.max_size";
   public static final int DEFAULT_QUEUED_TASK_TIME_MAX_SIZE = 2048;

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
@@ -140,9 +140,13 @@ public class FileAwareInputStreamDataWriter extends InstrumentedDataWriter<FileA
     this.fs = FileSystem.get(uri, conf);
     this.fileContext = FileContext.getFileContext(uri, conf);
 
-    this.stagingDir = this.writerAttemptIdOptional.isPresent() ? WriterUtils
-        .getWriterStagingDir(state, numBranches, branchId, this.writerAttemptIdOptional.get())
-        : WriterUtils.getWriterStagingDir(state, numBranches, branchId);
+    if (state.getPropAsBoolean(ConfigurationKeys.USER_DEFINED_STAGING_DIR_FLAG,false)) {
+      this.stagingDir = new Path(state.getProp(ConfigurationKeys.USER_DEFINED_STATIC_STAGING_DIR));
+    } else {
+      this.stagingDir = this.writerAttemptIdOptional.isPresent() ? WriterUtils.getWriterStagingDir(state, numBranches, branchId, this.writerAttemptIdOptional.get())
+          : WriterUtils.getWriterStagingDir(state, numBranches, branchId);
+    }
+
     this.outputDir = getOutputDir(state);
     this.copyableDatasetMetadata =
         CopyableDatasetMetadata.deserialize(state.getProp(CopySource.SERIALIZED_COPYABLE_DATASET));

--- a/gobblin-runtime/src/main/resources/templates/distcp.template
+++ b/gobblin-runtime/src/main/resources/templates/distcp.template
@@ -42,6 +42,7 @@ converter.classes=org.apache.gobblin.converter.IdentityConverter
 
 task.maxretries=0
 workunit.retry.enabled=false
+user.defined.staging.dir.flag=false
 
 distcp.persist.dir=/tmp/distcp-persist-dir
 


### PR DESCRIPTION

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


JIRA
https://jira01.corp.linkedin.com:8443/browse/ETL-10948


Description
Currently, Embedded distcp creates it's own temp staging directory. But, this PR adds the option to have a user defined staging directory which can be used in place of the temp staging directory.


Tests
My PR incorporates change to the following unit tests:
FileAwareInputStreamDataWriterTest.java


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

