### PR TITLE
[GOBBLIN-1221] Preserve source file's ModTime by configuration

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/PreserveAttributes.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/PreserveAttributes.java
@@ -44,7 +44,8 @@ public class PreserveAttributes {
     OWNER('u'),
     GROUP('g'),
     PERMISSION('p'),
-    VERSION('v');
+    VERSION('v'),
+    MOD_TIME('t');
 
     private final char token;
 
@@ -89,6 +90,7 @@ public class PreserveAttributes {
    * * g -> preserve group
    * * p -> preserve permissions
    * * v -> preserve version
+   * * t -> preserve file's modTime
    * Characters not in this character set will be ignored.
    *
    * @param s String of the form \[rbugpv]*\

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/publisher/CopyDataPublisher.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/publisher/CopyDataPublisher.java
@@ -186,8 +186,38 @@ public class CopyDataPublisher extends DataPublisher implements UnpublishedHandl
   }
 
   /**
+   * Unlike other preserving attributes of files (ownership, group, etc.), which is preserved in writer,
+   * some of the attributes have to be set during publish phase like ModTime,
+   * and versionStrategy (usually relevant to modTime as well), since they are subject to change with Publish(rename)
+   */
+  private void preserveFileAttrInPublisher(CopyableFile copyableFile) throws IOException {
+    // Preserving File ModTime, keep the accessing time of the target file.
+    if (copyableFile.getPreserve().preserve(PreserveAttributes.Option.MOD_TIME)) {
+      fs.setTimes(copyableFile.getDestination(), copyableFile.getOriginTimestamp(),
+          fs.getFileStatus(copyableFile.getDestination()).getAccessTime());
+    }
+
+    // Preserving File Version.
+    DataFileVersionStrategy srcVS = this.srcDataFileVersionStrategy;
+    DataFileVersionStrategy dstVS = this.dstDataFileVersionStrategy;
+
+    // Prefer to use copyableFile's specific version strategy
+    if (copyableFile.getDataFileVersionStrategy() != null) {
+      Config versionStrategyConfig = ConfigFactory.parseMap(ImmutableMap.of(
+          DataFileVersionStrategy.DATA_FILE_VERSION_STRATEGY_KEY, copyableFile.getDataFileVersionStrategy()));
+      srcVS = DataFileVersionStrategy.instantiateDataFileVersionStrategy(this.srcFs, versionStrategyConfig);
+      dstVS = DataFileVersionStrategy.instantiateDataFileVersionStrategy(this.fs, versionStrategyConfig);
+    }
+
+    if (copyableFile.getPreserve().preserve(PreserveAttributes.Option.VERSION)
+        && dstVS.hasCharacteristic(DataFileVersionStrategy.Characteristic.SETTABLE)) {
+      dstVS.setVersion(copyableFile.getDestination(),
+          srcVS.getVersion(copyableFile.getOrigin().getPath()));
+    }
+  }
+
+  /**
    * Publish data for a {@link CopyableDataset}.
-   *
    */
   private void publishFileSet(CopyEntity.DatasetAndPartition datasetAndPartition,
       Collection<WorkUnitState> datasetWorkUnitStates) throws IOException {
@@ -233,23 +263,7 @@ public class CopyDataPublisher extends DataPublisher implements UnpublishedHandl
       CopyEntity copyEntity = CopySource.deserializeCopyEntity(wus);
       if (copyEntity instanceof CopyableFile) {
         CopyableFile copyableFile = (CopyableFile) copyEntity;
-        DataFileVersionStrategy srcVS = this.srcDataFileVersionStrategy;
-        DataFileVersionStrategy dstVS = this.dstDataFileVersionStrategy;
-
-        // Prefer to use copyableFile's specific version strategy
-        if (copyableFile.getDataFileVersionStrategy() != null) {
-          Config versionStrategyConfig = ConfigFactory.parseMap(ImmutableMap.of(
-              DataFileVersionStrategy.DATA_FILE_VERSION_STRATEGY_KEY, copyableFile.getDataFileVersionStrategy()));
-          srcVS = DataFileVersionStrategy.instantiateDataFileVersionStrategy(this.srcFs, versionStrategyConfig);
-          dstVS = DataFileVersionStrategy.instantiateDataFileVersionStrategy(this.fs, versionStrategyConfig);
-        }
-
-        if (copyableFile.getPreserve().preserve(PreserveAttributes.Option.VERSION)
-            && dstVS.hasCharacteristic(DataFileVersionStrategy.Characteristic.SETTABLE)) {
-          dstVS.setVersion(copyableFile.getDestination(),
-              srcVS.getVersion(copyableFile.getOrigin().getPath()));
-        }
-
+        preserveFileAttrInPublisher(copyableFile);
         if (wus.getWorkingState() == WorkingState.COMMITTED) {
           CopyEventSubmitterHelper.submitSuccessfulFilePublish(this.eventSubmitter, copyableFile, wus);
           // Dataset Output path is injected in each copyableFile.
@@ -287,7 +301,8 @@ public class CopyDataPublisher extends DataPublisher implements UnpublishedHandl
     additionalMetadata.put(SlaEventKeys.DATASET_OUTPUT_PATH, fileSetRoot.or("Unknown"));
     CopyEventSubmitterHelper.submitSuccessfulDatasetPublish(this.eventSubmitter, datasetAndPartition,
         Long.toString(datasetOriginTimestamp), Long.toString(datasetUpstreamTimestamp), additionalMetadata);
-    }
+  }
+
 
   private static boolean hasCopyableFiles(Collection<WorkUnitState> workUnits) throws IOException {
     for (WorkUnitState wus : workUnits) {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1221


### Description
This change enabled distcp to preserve the ModTime in destination. It refactored a code block in `CopyPublisher` which is used to preserve the file version. Note that this is required to be placed in publisher since the rename in the publisher is the last operation change the ModTime, while other attributes like Owner/Group will not change after write operation in writer. 

Add a unit test for both positive and negative case.


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

