### PR TITLE
[GOBBLIN-1213] add common job properties to jobProps using putAll

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -353,7 +353,7 @@ public class ConfigurationKeys {
   public static final String FORK_MAX_WAIT_MININUTES = "fork.max.wait.minutes";
   public static final long DEFAULT_FORK_MAX_WAIT_MININUTES = 60;
   public static final String FORK_CLOSE_WRITER_ON_COMPLETION = "fork.closeWriterOnCompletion";
-  public static final boolean DEFAULT_FORK_CLOSE_WRITER_ON_COMPLETION = true;
+  public static final boolean DEFAULT_FORK_CLOSE_WRITER_ON_COMPLETION = false;
 
 
   /**

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobScheduler.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJobScheduler.java
@@ -304,7 +304,8 @@ public class GobblinHelixJobScheduler extends JobScheduler implements StandardMe
     String jobUri = newJobArrival.getJobName();
     LOGGER.info("Received new job configuration of job " + jobUri);
     try {
-      Properties jobProps = new Properties(this.commonJobProperties);
+      Properties jobProps = new Properties();
+      jobProps.putAll(this.commonJobProperties);
       jobProps.putAll(newJobArrival.getJobConfig());
 
       // set uri so that we can delete this job later


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1213


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
1) Properties p2 = Properties(Properties p1) constructor create `Properties` with p1's properties as a `default` properties of p2. Properties.putAll() method does not put `default` properties.
Changing the way jobProps are initialized so that common job properties are propagated to some other Properties when jobProps.putAll() is called () in HelixRetriggeringJobCallable

2) change default for fork.closeWriterOnCompletion to false for backward compatibility


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
trivial changes

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

