### PR TITLE
[GOBBLIN-1232]Enable verbose mode for waitForCompletion call

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/mapreduce/MRTask.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/mapreduce/MRTask.java
@@ -107,7 +107,7 @@ public class MRTask extends BaseAbstractTask {
       log.info("MR tracking URL {} for job {}", job.getTrackingURL(), job.getJobName());
 
       this.eventSubmitter.submit(Events.MR_JOB_STARTED_EVENT, Events.JOB_URL, job.getTrackingURL());
-      job.waitForCompletion(false);
+      job.waitForCompletion(true);
       this.mrJob = job;
 
       if (job.isSuccessful()) {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- https://issues.apache.org/jira/browse/GOBBLIN-1232


### Description
This is just to enable the verbose mode for waitForCompletion call to get more information on an internal intermittent bug.


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

