### PR TITLE
[GOBBLIN-1272] Fixing bug in loading config-store when the entry is empty

### DIFF
--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/policy/HiveRegistrationPolicyBase.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/policy/HiveRegistrationPolicyBase.java
@@ -56,6 +56,7 @@ import org.apache.gobblin.instrumented.Instrumented;
 import org.apache.gobblin.metrics.MetricContext;
 import org.apache.gobblin.source.extractor.extract.kafka.ConfigStoreUtils;
 import org.apache.gobblin.source.extractor.extract.kafka.KafkaSource;
+import org.apache.gobblin.util.ConfigUtils;
 
 
 /**
@@ -178,8 +179,7 @@ public class HiveRegistrationPolicyBase implements HiveRegistrationPolicy {
     }
 
     if (configForTopic.isPresent() && configForTopic.get().hasPath(ADDITIONAL_HIVE_DATABASE_NAMES)) {
-      databaseNames.addAll(
-          ConfigStoreUtils.getListOfValuesFromConfigStore(configForTopic.get(), ADDITIONAL_HIVE_DATABASE_NAMES).stream()
+      databaseNames.addAll(ConfigUtils.getStringList(configForTopic.get(), ADDITIONAL_HIVE_DATABASE_NAMES).stream()
           .map(x -> this.dbNamePrefix + x + this.dbNameSuffix).collect(Collectors.toList()));
     } else if (!Strings.isNullOrEmpty(this.props.getProp(ADDITIONAL_HIVE_DATABASE_NAMES))) {
       for (String additionalDbName : this.props.getPropAsList(ADDITIONAL_HIVE_DATABASE_NAMES)) {
@@ -261,8 +261,7 @@ public class HiveRegistrationPolicyBase implements HiveRegistrationPolicy {
 
     // Searching additional table name from ConfigStore-returned object.
     if (primaryTableName.isPresent() && configForTopic.isPresent() && configForTopic.get().hasPath(additionalNamesProp)) {
-      for (String additionalTableName : ConfigStoreUtils
-          .getListOfValuesFromConfigStore(configForTopic.get(), additionalNamesProp)) {
+      for (String additionalTableName : ConfigUtils.getStringList(configForTopic.get(), additionalNamesProp)) {
         String resolvedTableName =
             StringUtils.replace(additionalTableName, PRIMARY_TABLE_TOKEN, primaryTableName.get());
         tableNames.add(this.tableNamePrefix + resolvedTableName + this.tableNameSuffix);

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/ConfigStoreUtils.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/ConfigStoreUtils.java
@@ -20,13 +20,20 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.hadoop.fs.Path;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+import com.typesafe.config.Config;
+
+import lombok.extern.slf4j.Slf4j;
+
 import org.apache.gobblin.config.client.ConfigClient;
 import org.apache.gobblin.config.client.ConfigClientUtils;
 import org.apache.gobblin.config.client.api.ConfigStoreFactoryDoesNotExistsException;
@@ -38,15 +45,6 @@ import org.apache.gobblin.kafka.client.GobblinKafkaConsumerClient;
 import org.apache.gobblin.util.ConfigUtils;
 import org.apache.gobblin.util.DatasetFilterUtils;
 import org.apache.gobblin.util.PathUtils;
-import org.apache.hadoop.fs.Path;
-
-import com.google.common.base.Optional;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Splitter;
-import com.google.common.base.Strings;
-import com.typesafe.config.Config;
-
-import lombok.extern.slf4j.Slf4j;
 
 
 @Slf4j

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/ConfigStoreUtils.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/ConfigStoreUtils.java
@@ -260,13 +260,4 @@ public class ConfigStoreUtils {
       log.warn("None of the blacklist or whitelist tags are provided");
     }
   }
-
-  public static List<String> getListOfValuesFromConfigStore(Config config, String keyValue) {
-    String keyVal = config.getString(keyValue);
-    if (!Strings.isNullOrEmpty(keyVal)) {
-      return Splitter.on(",").trimResults().splitToList(keyVal);
-    } else {
-      return Collections.emptyList();
-    }
-  }
 }

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/ConfigStoreUtils.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/ConfigStoreUtils.java
@@ -20,6 +20,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
@@ -42,6 +43,7 @@ import org.apache.hadoop.fs.Path;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
 import com.typesafe.config.Config;
 
 import lombok.extern.slf4j.Slf4j;
@@ -260,8 +262,11 @@ public class ConfigStoreUtils {
   }
 
   public static List<String> getListOfValuesFromConfigStore(Config config, String keyValue) {
-    return Splitter.on(",")
-        .trimResults()
-        .splitToList(config.getString(keyValue));
+    String keyVal = config.getString(keyValue);
+    if (!Strings.isNullOrEmpty(keyVal)) {
+      return Splitter.on(",").trimResults().splitToList(keyVal);
+    } else {
+      return Collections.emptyList();
+    }
   }
 }

--- a/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/ConfigStoreUtilsTest.java
+++ b/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/ConfigStoreUtilsTest.java
@@ -27,6 +27,8 @@ import java.util.stream.Collectors;
 import org.apache.gobblin.config.client.ConfigClient;
 import org.apache.gobblin.config.client.api.VersionStabilityPolicy;
 import org.apache.gobblin.kafka.client.GobblinKafkaConsumerClient;
+import org.apache.gobblin.util.ConfigUtils;
+
 import org.apache.hadoop.fs.Path;
 import org.mockito.Mockito;
 import org.testng.Assert;
@@ -69,6 +71,21 @@ public class ConfigStoreUtilsTest {
     URL url = this.getClass().getClassLoader().getResource("_CONFIG_STORE");
     configStoreUri = getStoreURI(new Path(url.getPath()).getParent().toString()).toString();
     mockClient = Mockito.mock(GobblinKafkaConsumerClient.class);
+  }
+
+  @Test
+  public void testGetStringListForTopic() throws Exception {
+    Properties properties = new Properties();
+    properties.put("key", "v1,v2,v3");
+    properties.put("emptyKey", "");
+    Config config = ConfigUtils.propertiesToConfig(properties);
+    List<String> l1 = ConfigStoreUtils.getListOfValuesFromConfigStore(config, "key");
+    Assert.assertEquals(l1.size(), 3);
+    Assert.assertTrue(l1.contains("v1"));
+    Assert.assertTrue(l1.contains("v2"));
+    Assert.assertTrue(l1.contains("v3"));
+    List<String> l2 = ConfigStoreUtils.getListOfValuesFromConfigStore(config, "emptyKey");
+    Assert.assertTrue(l2.isEmpty());
   }
 
   @Test

--- a/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/ConfigStoreUtilsTest.java
+++ b/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/ConfigStoreUtilsTest.java
@@ -74,21 +74,6 @@ public class ConfigStoreUtilsTest {
   }
 
   @Test
-  public void testGetStringListForTopic() throws Exception {
-    Properties properties = new Properties();
-    properties.put("key", "v1,v2,v3");
-    properties.put("emptyKey", "");
-    Config config = ConfigUtils.propertiesToConfig(properties);
-    List<String> l1 = ConfigStoreUtils.getListOfValuesFromConfigStore(config, "key");
-    Assert.assertEquals(l1.size(), 3);
-    Assert.assertTrue(l1.contains("v1"));
-    Assert.assertTrue(l1.contains("v2"));
-    Assert.assertTrue(l1.contains("v3"));
-    List<String> l2 = ConfigStoreUtils.getListOfValuesFromConfigStore(config, "emptyKey");
-    Assert.assertTrue(l2.isEmpty());
-  }
-
-  @Test
   public void testGetUriStringForTopic() throws Exception {
     String commonPath = "/data/tracking";
     URI topic1URI = ConfigStoreUtils.getUriStringForTopic("Topic1", commonPath, configStoreUri);

--- a/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/ConfigStoreUtilsTest.java
+++ b/gobblin-modules/gobblin-kafka-common/src/test/java/org/apache/gobblin/source/extractor/extract/kafka/ConfigStoreUtilsTest.java
@@ -24,11 +24,6 @@ import java.util.List;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
-import org.apache.gobblin.config.client.ConfigClient;
-import org.apache.gobblin.config.client.api.VersionStabilityPolicy;
-import org.apache.gobblin.kafka.client.GobblinKafkaConsumerClient;
-import org.apache.gobblin.util.ConfigUtils;
-
 import org.apache.hadoop.fs.Path;
 import org.mockito.Mockito;
 import org.testng.Assert;
@@ -39,6 +34,10 @@ import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.typesafe.config.Config;
+
+import org.apache.gobblin.config.client.ConfigClient;
+import org.apache.gobblin.config.client.api.VersionStabilityPolicy;
+import org.apache.gobblin.kafka.client.GobblinKafkaConsumerClient;
 
 import static org.apache.gobblin.configuration.ConfigurationKeys.CONFIG_MANAGEMENT_STORE_ENABLED;
 import static org.apache.gobblin.configuration.ConfigurationKeys.CONFIG_MANAGEMENT_STORE_URI;


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- https://issues.apache.org/jira/browse/GOBBLIN-1272


### Description
A tiny PR that handle the case when there's empty string specified in an entry of Config-Store properly.


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

