### PR TITLE
[GOBBLIN-1206] Only populate path to dest-table if src-table has it as storageParam

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HivePartitionFileSet.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HivePartitionFileSet.java
@@ -186,7 +186,11 @@ public class HivePartitionFileSet extends HiveFileSet {
       targetPartition.getTPartition().putToParameters(HiveDataset.REGISTRATION_GENERATION_TIME_MILLIS,
           Long.toString(this.hiveCopyEntityHelper.getStartTime()));
       targetPartition.setLocation(targetLocation.toString());
-      targetPartition.getTPartition().getSd().getSerdeInfo().getParameters().put(HiveConstants.PATH, targetLocation.toString());
+      /**
+       * Only set the this constants when source partition has it.
+       */
+      targetPartition.getTPartition().getSd().getSerdeInfo().getParameters()
+          .computeIfPresent(HiveConstants.PATH, (k,v) -> targetLocation.toString());
       targetPartition.getTPartition().unsetCreateTime();
       return targetPartition;
     } catch (HiveException he) {

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/hive/HiveCopyEntityHelperTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/hive/HiveCopyEntityHelperTest.java
@@ -20,6 +20,7 @@ package org.apache.gobblin.data.management.copy.hive;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -345,6 +346,23 @@ public class HiveCopyEntityHelperTest {
     Path prefixReplacement = new Path("/data/databases/_parallel");
     Path expected = new Path("/data/databases/_parallel/DB1/Table1/SS1/part1.avro");
     Assert.assertEquals(HiveCopyEntityHelper.replacedPrefix(sourcePath, prefixTobeReplaced, prefixReplacement), expected);
+  }
+
+  @Test
+  public void testAddMetadataToTargetTable() throws Exception {
+    org.apache.hadoop.hive.ql.metadata.Table meta_table =
+        new Table(Table.getEmptyTable("testDB", "testTable"));
+
+    Map<String, String> storageParams = new HashMap<>();
+    storageParams.put("path", "randomPath");
+    meta_table.getSd().getSerdeInfo().setParameters(storageParams);
+    HiveCopyEntityHelper.addMetadataToTargetTable(meta_table, new Path("newPath"), "testDB", 10L);
+    Assert.assertEquals(meta_table.getSd().getSerdeInfo().getParameters().get("path"), "newPath");
+
+    storageParams.clear();
+    meta_table.getSd().getSerdeInfo().setParameters(storageParams);
+    HiveCopyEntityHelper.addMetadataToTargetTable(meta_table, new Path("newPath"), "testDB", 10L);
+    Assert.assertFalse(meta_table.getSd().getSerdeInfo().getParameters().containsKey("path"));
   }
 
   private boolean containsPath(Collection<FileStatus> statuses, Path path) {

--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/HiveConstants.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/HiveConstants.java
@@ -47,6 +47,7 @@ public class HiveConstants {
    * Storage properties
    */
   public static final String LOCATION = "location";
+  // A storage parameter that is managed by Spark for Spark Datasource tables
   public static final String PATH = "path";
   public static final String INPUT_FORMAT = "input.format";
   public static final String OUTPUT_FORMAT = "output.format";


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- https://issues.apache.org/jira/browse/GOBBLIN-1206


### Description
In distcp job, we only want to copy storage-params from source table to destination table if that entry existed in the source. 
For more context: https://github.com/apache/incubator-gobblin/commit/3bdad1148d86d479f0a27172a75f8bccda15371f

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

