### PR TITLE
[GOBBLIN-1256]Exclude log4j related jars in compile but include those in test

### DIFF
--- a/gradle/scripts/globalDependencies.gradle
+++ b/gradle/scripts/globalDependencies.gradle
@@ -21,6 +21,7 @@ import javax.tools.ToolProvider
 subprojects {
   plugins.withType(JavaPlugin) {
     configurations {
+      customTestCompile
       compile
       dependencies {
         if (!project.name.contains('gobblin-elasticsearch-deps')) {
@@ -35,19 +36,34 @@ subprojects {
           compile(externalDependency.guava) {
               force = true
           }
-      }
-          compile(externalDependency.commonsCodec) {
-            force = true
-          }
+        }
+        compile(externalDependency.commonsCodec) {
+          force = true
+        }
+        //Since testCompile inherit from compile, so we cannot use testCompile to import dependency for log4j
+        customTestCompile externalDependency.log4j
+        customTestCompile externalDependency.slf4jToLog4j
 
         // Required to add JDK's tool jar, which is required to run byteman tests.
         testCompile (files(((URLClassLoader) ToolProvider.getSystemToolClassLoader()).getURLs()))
       }
+      if (!project.name.contains('gobblin-aws')) {
+        //exclude this jar because we introduce log4j-over-slf4j, these two jars cannot present at the same time
+        configurations.compile.dependencies*.each {
+          it.exclude group: 'log4j', module: 'log4j'
+          it.exclude group: 'org.slf4j', module: 'slf4j-log4j12'
+          it.exclude group: 'log4j', module: 'apache-log4j-extras'
+        }
+      }
       all*.exclude group: 'org.apache.calcite', module: 'calcite-avatica' // replaced by org.apache.calcite.avatica:avatica-core
-      //exclude this jar because we introduce log4j-over-slf4j, these two jars cannot present at the same time
-      compileClasspath.exclude group: 'org.slf4j', module: 'slf4j-log4j12'
       //exclude this jar in test class path because we are using log4j implementation to test
       testCompile.exclude group: 'org.slf4j', module: 'log4j-over-slf4j'
+    }
+    test{
+      //Add log4j into runtime path
+      classpath += configurations.customTestCompile
+      //Add log4j into compile path
+      sourceSets.test.compileClasspath += configurations.customTestCompile
     }
   }
 

--- a/gradle/scripts/globalDependencies.gradle
+++ b/gradle/scripts/globalDependencies.gradle
@@ -48,10 +48,11 @@ subprojects {
         testCompile (files(((URLClassLoader) ToolProvider.getSystemToolClassLoader()).getURLs()))
       }
       if (!project.name.contains('gobblin-aws')) {
-        //exclude this jar because we introduce log4j-over-slf4j, these two jars cannot present at the same time
         configurations.compile.dependencies*.each {
-          it.exclude group: 'log4j', module: 'log4j'
+          //exclude this jar because we introduce log4j-over-slf4j, these two jars cannot present at the same time
           it.exclude group: 'org.slf4j', module: 'slf4j-log4j12'
+          //exclude log4j related jars to provide a clean log environment
+          it.exclude group: 'log4j', module: 'log4j'
           it.exclude group: 'log4j', module: 'apache-log4j-extras'
         }
       }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1256


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
This PR exclude all the log4j related jar from our published artifacts except gobblin-aws to provide a clean dependency for user. After this change, user who depend on gobblin will need to specify the log implementation in their project, i.e log4jV1 or log4jV2. 
Also this pr remain the log4j related dependency in unit test since we still use Log4j API to test. 

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Run unit test
Publish snapshot version and verify that we don't have log4j jars in the transitive dependency.

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

