### PR TITLE
[GOBBLIN-1291] Fixes bug where :sourceRelease intermittently fails

### DIFF
--- a/gradle/scripts/release.gradle
+++ b/gradle/scripts/release.gradle
@@ -107,6 +107,8 @@ task sourceRelease(type: Tar, dependsOn: prepare_release_config) {
         exclude 'package-lock.json'
         exclude '**/gen-java'
         exclude '**/generated-gobblin-cluster.conf'
+        exclude 'gobblin-modules/gobblin-couchbase/mock-couchbase'
+        exclude 'gobblin-modules/gobblin-elasticsearch/test-elasticsearch'
     }
 
     // rename gradle.properties.release to gradle.properties


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1291


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Certain Gobblin modules such as gobblin-elasticsearch install tars using scripts during testing. Occassionally these tars are not cleaned up fully by `./uninstall_test_deps.sh` which causes the file to be picked up by the :sourceRelease task, causing it to fail.

The patch ignores these tars adding files to the release tar.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

