### PR TITLE
[GOBBLIN-1251] Propagate exception in TaskStateTracker for caller to trigger Helix retry

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixTaskStateTracker.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixTaskStateTracker.java
@@ -22,9 +22,6 @@ import java.util.Properties;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledFuture;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Maps;
@@ -49,7 +46,7 @@ import org.apache.gobblin.runtime.Task;
 public class GobblinHelixTaskStateTracker extends AbstractTaskStateTracker {
   @VisibleForTesting
   static final String IS_TASK_METRICS_SCHEDULING_FAILURE_FATAl = "helixTaskTracker.isNewTaskRegFailureFatal";
-  private static final String DEFAULT_TASK_METRICS_SCHEDULING_FAILURE_FATAl = "false";
+  private static final String DEFAULT_TASK_METRICS_SCHEDULING_FAILURE_FATAL = "false";
 
   // Mapping between tasks and the task state reporters associated with them
   private final Map<String, ScheduledFuture<?>> scheduledReporters = Maps.newHashMap();
@@ -58,7 +55,7 @@ public class GobblinHelixTaskStateTracker extends AbstractTaskStateTracker {
   public GobblinHelixTaskStateTracker(Properties properties) {
     super(properties, log);
     isNewTaskRegFailureFatal = Boolean.parseBoolean(properties.getProperty(IS_TASK_METRICS_SCHEDULING_FAILURE_FATAl,
-        DEFAULT_TASK_METRICS_SCHEDULING_FAILURE_FATAl));
+        DEFAULT_TASK_METRICS_SCHEDULING_FAILURE_FATAL));
   }
 
   @Override

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixTaskStateTracker.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixTaskStateTracker.java
@@ -45,7 +45,7 @@ import org.apache.gobblin.runtime.Task;
 @Slf4j
 public class GobblinHelixTaskStateTracker extends AbstractTaskStateTracker {
   @VisibleForTesting
-  static final String IS_TASK_METRICS_SCHEDULING_FAILURE_FATAl = "helixTaskTracker.isNewTaskRegFailureFatal";
+  static final String IS_TASK_METRICS_SCHEDULING_FAILURE_FATAL = "helixTaskTracker.isNewTaskRegFailureFatal";
   private static final String DEFAULT_TASK_METRICS_SCHEDULING_FAILURE_FATAL = "false";
 
   // Mapping between tasks and the task state reporters associated with them
@@ -54,7 +54,7 @@ public class GobblinHelixTaskStateTracker extends AbstractTaskStateTracker {
 
   public GobblinHelixTaskStateTracker(Properties properties) {
     super(properties, log);
-    isNewTaskRegFailureFatal = Boolean.parseBoolean(properties.getProperty(IS_TASK_METRICS_SCHEDULING_FAILURE_FATAl,
+    isNewTaskRegFailureFatal = Boolean.parseBoolean(properties.getProperty(IS_TASK_METRICS_SCHEDULING_FAILURE_FATAL,
         DEFAULT_TASK_METRICS_SCHEDULING_FAILURE_FATAL));
   }
 

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinHelixTaskTest.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinHelixTaskTest.java
@@ -32,7 +32,6 @@ import org.apache.gobblin.example.simplejson.SimpleJsonSource;
 import org.apache.gobblin.metastore.FsStateStore;
 import org.apache.gobblin.runtime.AbstractJobLauncher;
 import org.apache.gobblin.runtime.JobState;
-import org.apache.gobblin.runtime.TaskCreationException;
 import org.apache.gobblin.runtime.TaskExecutor;
 import org.apache.gobblin.source.workunit.WorkUnit;
 import org.apache.gobblin.util.Id;
@@ -68,7 +67,7 @@ import com.google.common.eventbus.Subscribe;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigValueFactory;
 
-import static org.apache.gobblin.cluster.GobblinHelixTaskStateTracker.IS_TASK_METRICS_SCHEDULING_FAILURE_FATAl;
+import static org.apache.gobblin.cluster.GobblinHelixTaskStateTracker.IS_TASK_METRICS_SCHEDULING_FAILURE_FATAL;
 import static org.apache.gobblin.util.retry.RetryerFactory.RETRY_TIMES;
 import static org.apache.gobblin.util.retry.RetryerFactory.RETRY_TYPE;
 import static org.mockito.Mockito.when;
@@ -114,7 +113,7 @@ public class GobblinHelixTaskTest {
     this.helixManager = Mockito.mock(HelixManager.class);
     when(this.helixManager.getInstanceName()).thenReturn(GobblinHelixTaskTest.class.getSimpleName());
     Properties stateTrackerProp = new Properties();
-    stateTrackerProp.setProperty(IS_TASK_METRICS_SCHEDULING_FAILURE_FATAl, "true");
+    stateTrackerProp.setProperty(IS_TASK_METRICS_SCHEDULING_FAILURE_FATAL, "true");
     this.taskStateTracker = new GobblinHelixTaskStateTracker(stateTrackerProp);
 
     this.localFs = FileSystem.getLocal(configuration);

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinHelixTaskTest.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinHelixTaskTest.java
@@ -68,6 +68,7 @@ import com.google.common.eventbus.Subscribe;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigValueFactory;
 
+import static org.apache.gobblin.cluster.GobblinHelixTaskStateTracker.IS_TASK_METRICS_SCHEDULING_FAILURE_FATAl;
 import static org.apache.gobblin.util.retry.RetryerFactory.RETRY_TIMES;
 import static org.apache.gobblin.util.retry.RetryerFactory.RETRY_TYPE;
 import static org.mockito.Mockito.when;
@@ -112,7 +113,9 @@ public class GobblinHelixTaskTest {
 
     this.helixManager = Mockito.mock(HelixManager.class);
     when(this.helixManager.getInstanceName()).thenReturn(GobblinHelixTaskTest.class.getSimpleName());
-    this.taskStateTracker = new GobblinHelixTaskStateTracker(new Properties());
+    Properties stateTrackerProp = new Properties();
+    stateTrackerProp.setProperty(IS_TASK_METRICS_SCHEDULING_FAILURE_FATAl, "true");
+    this.taskStateTracker = new GobblinHelixTaskStateTracker(stateTrackerProp);
 
     this.localFs = FileSystem.getLocal(configuration);
     this.appWorkDir = new Path(GobblinHelixTaskTest.class.getSimpleName());

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/GobblinMultiTaskAttempt.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/GobblinMultiTaskAttempt.java
@@ -389,8 +389,8 @@ public class GobblinMultiTaskAttempt {
     List<Task> tasks = Lists.newArrayList();
 
     // A flag indicating if there are any tasks not submitted successfully.
-    // Caller of this method should handler un-submitted task accordingly.
-    boolean areAllTaskSubmitted = true;
+    // Caller of this method should handle tasks with submission failures accordingly.
+    boolean areAllTasksSubmitted = true;
     while (this.workUnits.hasNext()) {
       WorkUnit workUnit = this.workUnits.next();
       String taskId = workUnit.getProp(ConfigurationKeys.TASK_ID_KEY);
@@ -431,7 +431,7 @@ public class GobblinMultiTaskAttempt {
         if (task == null) {
           if (e instanceof RetryException) {
             // Indicating task being null due to failure in creation even after retrying.
-            areAllTaskSubmitted = false;
+            areAllTasksSubmitted = false;
           }
           // task could not be created, so directly count down
           countDownLatch.countDown();
@@ -440,7 +440,7 @@ public class GobblinMultiTaskAttempt {
           // Task was created and may have been registered, but not submitted, so call the
           // task state tracker task run completion directly since the task cancel does nothing if not submitted
           this.taskStateTracker.onTaskRunCompletion(task);
-          areAllTaskSubmitted = false;
+          areAllTasksSubmitted = false;
           log.error("Could not submit task for workunit {}", workUnit, e);
         } else {
           // task was created and submitted, but failed later, so cancel the task to decrement the CountDownLatch
@@ -455,7 +455,7 @@ public class GobblinMultiTaskAttempt {
     eventSubmitterBuilder.addMetadata(this.taskEventMetadataGenerator.getMetadata(jobState, JobEvent.TASKS_SUBMITTED));
     eventSubmitterBuilder.build().submit(JobEvent.TASKS_SUBMITTED, "tasksCount", Long.toString(countDownLatch.getRegisteredParties()));
 
-    return new Pair<>(tasks, areAllTaskSubmitted);
+    return new Pair<>(tasks, areAllTasksSubmitted);
   }
 
   private void printMemoryUsage() {

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/GobblinMultiTaskAttemptTest.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/GobblinMultiTaskAttemptTest.java
@@ -73,7 +73,6 @@ public class GobblinMultiTaskAttemptTest {
     JobState jobState = new JobState();
     // Limit the number of times of retry in task-creation.
     jobState.setProp(RETRY_TIME_OUT_MS, 1000);
-    jobState.setProp(ConfigurationKeys.SOURCE_CLASS_KEY, DatasetStateStoreTest.DummySource.class.getName());
     TaskStateTracker stateTrackerMock = Mockito.mock(TaskStateTracker.class);
 
     taskAttempt =
@@ -105,6 +104,7 @@ public class GobblinMultiTaskAttemptTest {
     JobState jobState = new JobState();
     // Limit the number of times of retry in task-creation.
     jobState.setProp(RETRY_TIME_OUT_MS, 1000);
+    jobState.setProp(ConfigurationKeys.SOURCE_CLASS_KEY, DatasetStateStoreTest.DummySource.class.getName());
 
     taskAttempt = new GobblinMultiTaskAttempt(workUnit.iterator(), "testJob", jobState, stateTracker, taskExecutorMock,
         Optional.absent(), Optional.absent(), jobBroker);
@@ -114,7 +114,7 @@ public class GobblinMultiTaskAttemptTest {
       // as a way to simulate the case when scheduling reporter is rejected.
       taskAttempt.run();
     } catch (Exception e) {
-      Assert.assertTrue(e instanceof RuntimeException);
+      Assert.assertTrue(e instanceof TaskCreationException);
       return;
     }
 

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/GobblinMultiTaskAttemptTest.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/GobblinMultiTaskAttemptTest.java
@@ -24,6 +24,7 @@ import java.util.Properties;
 import org.junit.Assert;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import com.google.common.base.Optional;
@@ -49,6 +50,7 @@ public class GobblinMultiTaskAttemptTest {
   private TaskExecutor taskExecutorMock;
   private SharedResourcesBrokerImpl<GobblinScopeTypes> jobBroker;
 
+  @BeforeClass
   public void setup() {
     // Initializing jobBroker
     Config config = ConfigFactory.empty();
@@ -71,6 +73,7 @@ public class GobblinMultiTaskAttemptTest {
     JobState jobState = new JobState();
     // Limit the number of times of retry in task-creation.
     jobState.setProp(RETRY_TIME_OUT_MS, 1000);
+    jobState.setProp(ConfigurationKeys.SOURCE_CLASS_KEY, DatasetStateStoreTest.DummySource.class.getName());
     TaskStateTracker stateTrackerMock = Mockito.mock(TaskStateTracker.class);
 
     taskAttempt =
@@ -82,7 +85,7 @@ public class GobblinMultiTaskAttemptTest {
       // org.apache.gobblin.runtime.TaskContext.getSource
       taskAttempt.run();
     } catch (Exception e) {
-      Assert.assertTrue(e instanceof IOException);
+      Assert.assertTrue(e instanceof TaskCreationException);
       return;
     }
 


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- https://issues.apache.org/jira/browse/GOBBLIN-1251


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
`registerNewTask` called in `org.apache.gobblin.runtime.GobblinMultiTaskAttempt#runWorkUnits(org.apache.gobblin.runtime.CountUpAndDownLatch)` would swallow the exception if scheduling failed before this change. Post the change, the exception-handling logic within `runWorkunits` will handle it and retry if necessary. 

Also did some comment-enhancement and variable renaming which doesn't break atomicity for this PR since they are relevant.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

