### PR TITLE
[GOBBLIN-1277] Added travis_retry function to deploy phase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ jobs:
       env: RUN_TEST_GROUP=none
       install: skip
       script:
-        - ./travis/bintrayDeploy.sh
+        - travis_retry ./travis/bintrayDeploy.sh
 
 env:
   jobs:

--- a/gradle/scripts/bintrayPublishing.gradle
+++ b/gradle/scripts/bintrayPublishing.gradle
@@ -110,7 +110,8 @@ subprojects{
     key = project.hasProperty('bintrayApiKey') ? project.property('bintrayApiKey') : System.getenv('BINTRAY_API_KEY')
     publications = ["mavenJava"]
     publish = true
-    dryRun = project.hasProperty("bintray.dryRun")
+    override = project.hasProperty("bintray.override") //[Default: false]
+    dryRun = project.hasProperty("bintray.dryRun") //[Default: false]
     pkg {
       repo = 'maven'
       name = 'gobblin-github'

--- a/travis/bintrayDeploy.sh
+++ b/travis/bintrayDeploy.sh
@@ -35,5 +35,5 @@ echo "Pull request: [$TRAVIS_PULL_REQUEST], Travis branch: [$TRAVIS_BRANCH]"
 if [ "$TRAVIS_PULL_REQUEST" = "false" ]
 then
     echo "Uploading artifacts to bintray for version $BUILD_VERSION"
-    ./gradlew -i bintrayUpload -Pversion=$BUILD_VERSION
+    ./gradlew bintrayUpload -Pversion=$BUILD_VERSION -Pbintray.override
 fi


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. 
    - https://issues.apache.org/jira/browse/GOBBLIN-1277


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Gobblin artifacts publishing to bintray often fails due to HTTPs timeouts. This effects developer productivity as they have to wait for another commit and hope that even that succeeds in bintray publishing phase. With this change the publishing will be tried for upto 3 times before giving up. 

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tested on travis-ci.com and saw retry 3 times [The command "./travis/bintrayDeploy.sh" failed. Retrying, 2 of 3.]

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

