### PR TITLE
GOBBLIN-1287: Cleanup code duplication across tests that choose a random open port for spinning up an embedded mysql server

### DIFF
--- a/gobblin-metastore/src/test/java/org/apache/gobblin/metastore/testing/TestMetastoreDatabaseServer.java
+++ b/gobblin-metastore/src/test/java/org/apache/gobblin/metastore/testing/TestMetastoreDatabaseServer.java
@@ -45,6 +45,7 @@ import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.metastore.MetaStoreModule;
 import org.apache.gobblin.metastore.util.DatabaseJobHistoryStoreSchemaManager;
 import org.apache.gobblin.metastore.util.MySqlJdbcUrl;
+import org.apache.gobblin.util.PortUtils;
 
 
 class TestMetastoreDatabaseServer implements Closeable {
@@ -83,7 +84,7 @@ class TestMetastoreDatabaseServer implements Closeable {
     this.dbUserName = realConfig.getString(DBUSER_NAME_KEY);
     this.dbUserPassword = realConfig.getString(DBUSER_PASSWORD_KEY);
     this.dbHost = this.embeddedMysqlEnabled ? "localhost" : realConfig.getString(DBHOST_KEY);
-    this.dbPort = this.embeddedMysqlEnabled ? chooseRandomPort() : realConfig.getInt(DBPORT_KEY);
+    this.dbPort = this.embeddedMysqlEnabled ? new PortUtils.ServerSocketPortLocator().random() : realConfig.getInt(DBPORT_KEY);
 
     this.log.error("Starting with config: embeddedMysqlEnabled={} dbUserName={} dbHost={} dbPort={}",
                   this.embeddedMysqlEnabled,
@@ -131,18 +132,6 @@ class TestMetastoreDatabaseServer implements Closeable {
   public void close() throws IOException {
     if (testingMySqlServer != null) {
       testingMySqlServer.stop();
-    }
-  }
-
-  private int chooseRandomPort() throws IOException {
-    ServerSocket socket = null;
-    try {
-      socket = new ServerSocket(0);
-      return socket.getLocalPort();
-    } finally {
-      if (socket != null) {
-        socket.close();
-      }
     }
   }
 

--- a/gobblin-rest-service/gobblin-rest-server/src/test/java/org/apache/gobblin/rest/JobExecutionInfoServerTest.java
+++ b/gobblin-rest-service/gobblin-rest-server/src/test/java/org/apache/gobblin/rest/JobExecutionInfoServerTest.java
@@ -40,6 +40,7 @@ import org.apache.gobblin.metastore.JobHistoryStore;
 import org.apache.gobblin.metastore.MetaStoreModule;
 import org.apache.gobblin.metastore.testing.ITestMetastoreDatabase;
 import org.apache.gobblin.metastore.testing.TestMetastoreDatabaseFactory;
+import org.apache.gobblin.util.PortUtils;
 
 
 /**
@@ -70,7 +71,8 @@ public class JobExecutionInfoServerTest {
     Properties properties = new Properties();
     properties.setProperty(ConfigurationKeys.JOB_HISTORY_STORE_URL_KEY, testMetastoreDatabase.getJdbcUrl());
 
-    int randomPort = chooseRandomPort();
+    int randomPort = new PortUtils.ServerSocketPortLocator().random();
+
     properties.setProperty(ConfigurationKeys.REST_SERVER_PORT_KEY, Integer.toString(randomPort));
 
     Injector injector = Guice.createInjector(new MetaStoreModule(properties));
@@ -150,18 +152,6 @@ public class JobExecutionInfoServerTest {
     }
     if (this.testMetastoreDatabase != null) {
       this.testMetastoreDatabase.close();
-    }
-  }
-
-  private static int chooseRandomPort() throws IOException {
-    ServerSocket socket = null;
-    try {
-      socket = new ServerSocket(0);
-      return socket.getLocalPort();
-    } finally {
-      if (socket != null) {
-        socket.close();
-      }
     }
   }
 

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-client/src/test/java/org/apache/gobblin/service/FlowConfigTest.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-client/src/test/java/org/apache/gobblin/service/FlowConfigTest.java
@@ -329,16 +329,4 @@ public class FlowConfigTest {
     _testDirectory.delete();
     cleanUpDir(TEST_SPEC_STORE_DIR);
   }
-
-  private static int chooseRandomPort() throws IOException {
-    ServerSocket socket = null;
-    try {
-      socket = new ServerSocket(0);
-      return socket.getLocalPort();
-    } finally {
-      if (socket != null) {
-        socket.close();
-      }
-    }
-  }
 }

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/PortUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/PortUtils.java
@@ -151,7 +151,7 @@ public class PortUtils {
     int specific(int port) throws Exception;
   }
 
-  private static class ServerSocketPortLocator implements PortLocator {
+  public static class ServerSocketPortLocator implements PortLocator {
     @Override
     public int random() throws Exception {
         try (ServerSocket serverSocket = new ServerSocket(0)) {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1287


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
The chooseRandomPort() method that returns a random open port for a server to listen on has been implemented across 3 different test classes, and is also implemented in PortUtils class in gobblin-utility. This task cleans up the unnecessary duplication. This PR also removes dead code in FlowConfigTest.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Existing unit tests.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

