### PR TITLE
GOBBLIN-1209: Provide an option to configure the java tmp dir to the …

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterUtils.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterUtils.java
@@ -46,6 +46,7 @@ import org.apache.gobblin.util.PathUtils;
 @Alpha
 @Slf4j
 public class GobblinClusterUtils {
+  public static final String JAVA_TMP_DIR_KEY = "java.io.tmpdir";
 
   public enum TMP_DIR {
     YARN_CACHE
@@ -125,7 +126,7 @@ public class GobblinClusterUtils {
         ConfigFactory.empty()));
 
     for (Map.Entry<Object, Object> entry: properties.entrySet()) {
-      if (entry.getKey().toString().equals("java.io.tmpdir")) {
+      if (entry.getKey().toString().equals(JAVA_TMP_DIR_KEY)) {
         if (entry.getValue().toString().equalsIgnoreCase(TMP_DIR.YARN_CACHE.toString())) {
           //When java.io.tmpdir is configured to "YARN_CACHE", it sets the tmp dir to the Yarn container's cache location.
           // This setting will only be useful when the cluster is deployed in Yarn mode.

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterUtils.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinClusterUtils.java
@@ -117,7 +117,7 @@ public class GobblinClusterUtils {
   }
 
   /**
-   * Return the system properties from the input {@link Config} instance
+   * Set the system properties from the input {@link Config} instance
    * @param config
    */
   public static void setSystemProperties(Config config) {
@@ -127,6 +127,8 @@ public class GobblinClusterUtils {
     for (Map.Entry<Object, Object> entry: properties.entrySet()) {
       if (entry.getKey().toString().equals("java.io.tmpdir")) {
         if (entry.getValue().toString().equalsIgnoreCase(TMP_DIR.YARN_CACHE.toString())) {
+          //When java.io.tmpdir is configured to "YARN_CACHE", it sets the tmp dir to the Yarn container's cache location.
+          // This setting will only be useful when the cluster is deployed in Yarn mode.
           log.info("Setting tmp directory to: {}", System.getenv(ApplicationConstants.Environment.PWD.key()));
           System.setProperty(entry.getKey().toString(), System.getenv(ApplicationConstants.Environment.PWD.key()));
           continue;

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinTaskRunner.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinTaskRunner.java
@@ -183,6 +183,14 @@ public class GobblinTaskRunner implements StandardMetricsBridge {
       String taskRunnerId,
       Config config,
       Optional<Path> appWorkDirOptional) throws Exception {
+    // Set system properties passed in via application config. As an example, Helix uses System#getProperty() for ZK configuration
+    // overrides such as sessionTimeout. In this case, the overrides specified
+    // in the application configuration have to be extracted and set before initializing HelixManager.
+    GobblinClusterUtils.setSystemProperties(config);
+
+    //Add dynamic config
+    config = GobblinClusterUtils.addDynamicConfig(config);
+
     this.isTaskDriver = ConfigUtils.getBoolean(config, GobblinClusterConfigurationKeys.TASK_DRIVER_ENABLED,false);
     this.helixInstanceName = helixInstanceName;
     this.taskRunnerId = taskRunnerId;
@@ -205,11 +213,6 @@ public class GobblinTaskRunner implements StandardMetricsBridge {
         ConfigurationKeys.DEFAULT_GOBBLIN_TASK_EVENT_REPORTING_FAILURE_FATAL);
 
     logger.info("Configured GobblinTaskRunner work dir to: {}", this.appWorkPath.toString());
-
-    // Set system properties passed in via application config. As an example, Helix uses System#getProperty() for ZK configuration
-    // overrides such as sessionTimeout. In this case, the overrides specified
-    // in the application configuration have to be extracted and set before initializing HelixManager.
-    HelixUtils.setSystemProperties(config);
 
     this.isContainerExitOnHealthCheckFailureEnabled = ConfigUtils.getBoolean(config, GobblinClusterConfigurationKeys.CONTAINER_EXIT_ON_HEALTH_CHECK_FAILURE_ENABLED,
         GobblinClusterConfigurationKeys.DEFAULT_CONTAINER_EXIT_ON_HEALTH_CHECK_FAILURE_ENABLED);

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/HelixUtils.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/HelixUtils.java
@@ -23,7 +23,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -47,15 +46,11 @@ import org.apache.helix.task.WorkflowConfig;
 import org.apache.helix.task.WorkflowContext;
 import org.apache.helix.tools.ClusterSetup;
 
-import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
-
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.runtime.JobException;
 import org.apache.gobblin.runtime.listeners.JobListener;
-import org.apache.gobblin.util.ConfigUtils;
 
 import static org.apache.helix.task.TaskState.STOPPED;
 
@@ -323,19 +318,6 @@ public class HelixUtils {
       }
     }
     return jobNameToWorkflowId;
-  }
-
-  /**
-   * Return the system properties from the input {@link Config} instance
-   * @param config
-   */
-  public static void setSystemProperties(Config config) {
-    Properties properties = ConfigUtils.configToProperties(ConfigUtils.getConfig(config, GobblinClusterConfigurationKeys.GOBBLIN_CLUSTER_SYSTEM_PROPERTY_PREFIX,
-        ConfigFactory.empty()));
-
-    for (Map.Entry<Object, Object> entry: properties.entrySet()) {
-      System.setProperty(entry.getKey().toString(), entry.getValue().toString());
-    }
   }
 
   /**

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinClusterUtilsTest.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinClusterUtilsTest.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import com.typesafe.config.Config;
@@ -60,4 +61,22 @@ public class GobblinClusterUtilsTest {
         .getAppWorkDirPathFromConfig(ConfigFactory.empty(), mockFs, TEST_APP_NAME, TEST_APP_ID);
     assertEquals(PathUtils.combinePaths(DEFAULT_HOME_DIR, TEST_APP_NAME, TEST_APP_ID), workDirPath);
   }
+
+  @Test
+  public void testSetSystemProperties() {
+    //Set a dummy property before calling GobblinClusterUtils#setSystemProperties() and assert that this property and value
+    //exists even after the call to the setSystemProperties() method.
+    System.setProperty("prop1", "val1");
+
+    Config config = ConfigFactory.empty().withValue(GobblinClusterConfigurationKeys.GOBBLIN_CLUSTER_SYSTEM_PROPERTY_PREFIX + ".prop2",
+        ConfigValueFactory.fromAnyRef("val2"))
+        .withValue(GobblinClusterConfigurationKeys.GOBBLIN_CLUSTER_SYSTEM_PROPERTY_PREFIX + ".prop3", ConfigValueFactory.fromAnyRef("val3"));
+
+    GobblinClusterUtils.setSystemProperties(config);
+
+    Assert.assertEquals(System.getProperty("prop1"), "val1");
+    Assert.assertEquals(System.getProperty("prop2"), "val2");
+    Assert.assertEquals(System.getProperty("prop3"), "val3");
+  }
+
 }

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/HelixUtilsTest.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/HelixUtilsTest.java
@@ -33,7 +33,6 @@ import org.testng.annotations.Test;
 
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
-import com.typesafe.config.ConfigValueFactory;
 
 import org.apache.gobblin.util.ConfigUtils;
 
@@ -79,23 +78,6 @@ public class HelixUtilsTest {
     Assert.assertEquals(properties.getProperty("k3"), "1000");
     Assert.assertEquals(properties.getProperty("k4"), "true");
     Assert.assertEquals(properties.getProperty("k5"), "10000");
-  }
-
-  @Test
-  public void testSetSystemProperties() {
-    //Set a dummy property before calling HelixUtils#setSystemProperties() and assert that this property and value
-    //exists even after the call to the setSystemProperties() method.
-    System.setProperty("prop1", "val1");
-
-    Config config = ConfigFactory.empty().withValue(GobblinClusterConfigurationKeys.GOBBLIN_CLUSTER_SYSTEM_PROPERTY_PREFIX + ".prop2",
-        ConfigValueFactory.fromAnyRef("val2"))
-        .withValue(GobblinClusterConfigurationKeys.GOBBLIN_CLUSTER_SYSTEM_PROPERTY_PREFIX + ".prop3", ConfigValueFactory.fromAnyRef("val3"));
-
-    HelixUtils.setSystemProperties(config);
-
-    Assert.assertEquals(System.getProperty("prop1"), "val1");
-    Assert.assertEquals(System.getProperty("prop2"), "val2");
-    Assert.assertEquals(System.getProperty("prop3"), "val3");
   }
 
   @AfterClass

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinApplicationMaster.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinApplicationMaster.java
@@ -25,9 +25,6 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-
-import org.apache.commons.lang3.StringUtils;
-import org.apache.gobblin.util.logs.LogCopier;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -35,13 +32,11 @@ import org.apache.hadoop.yarn.api.ApplicationConstants;
 import org.apache.hadoop.yarn.api.records.ContainerId;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.util.ConverterUtils;
-
 import org.apache.helix.NotificationContext;
 import org.apache.helix.messaging.handling.HelixTaskResult;
 import org.apache.helix.messaging.handling.MessageHandler;
 import org.apache.helix.messaging.handling.MessageHandlerFactory;
 import org.apache.helix.model.Message;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,6 +56,7 @@ import org.apache.gobblin.util.ConfigUtils;
 import org.apache.gobblin.util.JvmUtils;
 import org.apache.gobblin.util.PathUtils;
 import org.apache.gobblin.util.logs.Log4jConfigurationHelper;
+import org.apache.gobblin.util.logs.LogCopier;
 import org.apache.gobblin.util.reflection.GobblinConstructorUtils;
 import org.apache.gobblin.yarn.event.DelegationTokenUpdatedEvent;
 
@@ -85,9 +81,8 @@ public class GobblinApplicationMaster extends GobblinClusterManager {
 
   public GobblinApplicationMaster(String applicationName, String applicationId, ContainerId containerId, Config config,
       YarnConfiguration yarnConfiguration) throws Exception {
-    super(applicationName, applicationId, GobblinClusterUtils.addDynamicConfig(config
-            .withValue(GobblinYarnConfigurationKeys.CONTAINER_NUM_KEY,
-                ConfigValueFactory.fromAnyRef(YarnHelixUtils.getContainerNum(containerId.toString())))),
+    super(applicationName, applicationId, config.withValue(GobblinYarnConfigurationKeys.CONTAINER_NUM_KEY,
+        ConfigValueFactory.fromAnyRef(YarnHelixUtils.getContainerNum(containerId.toString()))),
         Optional.<Path>absent());
 
     String containerLogDir = config.getString(GobblinYarnConfigurationKeys.LOGS_SINK_ROOT_DIR_KEY);

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnTaskRunner.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnTaskRunner.java
@@ -62,9 +62,9 @@ public class GobblinYarnTaskRunner extends GobblinTaskRunner {
 
   public GobblinYarnTaskRunner(String applicationName, String applicationId, String helixInstanceName, ContainerId containerId, Config config,
       Optional<Path> appWorkDirOptional) throws Exception {
-    super(applicationName, helixInstanceName, applicationId, getTaskRunnerId(containerId),
-        GobblinClusterUtils.addDynamicConfig(config.withValue(GobblinYarnConfigurationKeys.CONTAINER_NUM_KEY,
-            ConfigValueFactory.fromAnyRef(YarnHelixUtils.getContainerNum(containerId.toString())))), appWorkDirOptional);
+    super(applicationName, helixInstanceName, applicationId, getTaskRunnerId(containerId), config
+        .withValue(GobblinYarnConfigurationKeys.CONTAINER_NUM_KEY,
+            ConfigValueFactory.fromAnyRef(YarnHelixUtils.getContainerNum(containerId.toString()))), appWorkDirOptional);
   }
 
   @Override


### PR DESCRIPTION
…Yarn cache location

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1209


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
This PR allows the tmp dir to be set to the container's cache location overriding the default setting of /tmp. This requires the the tmp dir system property to dynamically configured to the cache location.  


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Existing unit tests.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

