### PR TITLE
[GOBBLIN-1274] fix import in MultiEventMetadataGenerator

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/MultiEventMetadataGenerator.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/MultiEventMetadataGenerator.java
@@ -20,10 +20,8 @@ package org.apache.gobblin.runtime.api;
 import java.util.List;
 import java.util.Map;
 
-import com.google.common.base.Splitter;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-
-import avro.shaded.com.google.common.collect.Lists;
 
 import org.apache.gobblin.metrics.event.EventName;
 import org.apache.gobblin.runtime.JobContext;


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1274


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
pick com.google.common.collect.Lists over avro.shaded.com.google.common.collect.Lists in import statement

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
trivial changes

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

