### PR TITLE
[GOBBLIN-1290] Auto-tune ORC writer parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 **/*.iws
 **/*.ipr
 .shelf/
+.ideaDataSources/
 
 # VS Code related 
 .vscode

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ out/
 */bin/
 **/mainGeneratedDataTemplate
 **/mainGeneratedRest
+**/main/snapshot
 gobblin-dist/
 gobblin-distribution-*.tar.gz
 gobblin.tar.gz

--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -502,6 +502,10 @@ public class ConfigurationKeys {
   public static final boolean DEFAULT_SCHEMA_IN_SOURCE_DIR = false;
   public static final String SCHEMA_FILENAME = "schema.filename";
   public static final String DEFAULT_SCHEMA_FILENAME = "metadata.json";
+  // An optional configuration for extractor's specific implementation to set, which helps data writer
+  // tune some parameters that are relevant to the record size.
+  // See the reference GobblinOrcWriter as an example.
+  public static final String AVG_RECORD_SIZE = "avg.record.size";
 
   // Comma-separated source entity names
   public static final String SOURCE_ENTITIES = "source.entities";

--- a/gobblin-cluster/build.gradle
+++ b/gobblin-cluster/build.gradle
@@ -85,14 +85,12 @@ configurations {
   }
 }
 // Generates a maven test artifact (gobblin-cluster-test)
-project.publishing {
-  publications {
-    testsPub(MavenPublication) {
-      artifactId "${project.archivesBaseName}-test"
-      artifacts = [testJar]
-      pom pomAttributes
-      pom.withXml addRuntimeDependenciesToPom
-    }
+project.publishing.publications {
+  testsPub(MavenPublication) {
+    artifactId "${project.archivesBaseName}-test"
+    artifacts = [testJar]
+    pom pomAttributes
+    pom.withXml addRuntimeDependenciesToPom
   }
 }
 addPublicationToBintray("testsPub")

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSource.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaSource.java
@@ -105,7 +105,6 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
   //A workunit property that contains the number of topic partitions for a given topic. Useful for
   //workunit size estimation to assign weights to a given topic partition.
   public static final String NUM_TOPIC_PARTITIONS = "numTopicPartitions";
-  public static final String AVG_RECORD_SIZE = "avg.record.size";
   public static final String AVG_RECORD_MILLIS = "avg.record.millis";
   public static final String START_FETCH_EPOCH_TIME = "startFetchEpochTime";
   public static final String STOP_FETCH_EPOCH_TIME = "stopFetchEpochTime";

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaUtils.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaUtils.java
@@ -110,7 +110,7 @@ public class KafkaUtils {
    */
   public static boolean containsPartitionAvgRecordSize(State state, KafkaPartition partition) {
     return state.contains(
-        getPartitionPropName(partition.getTopicName(), partition.getId()) + "." + KafkaSource.AVG_RECORD_SIZE);
+        getPartitionPropName(partition.getTopicName(), partition.getId()) + "." + ConfigurationKeys.AVG_RECORD_SIZE);
   }
 
   /**
@@ -119,7 +119,7 @@ public class KafkaUtils {
    */
   public static long getPartitionAvgRecordSize(State state, KafkaPartition partition) {
     return state.getPropAsLong(
-        getPartitionPropName(partition.getTopicName(), partition.getId()) + "." + KafkaSource.AVG_RECORD_SIZE);
+        getPartitionPropName(partition.getTopicName(), partition.getId()) + "." + ConfigurationKeys.AVG_RECORD_SIZE);
   }
 
   /**
@@ -127,7 +127,7 @@ public class KafkaUtils {
    * "[topicname].[partitionid].avg.record.size".
    */
   public static void setPartitionAvgRecordSize(State state, KafkaPartition partition, long size) {
-    state.setProp(getPartitionPropName(partition.getTopicName(), partition.getId()) + "." + KafkaSource.AVG_RECORD_SIZE,
+    state.setProp(getPartitionPropName(partition.getTopicName(), partition.getId()) + "." + ConfigurationKeys.AVG_RECORD_SIZE,
         size);
   }
 

--- a/gobblin-modules/gobblin-orc/build.gradle
+++ b/gobblin-modules/gobblin-orc/build.gradle
@@ -29,6 +29,8 @@ dependencies {
   compile externalDependency.hiveStorageApi
   compile externalDependency.orcCore
 
+  compileOnly (project(':gobblin-yarn'))
+
   testCompile externalDependency.testng
   testCompile externalDependency.mockito
   testCompile externalDependency.hiveSerDe

--- a/gobblin-modules/gobblin-orc/build.gradle
+++ b/gobblin-modules/gobblin-orc/build.gradle
@@ -29,7 +29,6 @@ dependencies {
   compile externalDependency.hiveStorageApi
   compile externalDependency.orcCore
 
-  compileOnly (project(':gobblin-yarn'))
 
   testCompile externalDependency.testng
   testCompile externalDependency.mockito

--- a/gobblin-modules/gobblin-orc/src/main/java/org/apache/gobblin/writer/GobblinOrcWriter.java
+++ b/gobblin-modules/gobblin-orc/src/main/java/org/apache/gobblin/writer/GobblinOrcWriter.java
@@ -110,12 +110,13 @@ public class GobblinOrcWriter extends FsDataWriter<GenericRecord> {
     // Upstream constructs will need to set this value properly
     long estimatedRecordSize = getEstimatedRecordSize(properties);
     long rowsBetweenCheck = availableHeapPerWriter / estimatedRecordSize;
-    log.info("Tuned the parameter " + OrcConf.ROWS_BETWEEN_CHECKS.name() + " to be:" + rowsBetweenCheck);
-
     properties.setProp(OrcConf.ROWS_BETWEEN_CHECKS.name(),
         Math.min(rowsBetweenCheck, (long) OrcConf.ROWS_BETWEEN_CHECKS.getDefaultValue()));
     // Row batch size should be smaller than row_between_check, 4 is just a magic number picked here.
-    properties.setProp(ORC_WRITER_BATCH_SIZE, Math.min(rowsBetweenCheck / 4, DEFAULT_ORC_WRITER_BATCH_SIZE));
+    long batchSize = Math.min(rowsBetweenCheck / 4, DEFAULT_ORC_WRITER_BATCH_SIZE);
+    properties.setProp(ORC_WRITER_BATCH_SIZE, batchSize);
+    log.info("Tuned the parameter " + OrcConf.ROWS_BETWEEN_CHECKS.name() + " to be:" + rowsBetweenCheck + ","
+        + ORC_WRITER_BATCH_SIZE + " to be:" + batchSize);
   }
 
   protected long availableHeapSize(State Properties) {

--- a/gobblin-modules/gobblin-orc/src/test/java/org/apache/gobblin/writer/GobblinOrcWriterTest.java
+++ b/gobblin-modules/gobblin-orc/src/test/java/org/apache/gobblin/writer/GobblinOrcWriterTest.java
@@ -45,12 +45,12 @@ import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.source.workunit.WorkUnit;
 
-import static org.apache.gobblin.source.extractor.extract.kafka.KafkaSource.AVG_RECORD_SIZE;
+import static org.apache.gobblin.configuration.ConfigurationKeys.AVG_RECORD_SIZE;
 import static org.apache.gobblin.writer.GenericRecordToOrcValueWriterTest.deserializeOrcRecords;
+import static org.apache.gobblin.writer.GobblinOrcWriter.CONTAINER_JVM_MEMORY_OVERHEAD_MBS;
 import static org.apache.gobblin.writer.GobblinOrcWriter.DEFAULT_RECORD_SIZE_SCALE_FACTOR;
 import static org.apache.gobblin.writer.GobblinOrcWriter.ORC_WRITER_AUTO_TUNE_ENABLED;
 import static org.apache.gobblin.writer.GobblinOrcWriter.RECORD_SIZE_SCALE_FACTOR;
-import static org.apache.gobblin.yarn.GobblinYarnConfigurationKeys.CONTAINER_JVM_MEMORY_OVERHEAD_MBS_KEY;
 import static org.mockito.Mockito.*;
 
 
@@ -99,7 +99,7 @@ public class GobblinOrcWriterTest {
     when(mockBuilder.getFileName(properties)).thenReturn("file");
 
     properties.setProp(ORC_WRITER_AUTO_TUNE_ENABLED, true);
-    properties.setProp(CONTAINER_JVM_MEMORY_OVERHEAD_MBS_KEY, 2048);
+    properties.setProp(CONTAINER_JVM_MEMORY_OVERHEAD_MBS, 2048);
     closer.register(new GobblinOrcWriter(mockBuilder, properties));
     // Verify the side effect within the properties object.
     Assert.assertEquals(properties.getPropAsInt(OrcConf.ROWS_BETWEEN_CHECKS.name()),

--- a/gobblin-modules/gobblin-orc/src/test/java/org/apache/gobblin/writer/GobblinOrcWriterTest.java
+++ b/gobblin-modules/gobblin-orc/src/test/java/org/apache/gobblin/writer/GobblinOrcWriterTest.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Writable;
+import org.apache.orc.OrcConf;
 import org.apache.orc.storage.ql.exec.vector.BytesColumnVector;
 import org.apache.orc.storage.ql.exec.vector.ListColumnVector;
 import org.mockito.Mockito;
@@ -44,10 +45,19 @@ import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.source.workunit.WorkUnit;
 
+import static org.apache.gobblin.source.extractor.extract.kafka.KafkaSource.AVG_RECORD_SIZE;
 import static org.apache.gobblin.writer.GenericRecordToOrcValueWriterTest.deserializeOrcRecords;
+import static org.apache.gobblin.writer.GobblinOrcWriter.DEFAULT_RECORD_SIZE_SCALE_FACTOR;
+import static org.apache.gobblin.writer.GobblinOrcWriter.ORC_WRITER_AUTO_TUNE_ENABLED;
+import static org.apache.gobblin.writer.GobblinOrcWriter.RECORD_SIZE_SCALE_FACTOR;
+import static org.apache.gobblin.yarn.GobblinYarnConfigurationKeys.CONTAINER_JVM_MEMORY_OVERHEAD_MBS_KEY;
 import static org.mockito.Mockito.*;
 
 
+/**
+ * For running these tests in IDE, make sure all ORC libraries existed in the external library folder are specified
+ * with "nohive" classifier if they do (orc-core)
+ */
 public class GobblinOrcWriterTest {
 
   public static final List<GenericRecord> deserializeAvroRecords(Class clazz, Schema schema, String schemaPath)
@@ -69,6 +79,38 @@ public class GobblinOrcWriterTest {
       dataInputStream.close();
     }
     return records;
+  }
+
+  @Test
+  public void testAutoTuned() throws Exception {
+    Closer closer = Closer.create();
+    Schema schema =
+        new Schema.Parser().parse(this.getClass().getClassLoader().getResourceAsStream("orc_writer_test/schema.avsc"));
+
+    FsDataWriterBuilder<Schema, GenericRecord> mockBuilder =
+        (FsDataWriterBuilder<Schema, GenericRecord>) Mockito.mock(FsDataWriterBuilder.class);
+    when(mockBuilder.getSchema()).thenReturn(schema);
+    State properties = new WorkUnit();
+    String stagingDir = Files.createTempDir().getAbsolutePath();
+    String outputDir = Files.createTempDir().getAbsolutePath();
+    properties.setProp(ConfigurationKeys.WRITER_STAGING_DIR, stagingDir);
+    properties.setProp(ConfigurationKeys.WRITER_FILE_PATH, "simple");
+    properties.setProp(ConfigurationKeys.WRITER_OUTPUT_DIR, outputDir);
+    when(mockBuilder.getFileName(properties)).thenReturn("file");
+
+    properties.setProp(ORC_WRITER_AUTO_TUNE_ENABLED, true);
+    properties.setProp(CONTAINER_JVM_MEMORY_OVERHEAD_MBS_KEY, 2048);
+    closer.register(new GobblinOrcWriter(mockBuilder, properties));
+    // Verify the side effect within the properties object.
+    Assert.assertEquals(properties.getPropAsInt(OrcConf.ROWS_BETWEEN_CHECKS.name()),
+        Math.round((4096 - 2048) * 0.5 * 1024 / 3) / (1024 * properties.getPropAsInt(RECORD_SIZE_SCALE_FACTOR, DEFAULT_RECORD_SIZE_SCALE_FACTOR)));
+
+    // Will get to 5000
+    properties.setProp(AVG_RECORD_SIZE, 10);
+    closer.register(new GobblinOrcWriter(mockBuilder, properties));
+    Assert.assertEquals(properties.getPropAsInt(OrcConf.ROWS_BETWEEN_CHECKS.name()), 5000);
+
+    closer.close();
   }
 
   @Test


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1290

### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Here is a brief intro for the memory consumption within the streaming ingestor: 

Physical Memory (Usually 4G)
- 50% for ORC writer (2G): This is not a hard cap, it is primarily used for scaling down the threshold for each writer registered in the memory manager. So it is possible to exceed this limit if the number of writers increases when, for example, it needs to deal with portions of late data. 
During normal traffic (non catching up/backfilling mode), having 2~3 writers running in parallel is quite normal due to hourly-boundary interval and late data arrival.
- Metrics objects and other Gobblin overhead : Usually around ~400MB, Typical consumer:
   - TaskExecutor
   - Kafka Extractor 
Non heap memory overhead (600MB, configurable) 
	
	
Given the approximate data points above, we should have no more than ~500MB raw buffer space for each writer. Given the default number of rows between memory check (5000), that means record size should be smaller than 100K. The record size we measured in the streaming pipeline comes from serialized key size plus serialized value size, when they are stored in TreeWriter, the value could be a bit more larger given the object overhead.  Therefore there's a scaling factor being used to indicate this. 

The equation for the auto-tuning is: 
#rowBetweenCheck = actualHeapSize * ratio (50%) / parallelsimOfWriters / (serializedRecordSize * scalingFactor) 

Tested with several heavy topics internally and it works well. 

Other than the major changes, also fix two small issues: 
- build.gradle in gobblin-service module hits a problem and resolved by referring to: https://stackoverflow.com/questions/36079404/errorcannot-configure-the-publishing-extension-after-it-has-been-accessed 
- update gitignore file

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

