### PR TITLE
[GOBBLIN-1219] do not schedule flow spec from slave instance of GobblinServiceJobSch…

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/restli/GobblinServiceFlowConfigResourceHandler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/restli/GobblinServiceFlowConfigResourceHandler.java
@@ -122,7 +122,7 @@ public class GobblinServiceFlowConfigResourceHandler implements FlowConfigsResou
         CreateResponse response = null;
         if (this.flowCatalogLocalCommit) {
           // We will handle FS I/O locally for load balance before forwarding to remote node.
-          response = this.localHandler.createFlowConfig(flowConfig, false);
+          response = this.localHandler.createFlowConfig(flowConfig, true);
         }
 
         if (!flowConfig.hasExplain() || !flowConfig.isExplain()) {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobScheduler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobScheduler.java
@@ -290,10 +290,11 @@ public class GobblinServiceJobScheduler extends JobScheduler implements SpecCata
 
     boolean compileSuccess = FlowCatalog.isCompileSuccessful(response);
 
-    if (isExplain || !compileSuccess) {
+    if (isExplain || !compileSuccess || !this.isActive) {
       // todo: in case of a scheudled job, we should also check if the job schedule is a valid cron schedule
       //  so it can be scheduled
-      _log.info("Ignoring the spec {}. isExplain: {}, compileSuccess: {}", addedSpec, isExplain, compileSuccess);
+      _log.info("Ignoring the spec {}. isExplain: {}, compileSuccess: {}, master: {}",
+          addedSpec, isExplain, compileSuccess, this.isActive);
       return new AddSpecResponse<>(response);
     }
 


### PR DESCRIPTION
…eduler

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below! @jack-moseley  @sv2000  please review


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1219


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Trigger listener (GobblinServiceJobScheduler) on slave instance too, so that a flow is compiled even when submitted to slave. But, do not schedule flow spec from slave instance of GobblinServiceJobScheduler to avoid double scheduling.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
manually tested

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

