### PR TITLE
[GOBBLIN-1222] Create right abstraction to assemble dataset staging dir for Hive dataset finder

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -209,8 +209,8 @@ public class ConfigurationKeys {
   public static final String MAXIMUM_JAR_COPY_RETRY_TIMES_KEY = JOB_JAR_FILES_KEY + ".uploading.retry.maximum";
   public static final String USER_DEFINED_STATIC_STAGING_DIR = "user.defined.static.staging.dir";
   public static final String USER_DEFINED_STAGING_DIR_FLAG = "user.defined.staging.dir.flag";
+  public static final String IS_DATASET_STAGING_DIR_USED = "dataset.staging.dir.used";
   public static final String DATASET_STAGING_DIR = "dataset.staging.dir";
-  public static final String HIVE_DATASET_STAGING_DIR = "hive.dataset.staging.dir";
 
   public static final String QUEUED_TASK_TIME_MAX_SIZE = "taskexecutor.queued_task_time.history.max_size";
   public static final int DEFAULT_QUEUED_TASK_TIME_MAX_SIZE = 2048;

--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -209,6 +209,8 @@ public class ConfigurationKeys {
   public static final String MAXIMUM_JAR_COPY_RETRY_TIMES_KEY = JOB_JAR_FILES_KEY + ".uploading.retry.maximum";
   public static final String USER_DEFINED_STATIC_STAGING_DIR = "user.defined.static.staging.dir";
   public static final String USER_DEFINED_STAGING_DIR_FLAG = "user.defined.staging.dir.flag";
+  public static final String DATASET_STAGING_DIR = "dataset.staging.dir";
+  public static final String HIVE_DATASET_STAGING_DIR = "hive.dataset.staging.dir";
 
   public static final String QUEUED_TASK_TIME_MAX_SIZE = "taskexecutor.queued_task_time.history.max_size";
   public static final int DEFAULT_QUEUED_TASK_TIME_MAX_SIZE = 2048;

--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -210,7 +210,6 @@ public class ConfigurationKeys {
   public static final String USER_DEFINED_STATIC_STAGING_DIR = "user.defined.static.staging.dir";
   public static final String USER_DEFINED_STAGING_DIR_FLAG = "user.defined.staging.dir.flag";
   public static final String IS_DATASET_STAGING_DIR_USED = "dataset.staging.dir.used";
-  public static final String DATASET_STAGING_DIR = "dataset.staging.dir";
 
   public static final String QUEUED_TASK_TIME_MAX_SIZE = "taskexecutor.queued_task_time.history.max_size";
   public static final int DEFAULT_QUEUED_TASK_TIME_MAX_SIZE = 2048;

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/CopySource.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/CopySource.java
@@ -199,8 +199,6 @@ public class CopySource extends AbstractSource<String, FileAwareInputStream> {
           datasetFinder instanceof IterableDatasetFinder ? (IterableDatasetFinder<CopyableDatasetBase>) datasetFinder
               : new IterableDatasetFinderImpl<>(datasetFinder);
 
-
-
       Iterator<CopyableDatasetRequestor> requestorIteratorWithNulls = Iterators
           .transform(iterableDatasetFinder.getDatasetsIterator(),
               new CopyableDatasetRequestor.Factory(targetFs, copyConfiguration, log));
@@ -372,7 +370,7 @@ public class CopySource extends AbstractSource<String, FileAwareInputStream> {
               workUnit.setProp(ConfigurationKeys.COPY_EXPECTED_SCHEMA, ((ConfigBasedDataset) this.copyableDataset).getExpectedSchema());
             }
           }
-          if ((this.copyableDataset instanceof HiveDataset) && (state.getPropAsBoolean(ConfigurationKeys.DATASET_STAGING_DIR,false))) {
+          if ((this.copyableDataset instanceof HiveDataset) && (state.getPropAsBoolean(ConfigurationKeys.IS_DATASET_STAGING_DIR_USED,false))) {
             workUnit.setProp(DATASET_STAGING_DIR_PATH, ((HiveDataset) this.copyableDataset).getProperties().getProperty(DATASET_STAGING_PATH));
           }
           serializeCopyEntity(workUnit, copyEntity);

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/CopySource.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/CopySource.java
@@ -32,8 +32,6 @@ import javax.annotation.Nullable;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-import org.apache.gobblin.data.management.copy.hive.HiveDataset;
-import org.apache.gobblin.data.management.copy.hive.HiveDatasetFinder;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 
@@ -55,6 +53,8 @@ import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.configuration.WorkUnitState;
 import org.apache.gobblin.data.management.copy.extractor.EmptyExtractor;
 import org.apache.gobblin.data.management.copy.extractor.FileAwareInputStreamExtractor;
+import org.apache.gobblin.data.management.copy.hive.HiveDataset;
+import org.apache.gobblin.data.management.copy.hive.HiveDatasetFinder;
 import org.apache.gobblin.data.management.copy.prioritization.FileSetComparator;
 import org.apache.gobblin.data.management.copy.publisher.CopyEventSubmitterHelper;
 import org.apache.gobblin.data.management.copy.replication.ConfigBasedDataset;

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HiveDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HiveDataset.java
@@ -131,7 +131,7 @@ public class HiveDataset implements PrioritizedCopyableDataset {
 
     this.tableIdentifier = this.table.getDbName() + "." + this.table.getTableName();
     this.tableLocation = this.table.getPath();
-    if (!(this.properties.isEmpty())) {
+    if (!(this.tableLocation.getName().isEmpty())) {
       this.datasetStagingDir = properties.getProperty(DATASET_PREFIX_REPLACEMENT) + "/" + this.tableLocation.getName();
       properties.setProperty(DATASET_STAGING_PATH,this.datasetStagingDir);
     }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HiveDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HiveDataset.java
@@ -107,7 +107,6 @@ public class HiveDataset implements PrioritizedCopyableDataset {
   protected final Optional<Path> tableRootPath;
   protected final Path tableLocation;
   protected final String tableIdentifier;
-  protected final String datasetStagingDir;
   protected final Optional<String> datasetNamePattern;
   protected final DbAndTable dbAndTable;
   protected final DbAndTable logicalDbAndTable;
@@ -132,8 +131,8 @@ public class HiveDataset implements PrioritizedCopyableDataset {
     this.tableIdentifier = this.table.getDbName() + "." + this.table.getTableName();
     this.tableLocation = this.table.getPath();
     if (!(this.tableLocation.getName().isEmpty())) {
-      this.datasetStagingDir = properties.getProperty(DATASET_PREFIX_REPLACEMENT) + "/" + this.tableLocation.getName();
-      properties.setProperty(DATASET_STAGING_PATH,this.datasetStagingDir);
+      String datasetStagingDir = properties.getProperty(DATASET_PREFIX_REPLACEMENT) + "/" + this.tableLocation.getName();
+      properties.setProperty(DATASET_STAGING_PATH,datasetStagingDir);
     }
 
     this.datasetNamePattern = Optional.fromNullable(ConfigUtils.getString(datasetConfig, DATASET_NAME_PATTERN_KEY, null));

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HiveDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HiveDataset.java
@@ -67,6 +67,7 @@ import org.apache.gobblin.util.ConfigUtils;
 import org.apache.gobblin.util.PathUtils;
 import org.apache.gobblin.util.request_allocation.PushDownRequestor;
 
+import static org.apache.gobblin.data.management.copy.hive.HiveTargetPathHelper.*;
 
 /**
  * Hive dataset implementing {@link CopyableDataset}.
@@ -86,7 +87,6 @@ public class HiveDataset implements PrioritizedCopyableDataset {
   public static final String DATABASE = "Database";
   public static final String TABLE = "Table";
   public static final String DATASET_STAGING_PATH = "dataset.staging.path";
-  public static final String DATASET_PREFIX_REPLACEMENT = "hive.dataset.copy.target.table.prefixReplacement";
 
   public static final String DATABASE_TOKEN = "$DB";
   public static final String TABLE_TOKEN = "$TABLE";
@@ -105,7 +105,6 @@ public class HiveDataset implements PrioritizedCopyableDataset {
 
   // Only set if table has exactly one location
   protected final Optional<Path> tableRootPath;
-  protected final Path tableLocation;
   protected final String tableIdentifier;
   protected final Optional<String> datasetNamePattern;
   protected final DbAndTable dbAndTable;
@@ -129,9 +128,9 @@ public class HiveDataset implements PrioritizedCopyableDataset {
         Optional.fromNullable(this.table.getDataLocation());
 
     this.tableIdentifier = this.table.getDbName() + "." + this.table.getTableName();
-    this.tableLocation = this.table.getPath();
+    Path tableLocation = this.table.getPath();
     if (!(this.properties.isEmpty())) {
-      String datasetStagingDir = properties.getProperty(DATASET_PREFIX_REPLACEMENT) + "/" + this.tableLocation.getName();
+      String datasetStagingDir = this.properties.getProperty(COPY_TARGET_TABLE_PREFIX_REPLACEMENT) + "/" + tableLocation.getName();
       properties.setProperty(DATASET_STAGING_PATH,datasetStagingDir);
     }
 

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HiveDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HiveDataset.java
@@ -131,8 +131,10 @@ public class HiveDataset implements PrioritizedCopyableDataset {
 
     this.tableIdentifier = this.table.getDbName() + "." + this.table.getTableName();
     this.tableLocation = this.table.getPath();
-    this.datasetStagingDir = properties.getProperty(DATASET_PREFIX_REPLACEMENT) + "/" + this.tableLocation.getName();
-    properties.setProperty(DATASET_STAGING_PATH,this.datasetStagingDir);
+    if(this.tableLocation) {
+      this.datasetStagingDir = properties.getProperty(DATASET_PREFIX_REPLACEMENT) + "/" + this.tableLocation.getName();
+      properties.setProperty(DATASET_STAGING_PATH,this.datasetStagingDir);
+    }
 
     this.datasetNamePattern = Optional.fromNullable(ConfigUtils.getString(datasetConfig, DATASET_NAME_PATTERN_KEY, null));
     this.dbAndTable = new DbAndTable(table.getDbName(), table.getTableName());

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HiveDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HiveDataset.java
@@ -131,7 +131,7 @@ public class HiveDataset implements PrioritizedCopyableDataset {
 
     this.tableIdentifier = this.table.getDbName() + "." + this.table.getTableName();
     this.tableLocation = this.table.getPath();
-    this.datasetStagingDir = properties.getProperty(DATASET_PREFIX_REPLACEMENT) + "/" + getLastSegment(this.tableLocation);
+    this.datasetStagingDir = properties.getProperty(DATASET_PREFIX_REPLACEMENT) + "/" + this.tableLocation.getName();
     properties.setProperty(DATASET_STAGING_PATH,this.datasetStagingDir);
 
     this.datasetNamePattern = Optional.fromNullable(ConfigUtils.getString(datasetConfig, DATASET_NAME_PATTERN_KEY, null));
@@ -337,14 +337,5 @@ public class HiveDataset implements PrioritizedCopyableDataset {
       return false;
     }
     return true;
-  }
-
-  public String getLastSegment(Path location) {
-    if (location == null) {
-      return null;
-    }
-    String[] segments = location.toString().split("/");
-    String lastStr = segments[segments.length-1];
-    return lastStr;
   }
 }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HiveDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HiveDataset.java
@@ -85,6 +85,8 @@ public class HiveDataset implements PrioritizedCopyableDataset {
   public static final String DATASET_NAME_PATTERN_KEY = "hive.datasetNamePattern";
   public static final String DATABASE = "Database";
   public static final String TABLE = "Table";
+  public static final String DATASET_STAGING_PATH = "dataset.staging.path";
+  public static final String DATASET_PREFIX_TOBEREPLACED = "hive.dataset.copy.target.table.prefixToBeReplaced";
 
   public static final String DATABASE_TOKEN = "$DB";
   public static final String TABLE_TOKEN = "$TABLE";
@@ -126,8 +128,8 @@ public class HiveDataset implements PrioritizedCopyableDataset {
         Optional.fromNullable(this.table.getDataLocation());
 
     this.tableIdentifier = this.table.getDbName() + "." + this.table.getTableName();
-    this.datasetStagingDir = properties.getProperty("hive.dataset.copy.target.table.prefixToBeReplaced") + "/" + this.table.getDbName() + "/" + this.table.getTableName();
-    properties.setProperty("dataset.staging.path",this.datasetStagingDir);
+    this.datasetStagingDir = properties.getProperty(DATASET_PREFIX_TOBEREPLACED) + "/" + this.table.getDbName() + "/" + this.table.getTableName();
+    properties.setProperty(DATASET_STAGING_PATH,this.datasetStagingDir);
 
     this.datasetNamePattern = Optional.fromNullable(ConfigUtils.getString(datasetConfig, DATASET_NAME_PATTERN_KEY, null));
     this.dbAndTable = new DbAndTable(table.getDbName(), table.getTableName());
@@ -332,5 +334,9 @@ public class HiveDataset implements PrioritizedCopyableDataset {
       return false;
     }
     return true;
+  }
+
+  public Properties getProperties() {
+    return properties;
   }
 }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HiveDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HiveDataset.java
@@ -131,7 +131,7 @@ public class HiveDataset implements PrioritizedCopyableDataset {
 
     this.tableIdentifier = this.table.getDbName() + "." + this.table.getTableName();
     this.tableLocation = this.table.getPath();
-    if(this.tableLocation) {
+    if (!(this.properties.isEmpty())) {
       this.datasetStagingDir = properties.getProperty(DATASET_PREFIX_REPLACEMENT) + "/" + this.tableLocation.getName();
       properties.setProperty(DATASET_STAGING_PATH,this.datasetStagingDir);
     }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HiveDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HiveDataset.java
@@ -103,6 +103,7 @@ public class HiveDataset implements PrioritizedCopyableDataset {
   // Only set if table has exactly one location
   protected final Optional<Path> tableRootPath;
   protected final String tableIdentifier;
+  protected final String datasetStagingDir;
   protected final Optional<String> datasetNamePattern;
   protected final DbAndTable dbAndTable;
   protected final DbAndTable logicalDbAndTable;
@@ -125,6 +126,8 @@ public class HiveDataset implements PrioritizedCopyableDataset {
         Optional.fromNullable(this.table.getDataLocation());
 
     this.tableIdentifier = this.table.getDbName() + "." + this.table.getTableName();
+    this.datasetStagingDir = properties.getProperty("hive.dataset.copy.target.table.prefixToBeReplaced") + "/" + this.table.getDbName() + "/" + this.table.getTableName();
+    properties.setProperty("dataset.staging.path",this.datasetStagingDir);
 
     this.datasetNamePattern = Optional.fromNullable(ConfigUtils.getString(datasetConfig, DATASET_NAME_PATTERN_KEY, null));
     this.dbAndTable = new DbAndTable(table.getDbName(), table.getTableName());

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HiveDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HiveDataset.java
@@ -340,6 +340,9 @@ public class HiveDataset implements PrioritizedCopyableDataset {
   }
 
   public String getLastSegment(Path location) {
+    if (location == null) {
+      return null;
+    }
     String[] segments = location.toString().split("/");
     String lastStr = segments[segments.length-1];
     return lastStr;

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HiveDataset.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HiveDataset.java
@@ -130,7 +130,7 @@ public class HiveDataset implements PrioritizedCopyableDataset {
 
     this.tableIdentifier = this.table.getDbName() + "." + this.table.getTableName();
     this.tableLocation = this.table.getPath();
-    if (!(this.tableLocation.getName().isEmpty())) {
+    if (!(this.properties.isEmpty())) {
       String datasetStagingDir = properties.getProperty(DATASET_PREFIX_REPLACEMENT) + "/" + this.tableLocation.getName();
       properties.setProperty(DATASET_STAGING_PATH,datasetStagingDir);
     }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HiveDatasetFinder.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HiveDatasetFinder.java
@@ -107,6 +107,7 @@ public class HiveDatasetFinder implements IterableDatasetFinder<HiveDataset> {
   private static final String FAILURE_CONTEXT = "FailureContext";
 
   protected final Properties properties;
+  public Properties getProperties() { return properties; }
   protected final HiveMetastoreClientPool clientPool;
   protected final FileSystem fs;
   private final WhitelistBlacklist whitelistBlacklist;

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HiveDatasetFinder.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HiveDatasetFinder.java
@@ -29,6 +29,7 @@ import java.util.Properties;
 import javax.annotation.Nonnull;
 
 import lombok.Data;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.commons.lang3.StringUtils;
@@ -106,8 +107,8 @@ public class HiveDatasetFinder implements IterableDatasetFinder<HiveDataset> {
   private static final String DATASET_ERROR = "DatasetError";
   private static final String FAILURE_CONTEXT = "FailureContext";
 
+  @Getter
   protected final Properties properties;
-  public Properties getProperties() { return properties; }
   protected final HiveMetastoreClientPool clientPool;
   protected final FileSystem fs;
   private final WhitelistBlacklist whitelistBlacklist;

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
@@ -89,6 +89,7 @@ public class FileAwareInputStreamDataWriter extends InstrumentedDataWriter<FileA
   public static final String GOBBLIN_COPY_TASK_OVERWRITE_ON_COMMIT = "gobblin.copy.task.overwrite.on.commit";
   public static final boolean DEFAULT_GOBBLIN_COPY_TASK_OVERWRITE_ON_COMMIT = false;
   public static final String STAGING_DIR_SUFFIX = "/taskstaging";
+  public static final String DATASET_STAGING_DIR_PATH = "dataset.staging.dir.path";
 
   protected final AtomicLong bytesWritten = new AtomicLong();
   protected final AtomicLong filesWritten = new AtomicLong();
@@ -143,10 +144,16 @@ public class FileAwareInputStreamDataWriter extends InstrumentedDataWriter<FileA
     this.copyableDatasetMetadata =
         CopyableDatasetMetadata.deserialize(state.getProp(CopySource.SERIALIZED_COPYABLE_DATASET));
 
+    /**
+     * The staging directory defines the path of staging folder.
+     * USER_DEFINED_STATIC_STAGING_DIR_FLAG shall be set to true when user wants to specify the staging folder and the directory can be fetched through USER_DEFINED_STATIC_STAGING_DIR property.
+     * DATASET_STAGING_DIR when true creates the staging folder within a dataset location for hive dataset copying.
+     * Else system will calculate the staging directory automatically.
+     */
     if (state.getPropAsBoolean(ConfigurationKeys.USER_DEFINED_STAGING_DIR_FLAG,false)) {
       this.stagingDir = new Path(state.getProp(ConfigurationKeys.USER_DEFINED_STATIC_STAGING_DIR));
     } else if ((state.getPropAsBoolean(ConfigurationKeys.DATASET_STAGING_DIR,false))) {
-      String stg_dir = state.getProp("hive.dataset.staging.path") + STAGING_DIR_SUFFIX + "/" + state.getProp(ConfigurationKeys.JOB_NAME_KEY ) + "/" + state.getProp(ConfigurationKeys.JOB_ID_KEY);
+      String stg_dir = state.getProp(DATASET_STAGING_DIR_PATH) + STAGING_DIR_SUFFIX + "/" + state.getProp(ConfigurationKeys.JOB_NAME_KEY ) + "/" + state.getProp(ConfigurationKeys.JOB_ID_KEY);
       state.setProp(ConfigurationKeys.HIVE_DATASET_STAGING_DIR,stg_dir);
       this.stagingDir = this.writerAttemptIdOptional.isPresent() ? WriterUtils.getHiveDatasetWriterStagingDir(state, numBranches, branchId, this.writerAttemptIdOptional.get())
           : WriterUtils.getHiveDatasetWriterStagingDir(state, numBranches, branchId);

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
@@ -147,16 +147,16 @@ public class FileAwareInputStreamDataWriter extends InstrumentedDataWriter<FileA
     /**
      * The staging directory defines the path of staging folder.
      * USER_DEFINED_STATIC_STAGING_DIR_FLAG shall be set to true when user wants to specify the staging folder and the directory can be fetched through USER_DEFINED_STATIC_STAGING_DIR property.
-     * DATASET_STAGING_DIR when true creates the staging folder within a dataset location for hive dataset copying.
+     * IS_DATASET_STAGING_DIR_USED when true creates the staging folder within a dataset location for dataset copying.
      * Else system will calculate the staging directory automatically.
      */
     if (state.getPropAsBoolean(ConfigurationKeys.USER_DEFINED_STAGING_DIR_FLAG,false)) {
       this.stagingDir = new Path(state.getProp(ConfigurationKeys.USER_DEFINED_STATIC_STAGING_DIR));
-    } else if ((state.getPropAsBoolean(ConfigurationKeys.DATASET_STAGING_DIR,false))) {
+    } else if ((state.getPropAsBoolean(ConfigurationKeys.IS_DATASET_STAGING_DIR_USED,false))) {
       String stg_dir = state.getProp(DATASET_STAGING_DIR_PATH) + STAGING_DIR_SUFFIX + "/" + state.getProp(ConfigurationKeys.JOB_NAME_KEY ) + "/" + state.getProp(ConfigurationKeys.JOB_ID_KEY);
-      state.setProp(ConfigurationKeys.HIVE_DATASET_STAGING_DIR,stg_dir);
-      this.stagingDir = this.writerAttemptIdOptional.isPresent() ? WriterUtils.getHiveDatasetWriterStagingDir(state, numBranches, branchId, this.writerAttemptIdOptional.get())
-          : WriterUtils.getHiveDatasetWriterStagingDir(state, numBranches, branchId);
+      state.setProp(ConfigurationKeys.DATASET_STAGING_DIR,stg_dir);
+      this.stagingDir = this.writerAttemptIdOptional.isPresent() ? WriterUtils.getDatasetWriterStagingDir(state, numBranches, branchId, this.writerAttemptIdOptional.get())
+          : WriterUtils.getDatasetWriterStagingDir(state, numBranches, branchId);
     } else {
       this.stagingDir = this.writerAttemptIdOptional.isPresent() ? WriterUtils.getWriterStagingDir(state, numBranches, branchId, this.writerAttemptIdOptional.get())
           : WriterUtils.getWriterStagingDir(state, numBranches, branchId);

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
@@ -88,7 +88,7 @@ public class FileAwareInputStreamDataWriter extends InstrumentedDataWriter<FileA
   public static final boolean DEFAULT_GOBBLIN_COPY_CHECK_FILESIZE = false;
   public static final String GOBBLIN_COPY_TASK_OVERWRITE_ON_COMMIT = "gobblin.copy.task.overwrite.on.commit";
   public static final boolean DEFAULT_GOBBLIN_COPY_TASK_OVERWRITE_ON_COMMIT = false;
-  public static final String STAGING_DIR_SUFFIX = "/taskstaging";
+  public static final String STAGING_DIR_SUFFIX = "/taskStaging";
   public static final String DATASET_STAGING_DIR_PATH = "dataset.staging.dir.path";
 
   protected final AtomicLong bytesWritten = new AtomicLong();
@@ -153,10 +153,10 @@ public class FileAwareInputStreamDataWriter extends InstrumentedDataWriter<FileA
     if (state.getPropAsBoolean(ConfigurationKeys.USER_DEFINED_STAGING_DIR_FLAG,false)) {
       this.stagingDir = new Path(state.getProp(ConfigurationKeys.USER_DEFINED_STATIC_STAGING_DIR));
     } else if ((state.getPropAsBoolean(ConfigurationKeys.IS_DATASET_STAGING_DIR_USED,false))) {
-      String stg_dir = state.getProp(DATASET_STAGING_DIR_PATH) + STAGING_DIR_SUFFIX + "/" + state.getProp(ConfigurationKeys.JOB_NAME_KEY ) + "/" + state.getProp(ConfigurationKeys.JOB_ID_KEY);
-      state.setProp(ConfigurationKeys.DATASET_STAGING_DIR,stg_dir);
-      this.stagingDir = this.writerAttemptIdOptional.isPresent() ? WriterUtils.getDatasetWriterStagingDir(state, numBranches, branchId, this.writerAttemptIdOptional.get())
-          : WriterUtils.getDatasetWriterStagingDir(state, numBranches, branchId);
+      String stgDir = state.getProp(DATASET_STAGING_DIR_PATH) + STAGING_DIR_SUFFIX + "/" + state.getProp(ConfigurationKeys.JOB_NAME_KEY ) + "/" + state.getProp(ConfigurationKeys.JOB_ID_KEY);
+      state.setProp(ConfigurationKeys.WRITER_STAGING_DIR,stgDir);
+      this.stagingDir = this.writerAttemptIdOptional.isPresent() ? WriterUtils.getWriterStagingDir(state, numBranches, branchId, this.writerAttemptIdOptional.get())
+          : WriterUtils.getWriterStagingDir(state, numBranches, branchId);
     } else {
       this.stagingDir = this.writerAttemptIdOptional.isPresent() ? WriterUtils.getWriterStagingDir(state, numBranches, branchId, this.writerAttemptIdOptional.get())
           : WriterUtils.getWriterStagingDir(state, numBranches, branchId);

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
@@ -141,8 +141,6 @@ public class FileAwareInputStreamDataWriter extends InstrumentedDataWriter<FileA
     URI uri = URI.create(uriStr);
     this.fs = FileSystem.get(uri, conf);
     this.fileContext = FileContext.getFileContext(uri, conf);
-    this.copyableDatasetMetadata =
-        CopyableDatasetMetadata.deserialize(state.getProp(CopySource.SERIALIZED_COPYABLE_DATASET));
 
     /**
      * The staging directory defines the path of staging folder.
@@ -162,6 +160,8 @@ public class FileAwareInputStreamDataWriter extends InstrumentedDataWriter<FileA
           : WriterUtils.getWriterStagingDir(state, numBranches, branchId);
     }
 
+    this.copyableDatasetMetadata =
+        CopyableDatasetMetadata.deserialize(state.getProp(CopySource.SERIALIZED_COPYABLE_DATASET));
     this.outputDir = getOutputDir(state);
     this.recoveryHelper = new RecoveryHelper(this.fs, state);
     this.actualProcessedCopyableFile = Optional.absent();

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/WriterUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/WriterUtils.java
@@ -24,7 +24,6 @@ import java.util.concurrent.ExecutionException;
 import org.apache.avro.file.CodecFactory;
 import org.apache.avro.file.DataFileConstants;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileContext;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
@@ -92,15 +91,15 @@ public class WriterUtils {
         WriterUtils.getWriterFilePath(state, numBranches, branchId));
   }
 
-  public static Path getHiveDatasetWriterStagingDir(State state, int numBranches, int branchId) {
+  public static Path getDatasetWriterStagingDir(State state, int numBranches, int branchId) {
     String writerStagingDirKey =
-        ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.HIVE_DATASET_STAGING_DIR, numBranches, branchId);
+        ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.DATASET_STAGING_DIR, numBranches, branchId);
     Preconditions.checkArgument(state.contains(writerStagingDirKey),
         "Missing required property " + writerStagingDirKey);
 
     return new Path(
         state.getProp(
-            ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.HIVE_DATASET_STAGING_DIR, numBranches, branchId)),
+            ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.DATASET_STAGING_DIR, numBranches, branchId)),
         WriterUtils.getWriterFilePath(state, numBranches, branchId));
   }
   /**
@@ -111,9 +110,9 @@ public class WriterUtils {
     return new Path(getWriterStagingDir(state, numBranches, branchId), attemptId);
   }
 
-  public static Path getHiveDatasetWriterStagingDir(State state, int numBranches, int branchId, String attemptId) {
+  public static Path getDatasetWriterStagingDir(State state, int numBranches, int branchId, String attemptId) {
     Preconditions.checkArgument(attemptId != null && !attemptId.isEmpty(), "AttemptId cannot be null or empty: " + attemptId);
-    return new Path(getHiveDatasetWriterStagingDir(state, numBranches, branchId), attemptId);
+    return new Path(getDatasetWriterStagingDir(state, numBranches, branchId), attemptId);
   }
   /**
    * Get the {@link Path} corresponding the to the directory a given {@link org.apache.gobblin.writer.DataWriter} should be writing

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/WriterUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/WriterUtils.java
@@ -24,6 +24,7 @@ import java.util.concurrent.ExecutionException;
 import org.apache.avro.file.CodecFactory;
 import org.apache.avro.file.DataFileConstants;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileContext;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/WriterUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/WriterUtils.java
@@ -92,17 +92,6 @@ public class WriterUtils {
         WriterUtils.getWriterFilePath(state, numBranches, branchId));
   }
 
-  public static Path getDatasetWriterStagingDir(State state, int numBranches, int branchId) {
-    String writerStagingDirKey =
-        ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.DATASET_STAGING_DIR, numBranches, branchId);
-    Preconditions.checkArgument(state.contains(writerStagingDirKey),
-        "Missing required property " + writerStagingDirKey);
-
-    return new Path(
-        state.getProp(
-            ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.DATASET_STAGING_DIR, numBranches, branchId)),
-        WriterUtils.getWriterFilePath(state, numBranches, branchId));
-  }
   /**
    * Get the staging {@link Path} for {@link org.apache.gobblin.writer.DataWriter} that has attemptId in the path.
    */
@@ -111,10 +100,6 @@ public class WriterUtils {
     return new Path(getWriterStagingDir(state, numBranches, branchId), attemptId);
   }
 
-  public static Path getDatasetWriterStagingDir(State state, int numBranches, int branchId, String attemptId) {
-    Preconditions.checkArgument(attemptId != null && !attemptId.isEmpty(), "AttemptId cannot be null or empty: " + attemptId);
-    return new Path(getDatasetWriterStagingDir(state, numBranches, branchId), attemptId);
-  }
   /**
    * Get the {@link Path} corresponding the to the directory a given {@link org.apache.gobblin.writer.DataWriter} should be writing
    * its output data. The output data directory is determined by combining the

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/WriterUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/WriterUtils.java
@@ -92,6 +92,17 @@ public class WriterUtils {
         WriterUtils.getWriterFilePath(state, numBranches, branchId));
   }
 
+  public static Path getHiveDatasetWriterStagingDir(State state, int numBranches, int branchId) {
+    String writerStagingDirKey =
+        ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.HIVE_DATASET_STAGING_DIR, numBranches, branchId);
+    Preconditions.checkArgument(state.contains(writerStagingDirKey),
+        "Missing required property " + writerStagingDirKey);
+
+    return new Path(
+        state.getProp(
+            ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.HIVE_DATASET_STAGING_DIR, numBranches, branchId)),
+        WriterUtils.getWriterFilePath(state, numBranches, branchId));
+  }
   /**
    * Get the staging {@link Path} for {@link org.apache.gobblin.writer.DataWriter} that has attemptId in the path.
    */
@@ -100,6 +111,10 @@ public class WriterUtils {
     return new Path(getWriterStagingDir(state, numBranches, branchId), attemptId);
   }
 
+  public static Path getHiveDatasetWriterStagingDir(State state, int numBranches, int branchId, String attemptId) {
+    Preconditions.checkArgument(attemptId != null && !attemptId.isEmpty(), "AttemptId cannot be null or empty: " + attemptId);
+    return new Path(getHiveDatasetWriterStagingDir(state, numBranches, branchId), attemptId);
+  }
   /**
    * Get the {@link Path} corresponding the to the directory a given {@link org.apache.gobblin.writer.DataWriter} should be writing
    * its output data. The output data directory is determined by combining the


### PR DESCRIPTION
…asetFinder

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- https://issues.apache.org/jira/browse/GOBBLIN-1222


### Description
- To incorporate the hive datasets as the part of staging directory. With the new configurations created with this PR: while copying hive datasets, staging directory will have dataset and database name as part of it. Therefore, it will help create staging directory within the destination shard while performing data copying onto cloud cluster.


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

