### PR TITLE
[GOBBLIN-1254] Skip undecodeable message in KafkaAvroJobStatusMonitor

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaAvroJobStatusMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaAvroJobStatusMonitor.java
@@ -95,7 +95,7 @@ public class KafkaAvroJobStatusMonitor extends KafkaJobStatusMonitor {
     try {
       GobblinTrackingEvent decodedMessage = this.reader.get().read(null, decoder);
       return parseJobStatus(decodedMessage);
-    } catch (AvroRuntimeException | IOException exc) {
+    } catch (Exception exc) {
       this.messageParseFailures.mark();
       if (this.messageParseFailures.getFiveMinuteRate() < 1) {
         log.warn("Unable to decode input message.", exc);


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/GOBBLIN-1254


### Description
- [x] Here are some details about my PR:
 - `KafkaAvroJobStatusMonitor` should skip any undecodeable message to be able to continuously processing the valid messages behind.

### Tests
- [x] My PR adds the following unit tests:
 - Add coverage in unit test `KafkaAvroJobStatusMonitorTest.testProcessMessageForFailedFlow` to check an undecodeable message is successfully skipped.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

