### PR TITLE
[GOBBLIN-1241] Allow nodes/edges in HOCON format and delay resolution to allow overriding

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GitFlowGraphMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GitFlowGraphMonitor.java
@@ -184,13 +184,10 @@ public class GitFlowGraphMonitor extends GitMonitoringService {
     if (checkFilePath(change.getNewPath(), NODE_FILE_DEPTH)) {
       Path nodeFilePath = new Path(this.repositoryDir, change.getNewPath());
       try {
-        // Temporarily resolve the data node config when constructing it, but leave it unresolved after to allow overriding
-        Config unresolvedConfig = loadNodeFileWithOverrides(nodeFilePath);
-        Config resolvedConfig = unresolvedConfig.resolve();
-        Class dataNodeClass = Class.forName(ConfigUtils.getString(unresolvedConfig, FlowGraphConfigurationKeys.DATA_NODE_CLASS,
+        Config config = loadNodeFileWithOverrides(nodeFilePath);
+        Class dataNodeClass = Class.forName(ConfigUtils.getString(config, FlowGraphConfigurationKeys.DATA_NODE_CLASS,
             FlowGraphConfigurationKeys.DEFAULT_DATA_NODE_CLASS));
-        DataNode dataNode = (DataNode) GobblinConstructorUtils.invokeLongestConstructor(dataNodeClass, resolvedConfig);
-        dataNode.setRawConfig(unresolvedConfig);
+        DataNode dataNode = (DataNode) GobblinConstructorUtils.invokeLongestConstructor(dataNodeClass, config);
         if (!this.flowGraph.addDataNode(dataNode)) {
           log.warn("Could not add DataNode {} to FlowGraph; skipping", dataNode.getId());
         } else {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GitMonitoringService.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GitMonitoringService.java
@@ -101,6 +101,7 @@ public abstract class GitMonitoringService extends AbstractIdleService {
   final String folderName;
   final PullFileLoader pullFileLoader;
   final Set<String> javaPropsExtensions;
+  final Set<String> hoconFileExtensions;
 
   protected volatile boolean isActive = false;
 
@@ -169,11 +170,11 @@ public abstract class GitMonitoringService extends AbstractIdleService {
 
     Path folderPath = new Path(this.repositoryDir, this.folderName);
     this.javaPropsExtensions = Sets.newHashSet(config.getString(JAVA_PROPS_EXTENSIONS).split(","));
-    Set<String> hoconFileExtensions = Sets.newHashSet(config.getString(HOCON_FILE_EXTENSIONS).split(","));
+    this.hoconFileExtensions = Sets.newHashSet(config.getString(HOCON_FILE_EXTENSIONS).split(","));
     try {
       this.pullFileLoader = new PullFileLoader(folderPath,
           FileSystem.get(URI.create(ConfigurationKeys.LOCAL_FS_URI), new Configuration()),
-          this.javaPropsExtensions, hoconFileExtensions);
+          this.javaPropsExtensions, this.hoconFileExtensions);
     } catch (IOException e) {
       throw new RuntimeException("Could not create pull file loader", e);
     }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/BaseDataNode.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/BaseDataNode.java
@@ -23,6 +23,7 @@ import com.typesafe.config.Config;
 import joptsimple.internal.Strings;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.gobblin.annotation.Alpha;
@@ -39,6 +40,7 @@ public class BaseDataNode implements DataNode {
   @Getter
   private String id;
   @Getter
+  @Setter
   private Config rawConfig;
   @Getter
   private boolean active = true;

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/BaseDataNode.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/BaseDataNode.java
@@ -23,7 +23,6 @@ import com.typesafe.config.Config;
 import joptsimple.internal.Strings;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.gobblin.annotation.Alpha;
@@ -40,20 +39,22 @@ public class BaseDataNode implements DataNode {
   @Getter
   private String id;
   @Getter
-  @Setter
   private Config rawConfig;
+  @Getter
+  private Config resolvedConfig;
   @Getter
   private boolean active = true;
 
   public BaseDataNode(Config nodeProps) throws DataNodeCreationException {
     try {
-      String nodeId = ConfigUtils.getString(nodeProps, FlowGraphConfigurationKeys.DATA_NODE_ID_KEY, "");
+      this.rawConfig = nodeProps;
+      this.resolvedConfig = nodeProps.resolve();
+      String nodeId = ConfigUtils.getString(this.resolvedConfig, FlowGraphConfigurationKeys.DATA_NODE_ID_KEY, "");
       Preconditions.checkArgument(!Strings.isNullOrEmpty(nodeId), "Node Id cannot be null or empty");
       this.id = nodeId;
-      if (nodeProps.hasPath(FlowGraphConfigurationKeys.DATA_NODE_IS_ACTIVE_KEY)) {
-        this.active = nodeProps.getBoolean(FlowGraphConfigurationKeys.DATA_NODE_IS_ACTIVE_KEY);
+      if (this.resolvedConfig.hasPath(FlowGraphConfigurationKeys.DATA_NODE_IS_ACTIVE_KEY)) {
+        this.active = this.resolvedConfig.getBoolean(FlowGraphConfigurationKeys.DATA_NODE_IS_ACTIVE_KEY);
       }
-      this.rawConfig = nodeProps;
     } catch (Exception e) {
       throw new DataNodeCreationException(e);
     }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/BaseDataNode.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/BaseDataNode.java
@@ -34,7 +34,7 @@ import org.apache.gobblin.util.ConfigUtils;
  */
 @Alpha
 @Slf4j
-@EqualsAndHashCode (exclude = {"rawConfig", "active"})
+@EqualsAndHashCode (exclude = {"rawConfig", "resolvedConfig", "active"})
 public class BaseDataNode implements DataNode {
   @Getter
   private String id;

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/DataNode.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/DataNode.java
@@ -39,6 +39,12 @@ public interface DataNode {
   Config getRawConfig();
 
   /**
+   * Set raw config. This should only be used in cases where the data node's actual config should be different from the
+   * config it is constructed with (e.g. constructing with a resolved config).
+   */
+  void setRawConfig(Config config);
+
+  /**
    * @return a default dataset descriptor class for this DataNode, or null if a default should not be used.
    */
   String getDefaultDatasetDescriptorClass();

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/DataNode.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/DataNode.java
@@ -39,12 +39,6 @@ public interface DataNode {
   Config getRawConfig();
 
   /**
-   * Set raw config. This should only be used in cases where the data node's actual config should be different from the
-   * config it is constructed with (e.g. constructing with a resolved config).
-   */
-  void setRawConfig(Config config);
-
-  /**
    * @return a default dataset descriptor class for this DataNode, or null if a default should not be used.
    */
   String getDefaultDatasetDescriptorClass();

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/datanodes/fs/FileSystemDataNode.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/flowgraph/datanodes/fs/FileSystemDataNode.java
@@ -52,7 +52,7 @@ public abstract class FileSystemDataNode extends BaseDataNode {
   public FileSystemDataNode(Config nodeProps) throws DataNodeCreationException {
     super(nodeProps);
     try {
-      this.fsUri = ConfigUtils.getString(nodeProps, FS_URI_KEY, "");
+      this.fsUri = ConfigUtils.getString(this.getResolvedConfig(), FS_URI_KEY, "");
       Preconditions.checkArgument(!Strings.isNullOrEmpty(this.fsUri), "fs.uri cannot be null or empty.");
 
       //Validate the srcFsUri and destFsUri of the DataNode.


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1241


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
1. Allow data nodes/edges to optionally use .conf files for HOCON format instead of only java format
2. Delay resolution of data nodes/edges to allow overriding, but temporarily resolve config when constructing data nodes to allow for example passing fs.uri validation check

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tested GaaS locally with .conf files and overriding

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

