### PR TITLE
GOBBLIN-1276: Emit additional logs from Gobblin task execution for improved debuggability

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixTask.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixTask.java
@@ -169,6 +169,7 @@ public class GobblinHelixTask implements Task {
       this.taskMetrics.helixTaskTotalCompleted.incrementAndGet();
       return new TaskResult(TaskResult.Status.COMPLETED, "");
     } catch (InterruptedException ie) {
+      log.error("Interrupting task {}", this.taskId);
       Thread.currentThread().interrupt();
       log.error("Actual task {} interrupted.", this.taskId);
       this.taskMetrics.helixTaskTotalFailed.incrementAndGet();

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/fork/Fork.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/fork/Fork.java
@@ -365,17 +365,16 @@ public class Fork<S, D> implements Closeable, FinalState, RecordStreamConsumer<S
   /**
    * Commit data of this {@link Fork}.
    *
-   * @throws Exception if there is anything wrong committing the data
    */
-  public boolean commit()
-      throws Exception {
+  public boolean commit() {
     try {
       if (checkDataQuality(this.convertedSchema)) {
         // Commit data if all quality checkers pass. Again, not to catch the exception
         // it may throw so the exception gets propagated to the caller of this method.
-        this.logger.debug(String.format("Committing data for fork %d of task %s", this.index, this.taskId));
+        this.logger.info(String.format("Committing data for fork %d of task %s", this.index, this.taskId));
         commitData();
         verifyAndSetForkState(ForkState.SUCCEEDED, ForkState.COMMITTED);
+        this.logger.info(String.format("Fork %d of task %s successfully committed data", this.index, this.taskId));
         return true;
       }
       this.logger.error(String.format("Fork %d of task %s failed to pass quality checking", this.index, this.taskId));


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1276


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
We emit additional logs in GobblinHelixTask and Fork execution to provide more clarity on how the task exits on run() completion.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Logging change and verified log emission in a test pipeline.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

