### PR TITLE
[GOBBLIN-1255] Wait for compiler to be healthy before scheduling flows on startup

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobScheduler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/scheduler/GobblinServiceJobScheduler.java
@@ -144,6 +144,12 @@ public class GobblinServiceJobScheduler extends JobScheduler implements SpecCata
         Thread scheduleSpec = new Thread(new Runnable() {
           @Override
           public void run() {
+            // Ensure compiler is healthy before attempting to schedule flows
+            try {
+              GobblinServiceJobScheduler.this.orchestrator.getSpecCompiler().awaitHealthy();
+            } catch (InterruptedException e) {
+              throw new RuntimeException(e);
+            }
             scheduleSpecsFromCatalog();
           }
         });


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1255


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

Fix race condition where flows may fail to compile when they are scheduled on startup because the compiler is not healthy yet.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Updated unit test and tested in gaas locally

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

