### PR TITLE
GOBBLIN-1253: Update running jobs counter on Gobblin service restart

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
@@ -527,6 +527,8 @@ public class DagManager extends AbstractIdleService {
       for (DagNode<JobExecutionPlan> dagNode : dag.getNodes()) {
         if (DagManagerUtils.getExecutionStatus(dagNode) == RUNNING) {
           addJobState(dagId, dagNode);
+          //Update the running jobs counter.
+          getRunningJobsCounter(dagNode).inc();
           isDagRunning = true;
         }
       }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1253


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
On service restart or leadership change, the ownership of running dags are transferred to the new master. On this change, we need to correctly initialize the running jobs counter to account for already running jobs prior to the change. 


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
NA

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

