### PR TITLE
[GOBBLIN-1275] Changing user-facing docs from Gitter to Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Documentation Status](https://readthedocs.org/projects/gobblin/badge/?version=latest)](https://gobblin.readthedocs.org/en/latest/?badge=latest)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.apache.gobblin/gobblin-api/badge.svg)](https://search.maven.org/search?q=g:org.apache.gobblin)
 [![Stack Overflow](http://img.shields.io/:stack%20overflow-gobblin-brightgreen.svg)](http://stackoverflow.com/questions/tagged/gobblin)
-[![Gitter](https://img.shields.io/gitter/room/gobblin/Lobby)](https://gitter.im/gobblin/Lobby/)
+[![Get on Slack](https://img.shields.io/badge/slack-join-orange.svg)](https://join.slack.com/t/apache-gobblin/shared_invite/zt-hkwu51id-aVxL3bvtLdi778YHFV1b6A)
 [![codecov.io](https://codecov.io/github/apache/incubator-gobblin/branch/master/graph/badge.svg)](https://codecov.io/github/apache/incubator-gobblin)
 
 Apache Gobblin is a universal data ingestion framework for extracting, transforming, and loading large volume of data from a variety of data sources: databases, rest APIs, FTP/SFTP servers, filers, etc., onto Hadoop. 
@@ -52,8 +52,8 @@ The distribution will be created in build/gobblin-distribution/distributions dir
   * [Gobblin documentation](http://gobblin.readthedocs.org/en/latest/)
     * [Getting started guide](http://gobblin.readthedocs.org/en/latest/Getting-Started/)
     * [Gobblin architecture](http://gobblin.readthedocs.io/en/latest/Gobblin-Architecture/)
+  * Community Slack: [Sign up](https://join.slack.com/t/apache-gobblin/shared_invite/zt-hkwu51id-aVxL3bvtLdi778YHFV1b6A) or [login with existing account](https://apache-gobblin.slack.com) to `apache-gobblin` space on Slack
   * [List of companies known to use Gobblin](http://gobblin.readthedocs.io/en/latest/Powered-By/) 
   * [Sample project](https://github.com/apache/incubator-gobblin/tree/master/gobblin-example)
   * [How to build Gobblin from source code](http://gobblin.readthedocs.io/en/latest/user-guide/Building-Gobblin/)
-  * [Chat room for users and developers](https://gitter.im/gobblin/Lobby/)
   * [Issue tracker - Apache Jira](https://issues.apache.org/jira/projects/GOBBLIN/issues/)


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/GOBBLIN-1275) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
  - Replace Gitter chatroom with Slack room

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  - doc only

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

