### PR TITLE
[GOBBLIN-1273] Improving handling of config file load failures

### DIFF
--- a/gobblin-utility/src/test/java/org/apache/gobblin/util/PullFileLoaderTest.java
+++ b/gobblin-utility/src/test/java/org/apache/gobblin/util/PullFileLoaderTest.java
@@ -118,6 +118,8 @@ public class PullFileLoaderTest {
     sysProps.put("key1", "sysProps1");
     Collection<Config> configs =
         loader.loadPullFilesRecursively(this.basePath, ConfigUtils.propertiesToConfig(sysProps), false);
+    // Only 4 files should generate configs (ajob.pull, bjob.pull, dir1/job.pull, dir1/job.conf)
+    Assert.assertEquals(configs.size(), 4);
 
     path = new Path(this.basePath, "ajob.pull");
     pullFile = pullFileFromPath(configs, path);
@@ -274,4 +276,16 @@ public class PullFileLoaderTest {
     throw new IOException("Not found.");
   }
 
+
+  @Test
+  public void testExceptionWrapping() throws Exception {
+    Path path = new Path(this.basePath, "dir2/badjob.conf");
+    try {
+      Config pullFile = loader.loadPullFile(path, ConfigFactory.empty(), true);
+      Assert.fail("Should throw exception");
+    } catch (IOException ie) {
+      String message = ie.getMessage();
+      Assert.assertEquals(message, "Failed to parse config file " + path.toString() + " at lineNo:18");
+    }
+  }
 }

--- a/gobblin-utility/src/test/resources/pullFileLoaderTest/dir2/badjob.conf
+++ b/gobblin-utility/src/test/resources/pullFileLoaderTest/dir2/badjob.conf
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+key1=foo:122 // unquoted :


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1273


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
  - Adds line number and file name of file where error was encountered, if that information is retrievable from the thrown exception
  - Prevents config file loading failures from escaping and aborting the Gobblin standalone service. The service will continue to operate with the config files that it was able to load. 


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
 - Adds test in PullFileLoaderTest to check for line number in the exception trace

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

