### PR TITLE
GOBBLIN-1211: Track unused Helix instances in a thread-safe manner

### DIFF
--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnService.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnService.java
@@ -142,6 +142,7 @@ public class YarnService extends AbstractIdleService {
   private final Optional<GobblinMetrics> gobblinMetrics;
   private final Optional<EventSubmitter> eventSubmitter;
 
+  private final Object lock = new Object();
 
   @VisibleForTesting
   @Getter(AccessLevel.PROTECTED)
@@ -766,13 +767,21 @@ public class YarnService extends AbstractIdleService {
         //Iterate over the (thread-safe) set of unused instances to find the first instance that is not currently live.
         //Once we find a candidate instance, it is removed from the set.
         String instanceName = null;
-        Iterator<String> iterator = unusedHelixInstanceNames.iterator();
-        while (iterator.hasNext()) {
-          instanceName = iterator.next();
-          if (!HelixUtils.isInstanceLive(helixManager, instanceName)) {
-            iterator.remove();
-            LOGGER.info("Found an unused instance {}", instanceName);
-            break;
+
+        //Ensure that updates to unusedHelixInstanceNames are visible to other threads that might concurrently
+        //invoke the callback on container allocation.
+        synchronized (lock) {
+          Iterator<String> iterator = unusedHelixInstanceNames.iterator();
+          while (iterator.hasNext()) {
+            instanceName = iterator.next();
+            if (!HelixUtils.isInstanceLive(helixManager, instanceName)) {
+              iterator.remove();
+              LOGGER.info("Found an unused instance {}", instanceName);
+              break;
+            } else {
+              //Reset the instance name to null, since this instance name is live.
+              instanceName = null;
+            }
           }
         }
 

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnService.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/YarnService.java
@@ -142,8 +142,6 @@ public class YarnService extends AbstractIdleService {
   private final Optional<GobblinMetrics> gobblinMetrics;
   private final Optional<EventSubmitter> eventSubmitter;
 
-  private final Object lock = new Object();
-
   @VisibleForTesting
   @Getter(AccessLevel.PROTECTED)
   private final AMRMClientAsync<AMRMClient.ContainerRequest> amrmClientAsync;
@@ -770,7 +768,7 @@ public class YarnService extends AbstractIdleService {
 
         //Ensure that updates to unusedHelixInstanceNames are visible to other threads that might concurrently
         //invoke the callback on container allocation.
-        synchronized (lock) {
+        synchronized (this) {
           Iterator<String> iterator = unusedHelixInstanceNames.iterator();
           while (iterator.hasNext()) {
             instanceName = iterator.next();


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1211


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
The AMRMClient processes container allocation events asynchronously in a separate thread. If there are multiple concurrent container requests and consequent callbacks, we need to ensure that updates to shared data structures such as the set of unused Helix instance names are consistent and thread-safe. In other words, any updates to this set made by one thread will be visible to all other threads handling the container allocation events. 


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Existing tests.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

