### PR TITLE
GOBBLIN-1266: Refactor dataset lineage code to allow Lineage event emission in streaming mode

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/publisher/BaseDataPublisher.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/publisher/BaseDataPublisher.java
@@ -371,7 +371,7 @@ public class BaseDataPublisher extends SingleTaskDataPublisher {
    * This method publishes task output data for the given {@link WorkUnitState}, but if there are output data of
    * other tasks in the same folder, it may also publish those data.
    */
-  private void publishMultiTaskData(WorkUnitState state, int branchId, Set<Path> writerOutputPathsMoved)
+  protected void publishMultiTaskData(WorkUnitState state, int branchId, Set<Path> writerOutputPathsMoved)
       throws IOException {
     publishData(state, branchId, false, writerOutputPathsMoved);
     addLineageInfo(state, branchId);

--- a/gobblin-core/src/main/java/org/apache/gobblin/writer/PartitionedDataWriter.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/writer/PartitionedDataWriter.java
@@ -56,6 +56,7 @@ import org.apache.gobblin.instrumented.writer.InstrumentedDataWriterDecorator;
 import org.apache.gobblin.instrumented.writer.InstrumentedPartitionedDataWriterDecorator;
 import org.apache.gobblin.records.ControlMessageHandler;
 import org.apache.gobblin.stream.ControlMessage;
+import org.apache.gobblin.stream.FlushControlMessage;
 import org.apache.gobblin.stream.MetadataUpdateControlMessage;
 import org.apache.gobblin.stream.RecordEnvelope;
 import org.apache.gobblin.stream.StreamEntity;
@@ -395,6 +396,9 @@ public class PartitionedDataWriter<S, D> extends WriterWrapper<D> implements Fin
             .getGlobalMetadata().getSchema());
         state.setProp(WRITER_LATEST_SCHEMA, ((MetadataUpdateControlMessage) message)
             .getGlobalMetadata().getSchema());
+      } else if (message instanceof FlushControlMessage){
+        //Add Partition info to state to report partition level lineage events on Flush
+        serializePartitionInfoToState();
       }
 
       synchronized (PartitionedDataWriter.this) {
@@ -411,7 +415,7 @@ public class PartitionedDataWriter<S, D> extends WriterWrapper<D> implements Fin
   /**
    * Get the serialized key to partitions info in {@link #state}
    */
-  private static String getPartitionsKey(int branchId) {
+  public static String getPartitionsKey(int branchId) {
     return String.format("writer.%d.partitions", branchId);
   }
 

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/SafeDatasetCommit.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/SafeDatasetCommit.java
@@ -29,8 +29,11 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.common.io.Closer;
+
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import org.apache.gobblin.commit.CommitSequence;
 import org.apache.gobblin.commit.CommitStep;
@@ -38,8 +41,6 @@ import org.apache.gobblin.commit.DeliverySemantics;
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.WorkUnitState;
 import org.apache.gobblin.instrumented.Instrumented;
-import org.apache.gobblin.metrics.event.EventSubmitter;
-import org.apache.gobblin.metrics.event.lineage.LineageEventBuilder;
 import org.apache.gobblin.metrics.MetricContext;
 import org.apache.gobblin.metrics.event.FailureEventBuilder;
 import org.apache.gobblin.metrics.event.lineage.LineageInfo;
@@ -51,10 +52,6 @@ import org.apache.gobblin.runtime.commit.DatasetStateCommitStep;
 import org.apache.gobblin.runtime.task.TaskFactory;
 import org.apache.gobblin.runtime.task.TaskUtils;
 import org.apache.gobblin.source.extractor.JobCommitPolicy;
-
-import lombok.Data;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
 
 /**
@@ -228,11 +225,11 @@ final class SafeDatasetCommit implements Callable<Void> {
     try {
       if (StringUtils.isEmpty(datasetUrn)) {
         // This dataset may contain different kinds of LineageEvent
-        for (Map.Entry<String, Collection<TaskState>> entry : aggregateByLineageEvent(states).entrySet()) {
-          submitLineageEvent(entry.getKey(), entry.getValue());
+        for (Map.Entry<String, Collection<WorkUnitState>> entry : LineageInfo.aggregateByLineageEvent(states).entrySet()) {
+          LineageInfo.submitLineageEvent(entry.getKey(), entry.getValue(), metricContext);
         }
       } else {
-        submitLineageEvent(datasetUrn, states);
+        LineageInfo.submitLineageEvent(datasetUrn, states, metricContext);
       }
     } finally {
       // Purge lineage info from all states
@@ -240,13 +237,6 @@ final class SafeDatasetCommit implements Callable<Void> {
         LineageInfo.purgeLineageInfo(taskState);
       }
     }
-  }
-
-  private void submitLineageEvent(String dataset, Collection<TaskState> states) {
-    Collection<LineageEventBuilder> events = LineageInfo.load(states);
-    // Send events
-    events.forEach(event -> EventSubmitter.submit(this.metricContext, event));
-    log.info(String.format("Submitted %d lineage events for dataset %s", events.size(), dataset));
   }
 
   /**
@@ -442,14 +432,4 @@ final class SafeDatasetCommit implements Callable<Void> {
         .withDatasetState(datasetState).build());
   }
 
-  private static Map<String, Collection<TaskState>> aggregateByLineageEvent(Collection<TaskState> states) {
-    Map<String, Collection<TaskState>> statesByEvents = Maps.newHashMap();
-    for (TaskState state : states) {
-      String eventName = LineageInfo.getFullEventName(state);
-      Collection<TaskState> statesForEvent = statesByEvents.computeIfAbsent(eventName, k -> Lists.newArrayList());
-      statesForEvent.add(state);
-    }
-
-    return statesByEvents;
-  }
 }


### PR DESCRIPTION


Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1266


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Dataset Lineage emission in current Gobblin code is only available for batch mode of execution. For instance, the lineage events are emitted on dataset commit, which is never invoked for long-running tasks. This PR refactors lineage related code so that it is leverageable in streaming mode of execution as well.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Existing tests. This PR is purely re-factoring existing code to make it accessible in other classes.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

