### PR TITLE
GOBBLIN-1252: Provide a default flow SLA for Gobblin Service flows

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/service/ServiceConfigKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/service/ServiceConfigKeys.java
@@ -118,4 +118,8 @@ public class ServiceConfigKeys {
 
   // Prefix for config to ServiceBasedAppLauncher that will only be used by GaaS and not orchestrated jobs
   public static final String GOBBLIN_SERVICE_APP_LAUNCHER_PREFIX = "gobblinServiceAppLauncher";
+
+  //Flow concurrency config key to control default service behavior.
+  public static final String FLOW_CONCURRENCY_ALLOWED = GOBBLIN_SERVICE_PREFIX + "flowConcurrencyAllowed";
+  public static final Boolean DEFAULT_FLOW_CONCURRENCY_ALLOWED = true;
 }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
@@ -686,7 +686,7 @@ public class DagManager extends AbstractIdleService {
         dagToSLA.put(dagId, flowSla);
       }
 
-      if (flowSla != DagManagerUtils.NO_SLA && currentTime > flowStartTime + flowSla) {
+      if (currentTime > flowStartTime + flowSla) {
         log.info("Flow {} exceeded the SLA of {} ms. Killing the job {} now...",
             node.getValue().getJobSpec().getConfig().getString(ConfigurationKeys.FLOW_NAME_KEY), flowSla,
             node.getValue().getJobSpec().getConfig().getString(ConfigurationKeys.JOB_NAME_KEY));

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagerUtils.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagerUtils.java
@@ -45,7 +45,7 @@ import org.apache.gobblin.util.ConfigUtils;
 
 
 public class DagManagerUtils {
-  static long NO_SLA = -1L;
+  static long DEFAULT_FLOW_SLA_MILLIS = TimeUnit.HOURS.toMillis(24);
   static String QUOTA_KEY_SEPERATOR = ",";
 
   static FlowId getFlowId(Dag<JobExecutionPlan> dag) {
@@ -255,7 +255,7 @@ public class DagManagerUtils {
    * get the sla from the dag node config.
    * if time unit is not provided, it assumes time unit is minute.
    * @param dagNode dag node for which sla is to be retrieved
-   * @return sla if it is provided, {@value NO_SLA} otherwise
+   * @return sla if it is provided, DEFAULT_FLOW_SLA_MILLIS otherwise
    */
   static long getFlowSLA(DagNode<JobExecutionPlan> dagNode) {
     Config jobConfig = dagNode.getValue().getJobSpec().getConfig();
@@ -264,7 +264,7 @@ public class DagManagerUtils {
 
     return jobConfig.hasPath(ConfigurationKeys.GOBBLIN_FLOW_SLA_TIME)
         ? slaTimeUnit.toMillis(jobConfig.getLong(ConfigurationKeys.GOBBLIN_FLOW_SLA_TIME))
-        : NO_SLA;
+        : DEFAULT_FLOW_SLA_MILLIS;
   }
 
   /**


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1252


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Currently, Gobblin service flows have no Flow level SLA enabled by default. This task sets the default flow SLA for each flow orchestrated by GaaS. In addition, this PR also exposes a service level configuration key to control the default flow concurrency behavior. 


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Enhanced existing unit tests.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

