### PR TITLE
[GOBBLIN-1212] Handle non-Primitive type eligibility-check for shuffle key properly

### DIFF
--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/orc/OrcUtils.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/orc/OrcUtils.java
@@ -490,13 +490,17 @@ public class OrcUtils {
    */
   public static boolean eligibleForUpConvertHelper(TypeDescription originalSchema, TypeDescription targetSchema) {
     if (!targetSchema.getCategory().isPrimitive()) {
+      if (originalSchema.getCategory() != targetSchema.getCategory()) {
+        return false;
+      }
+
       if (targetSchema.getCategory().equals(TypeDescription.Category.LIST)) {
         Preconditions
-            .checkArgument(originalSchema.getChildren() != null, "Illegal format of ORC schema as:" + targetSchema);
+            .checkArgument(originalSchema.getChildren() != null, "Illegal format of ORC schema as:" + originalSchema);
         return eligibleForUpConvertHelper(originalSchema.getChildren().get(0), targetSchema.getChildren().get(0));
       } else if (targetSchema.getCategory().equals(TypeDescription.Category.MAP)) {
         Preconditions
-            .checkArgument(originalSchema.getChildren() != null, "Illegal format of ORC schema as:" + targetSchema);
+            .checkArgument(originalSchema.getChildren() != null, "Illegal format of ORC schema as:" + originalSchema);
 
         return eligibleForUpConvertHelper(originalSchema.getChildren().get(0), targetSchema.getChildren().get(0))
             && eligibleForUpConvertHelper(originalSchema.getChildren().get(1), targetSchema.getChildren().get(1));

--- a/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/orc/OrcUtils.java
+++ b/gobblin-compaction/src/main/java/org/apache/gobblin/compaction/mapreduce/orc/OrcUtils.java
@@ -57,7 +57,6 @@ import org.apache.orc.mapred.OrcMap;
 import org.apache.orc.mapred.OrcStruct;
 import org.apache.orc.mapred.OrcTimestamp;
 import org.apache.orc.mapred.OrcUnion;
-import org.apache.parquet.format.TypeDefinedOrder;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -492,8 +491,13 @@ public class OrcUtils {
   public static boolean eligibleForUpConvertHelper(TypeDescription originalSchema, TypeDescription targetSchema) {
     if (!targetSchema.getCategory().isPrimitive()) {
       if (targetSchema.getCategory().equals(TypeDescription.Category.LIST)) {
+        Preconditions
+            .checkArgument(originalSchema.getChildren() != null, "Illegal format of ORC schema as:" + targetSchema);
         return eligibleForUpConvertHelper(originalSchema.getChildren().get(0), targetSchema.getChildren().get(0));
       } else if (targetSchema.getCategory().equals(TypeDescription.Category.MAP)) {
+        Preconditions
+            .checkArgument(originalSchema.getChildren() != null, "Illegal format of ORC schema as:" + targetSchema);
+
         return eligibleForUpConvertHelper(originalSchema.getChildren().get(0), targetSchema.getChildren().get(0))
             && eligibleForUpConvertHelper(originalSchema.getChildren().get(1), targetSchema.getChildren().get(1));
       } else if (targetSchema.getCategory().equals(TypeDescription.Category.UNION)) {
@@ -518,7 +522,6 @@ public class OrcUtils {
         // and we will by default treated it as eligible.
         return true;
       }
-
     } else {
       // Check the unit type: Only for the category.
       return originalSchema.getCategory().equals(targetSchema.getCategory());

--- a/gobblin-compaction/src/test/java/org/apache/gobblin/compaction/mapreduce/orc/OrcUtilsTest.java
+++ b/gobblin-compaction/src/test/java/org/apache/gobblin/compaction/mapreduce/orc/OrcUtilsTest.java
@@ -295,7 +295,7 @@ public class OrcUtilsTest {
   }
 
   @Test
-  public void reproduce() throws Exception {
+  public void complextTypeEligibilityCheck() throws Exception {
     TypeDescription struct_array_0 = TypeDescription.fromString("struct<first:array<int>,second:int>");
     TypeDescription struct_array_1 = TypeDescription.fromString("struct<first:array<int>,second:int>");
     Assert.assertTrue(OrcUtils.eligibleForUpConvert(struct_array_0, struct_array_1));
@@ -307,11 +307,6 @@ public class OrcUtilsTest {
     TypeDescription struct_map_2 = TypeDescription.fromString("struct<first:map<string,int>,second:int>");
     Assert.assertTrue(OrcUtils.eligibleForUpConvert(struct_map_0, struct_map_1));
     Assert.assertFalse(OrcUtils.eligibleForUpConvert(struct_map_0, struct_map_2));
-
-    // A complicated schema
-    TypeDescription struct_a = TypeDescription.fromString("struct<stone:struct<memberId:int,viewerUrn:string,aUrn:string,csUserUrn:string,time:bigint,server:string,service:string,environment:string,guid:binary,treeId:binary,requestId:int,impersonatorId:string,version:string,instance:string,appName:string,testId:string,testSegmentId:string,auditstone:struct<time:bigint,server:string,instance:string,appName:string,messageId:binary,auditVersion:int,fabricUrn:string,clusterConnectionString:string>,pageInstance:struct<pageUrn:string,trackingId:binary>,clientApplicationInstance:struct<applicationUrn:string,version:string,trackingId:binary>,originSource:string,sessionUrn:string,traceData:struct<treeId:binary,requestId:int,taskId:int,rpcTrace:string,forceTraceEnabled:boolean,context:map<string,string>,scaleFactor:double>>,requeststone:struct<browserId:string,sessionId:string,ip:string,pageKey:string,path:string,locale:string,interfaceLocale:string,trackingCode:string,referer:string,userAgent:string,ipAsBytes:binary,requestProtocol:string,requestDomain:string>,statusCode:int,bodyDataAnnotationGroups:array<struct<annotations:array<struct<domainType:struct<entityId:int,attributeId:int>,sourceUrn:string>>,groupId:int,childrenGroupIds:array<int>,hashedSchemaName:int>>,resourceName:string,info:struct<rm:string,actionOrFinderName:string,schemaName:string>,xId:struct<tenantUrn:string,eUrn:string,memberUrn:string,cloudUrn:string,clientId:string,userMetadata:struct<emad:string,accountAgeInSeconds:bigint>>>");
-    TypeDescription struct_b = TypeDescription.fromString("struct<stone:struct<memberId:int,viewerUrn:string,aUrn:string,csUserUrn:string,time:bigint,server:string,service:string,environment:string,guid:binary,treeId:binary,requestId:int,impersonatorId:string,version:string,instance:string,appName:string,testId:string,testSegmentId:string,auditstone:struct<time:bigint,server:string,instance:string,appName:string,messageId:binary,auditVersion:int,fabricUrn:string,clusterConnectionString:string>,pageInstance:struct<pageUrn:string,trackingId:binary>,clientApplicationInstance:struct<applicationUrn:string,version:string,trackingId:binary>,originSource:string,sessionUrn:string,traceData:struct<treeId:binary,requestId:int,taskId:int,rpcTrace:string,forceTraceEnabled:boolean,context:map<string,string>,scaleFactor:double>>,requeststone:struct<browserId:string,sessionId:string,ip:string,pageKey:string,path:string,locale:string,interfaceLocale:string,trackingCode:string,referer:string,userAgent:string,ipAsBytes:binary,requestProtocol:string,requestDomain:string>,statusCode:int,bodyDataAnnotationGroups:array<struct<annotations:array<struct<domainType:struct<entityId:int,attributeId:int>,sourceUrn:string>>,groupId:int,childrenGroupIds:array<int>,hashedSchemaName:int>>,resourceName:string,info:struct<rm:string,actionOrFinderName:string,schemaName:string>,xId:struct<tenantUrn:string,eUrn:string,memberUrn:string,cloudUrn:string,clientId:string,userMetadata:struct<emad:string,accountAgeInSeconds:bigint>>>");
-    Assert.assertTrue(OrcUtils.eligibleForUpConvert(struct_a, struct_b));
   }
 
   public void testSchemaContains() throws Exception {

--- a/gobblin-compaction/src/test/java/org/apache/gobblin/compaction/mapreduce/orc/OrcUtilsTest.java
+++ b/gobblin-compaction/src/test/java/org/apache/gobblin/compaction/mapreduce/orc/OrcUtilsTest.java
@@ -295,7 +295,7 @@ public class OrcUtilsTest {
   }
 
   @Test
-  public void complextTypeEligibilityCheck() throws Exception {
+  public void complexTypeEligibilityCheck() throws Exception {
     TypeDescription struct_array_0 = TypeDescription.fromString("struct<first:array<int>,second:int>");
     TypeDescription struct_array_1 = TypeDescription.fromString("struct<first:array<int>,second:int>");
     Assert.assertTrue(OrcUtils.eligibleForUpConvert(struct_array_0, struct_array_1));
@@ -305,8 +305,10 @@ public class OrcUtilsTest {
     TypeDescription struct_map_0 = TypeDescription.fromString("struct<first:map<string,string>,second:int>");
     TypeDescription struct_map_1 = TypeDescription.fromString("struct<first:map<string,string>,second:int>");
     TypeDescription struct_map_2 = TypeDescription.fromString("struct<first:map<string,int>,second:int>");
+    TypeDescription struct_map_3 = TypeDescription.fromString("struct<second:int>");
     Assert.assertTrue(OrcUtils.eligibleForUpConvert(struct_map_0, struct_map_1));
     Assert.assertFalse(OrcUtils.eligibleForUpConvert(struct_map_0, struct_map_2));
+    Assert.assertTrue(OrcUtils.eligibleForUpConvert(struct_map_0, struct_map_3));
   }
 
   public void testSchemaContains() throws Exception {

--- a/gobblin-compaction/src/test/java/org/apache/gobblin/compaction/mapreduce/orc/OrcUtilsTest.java
+++ b/gobblin-compaction/src/test/java/org/apache/gobblin/compaction/mapreduce/orc/OrcUtilsTest.java
@@ -294,6 +294,26 @@ public class OrcUtilsTest {
     Assert.assertEquals(projectColumnStruct, projectedStructExpectedValue);
   }
 
+  @Test
+  public void reproduce() throws Exception {
+    TypeDescription struct_array_0 = TypeDescription.fromString("struct<first:array<int>,second:int>");
+    TypeDescription struct_array_1 = TypeDescription.fromString("struct<first:array<int>,second:int>");
+    Assert.assertTrue(OrcUtils.eligibleForUpConvert(struct_array_0, struct_array_1));
+    TypeDescription struct_array_2 = TypeDescription.fromString("struct<first:array<string>,second:int>");
+    Assert.assertFalse(OrcUtils.eligibleForUpConvert(struct_array_0, struct_array_2));
+
+    TypeDescription struct_map_0 = TypeDescription.fromString("struct<first:map<string,string>,second:int>");
+    TypeDescription struct_map_1 = TypeDescription.fromString("struct<first:map<string,string>,second:int>");
+    TypeDescription struct_map_2 = TypeDescription.fromString("struct<first:map<string,int>,second:int>");
+    Assert.assertTrue(OrcUtils.eligibleForUpConvert(struct_map_0, struct_map_1));
+    Assert.assertFalse(OrcUtils.eligibleForUpConvert(struct_map_0, struct_map_2));
+
+    // A complicated schema
+    TypeDescription struct_a = TypeDescription.fromString("struct<stone:struct<memberId:int,viewerUrn:string,aUrn:string,csUserUrn:string,time:bigint,server:string,service:string,environment:string,guid:binary,treeId:binary,requestId:int,impersonatorId:string,version:string,instance:string,appName:string,testId:string,testSegmentId:string,auditstone:struct<time:bigint,server:string,instance:string,appName:string,messageId:binary,auditVersion:int,fabricUrn:string,clusterConnectionString:string>,pageInstance:struct<pageUrn:string,trackingId:binary>,clientApplicationInstance:struct<applicationUrn:string,version:string,trackingId:binary>,originSource:string,sessionUrn:string,traceData:struct<treeId:binary,requestId:int,taskId:int,rpcTrace:string,forceTraceEnabled:boolean,context:map<string,string>,scaleFactor:double>>,requeststone:struct<browserId:string,sessionId:string,ip:string,pageKey:string,path:string,locale:string,interfaceLocale:string,trackingCode:string,referer:string,userAgent:string,ipAsBytes:binary,requestProtocol:string,requestDomain:string>,statusCode:int,bodyDataAnnotationGroups:array<struct<annotations:array<struct<domainType:struct<entityId:int,attributeId:int>,sourceUrn:string>>,groupId:int,childrenGroupIds:array<int>,hashedSchemaName:int>>,resourceName:string,info:struct<rm:string,actionOrFinderName:string,schemaName:string>,xId:struct<tenantUrn:string,eUrn:string,memberUrn:string,cloudUrn:string,clientId:string,userMetadata:struct<emad:string,accountAgeInSeconds:bigint>>>");
+    TypeDescription struct_b = TypeDescription.fromString("struct<stone:struct<memberId:int,viewerUrn:string,aUrn:string,csUserUrn:string,time:bigint,server:string,service:string,environment:string,guid:binary,treeId:binary,requestId:int,impersonatorId:string,version:string,instance:string,appName:string,testId:string,testSegmentId:string,auditstone:struct<time:bigint,server:string,instance:string,appName:string,messageId:binary,auditVersion:int,fabricUrn:string,clusterConnectionString:string>,pageInstance:struct<pageUrn:string,trackingId:binary>,clientApplicationInstance:struct<applicationUrn:string,version:string,trackingId:binary>,originSource:string,sessionUrn:string,traceData:struct<treeId:binary,requestId:int,taskId:int,rpcTrace:string,forceTraceEnabled:boolean,context:map<string,string>,scaleFactor:double>>,requeststone:struct<browserId:string,sessionId:string,ip:string,pageKey:string,path:string,locale:string,interfaceLocale:string,trackingCode:string,referer:string,userAgent:string,ipAsBytes:binary,requestProtocol:string,requestDomain:string>,statusCode:int,bodyDataAnnotationGroups:array<struct<annotations:array<struct<domainType:struct<entityId:int,attributeId:int>,sourceUrn:string>>,groupId:int,childrenGroupIds:array<int>,hashedSchemaName:int>>,resourceName:string,info:struct<rm:string,actionOrFinderName:string,schemaName:string>,xId:struct<tenantUrn:string,eUrn:string,memberUrn:string,cloudUrn:string,clientId:string,userMetadata:struct<emad:string,accountAgeInSeconds:bigint>>>");
+    Assert.assertTrue(OrcUtils.eligibleForUpConvert(struct_a, struct_b));
+  }
+
   public void testSchemaContains() throws Exception {
     // Simple case.
     TypeDescription struct_0 = TypeDescription.fromString("struct<a:int,b:int>");


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1212

### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):

Before this change, the handling for non-primitive types like map,array and union will hit NPE since they don't have `fieldNames`. This fixed that and making sure the eligibility check happens recursively into those types.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

