### PR TITLE
[GOBBLIN-1283] Fix schema redefine from adding field properties into field schema

### DIFF
--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/query/HiveAvroORCQueryGenerator.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/conversion/hive/query/HiveAvroORCQueryGenerator.java
@@ -399,7 +399,6 @@ public class HiveAvroORCQueryGenerator {
             } else {
               columns.append(", \n");
             }
-            convertFieldToSchemaWithProps(field.getJsonProps(), field.schema());
             String type = generateAvroToHiveColumnMapping(field.schema(), hiveColumns, false, datasetName);
             if (hiveColumns.isPresent()) {
               hiveColumns.get().put(field.name(), type);
@@ -419,7 +418,6 @@ public class HiveAvroORCQueryGenerator {
             } else {
               columns.append(",");
             }
-            convertFieldToSchemaWithProps(field.getJsonProps(), field.schema());
             String type = generateAvroToHiveColumnMapping(field.schema(), hiveColumns, false, datasetName);
             columns.append("`").append(field.name()).append("`").append(":").append(type);
           }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/GOBBLIN-1283


### Description
- [x] Here are some details about my PR:
 - It looks like when a nested child schema is present and referenced multiple times in the main schema, calling `convertFieldToSchemaWithProps` it over the nested child schema will trigger schema redefine parse exception.
 - We found `AvroFlattener` will keep the schema properties. There is no need to copy them from field properties.

### Tests
- [x] My PR uses the following unit tests:
 - The changes are covered by `HiveAvroORCQueryGeneratorTest`

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

