### PR TITLE
GOBBLIN-1213: Skip job state deserialization during SingleFailInCreat…

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SingleFailInCreationTask.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SingleFailInCreationTask.java
@@ -36,7 +36,8 @@ import org.apache.gobblin.runtime.util.StateStores;
 public class SingleFailInCreationTask extends SingleTask {
   public SingleFailInCreationTask(String jobId, Path workUnitFilePath, Path jobStateFilePath, FileSystem fs,
       TaskAttemptBuilder taskAttemptBuilder, StateStores stateStores, Config dynamicConfig) {
-    super(jobId, workUnitFilePath, jobStateFilePath, fs, taskAttemptBuilder, stateStores, dynamicConfig);
+    //Since this is a dummy task that is designed to fail immediately on run(), we skip fetching the job state.
+    super(jobId, workUnitFilePath, jobStateFilePath, fs, taskAttemptBuilder, stateStores, dynamicConfig, true);
   }
 
   @Override

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SingleTask.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SingleTask.java
@@ -81,10 +81,11 @@ public class SingleTask {
       TaskAttemptBuilder taskAttemptBuilder, StateStores stateStores, Config dynamicConfig) {
     this(jobId, workUnitFilePath, jobStateFilePath, fs, taskAttemptBuilder, stateStores, dynamicConfig, false);
   }
-    /**
-     * Do all heavy-lifting of initialization in constructor which could be retried if failed,
-     * see the example in {@link GobblinHelixTask}.
-     */
+
+  /**
+   * Do all heavy-lifting of initialization in constructor which could be retried if failed,
+   * see the example in {@link GobblinHelixTask}.
+   */
   SingleTask(String jobId, Path workUnitFilePath, Path jobStateFilePath, FileSystem fs,
       TaskAttemptBuilder taskAttemptBuilder, StateStores stateStores, Config dynamicConfig, boolean skipGetJobState) {
     _jobId = jobId;

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SingleTask.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SingleTask.java
@@ -77,12 +77,16 @@ public class SingleTask {
   private Condition _taskAttemptBuilt;
   private Lock _lock;
 
-  /**
-   * Do all heavy-lifting of initialization in constructor which could be retried if failed,
-   * see the example in {@link GobblinHelixTask}.
-   */
   SingleTask(String jobId, Path workUnitFilePath, Path jobStateFilePath, FileSystem fs,
       TaskAttemptBuilder taskAttemptBuilder, StateStores stateStores, Config dynamicConfig) {
+    this(jobId, workUnitFilePath, jobStateFilePath, fs, taskAttemptBuilder, stateStores, dynamicConfig, false);
+  }
+    /**
+     * Do all heavy-lifting of initialization in constructor which could be retried if failed,
+     * see the example in {@link GobblinHelixTask}.
+     */
+  SingleTask(String jobId, Path workUnitFilePath, Path jobStateFilePath, FileSystem fs,
+      TaskAttemptBuilder taskAttemptBuilder, StateStores stateStores, Config dynamicConfig, boolean skipGetJobState) {
     _jobId = jobId;
     _workUnitFilePath = workUnitFilePath;
     _jobStateFilePath = jobStateFilePath;
@@ -93,10 +97,14 @@ public class SingleTask {
     _lock = new ReentrantLock();
     _taskAttemptBuilt = _lock.newCondition();
 
-    try {
-      _jobState = getJobState();
-    } catch (IOException ioe) {
-      throw new RuntimeException("Failing in deserializing jobState...", ioe);
+    if (!skipGetJobState) {
+      try {
+        _jobState = getJobState();
+      } catch (IOException ioe) {
+        throw new RuntimeException("Failing in deserializing jobState...", ioe);
+      }
+    } else {
+      this._jobState = null;
     }
   }
 


### PR DESCRIPTION
…ionTask instantiation

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1213


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Since the failing task is designed to throw an exception immediately on run(), the job state de-serialization in the parent class (i.e. SingleTask) can be skipped to avoid instantiation failures. 


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Existing unit tests.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

