### PR TITLE
GOBBLIN-1292: Undo hardcoded tmp directory locations for unit tests

### DIFF
--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/FsJobConfigurationManagerTest.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/FsJobConfigurationManagerTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.gobblin.cluster;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -58,9 +59,8 @@ import org.apache.gobblin.util.filters.HiddenFilter;
 public class FsJobConfigurationManagerTest {
   private MutableJobCatalog _jobCatalog;
   private FsJobConfigurationManager jobConfigurationManager;
-
-  private String jobConfDir = "/tmp/" + this.getClass().getSimpleName() + "/jobCatalog";
-  private String fsSpecConsumerPathString = "/tmp/fsJobConfigManagerTest";
+  private String jobConfDir;
+  private String fsSpecConsumerPathString;
   private String jobSpecUriString = "testJobSpec";
 
   private FileSystem fs;
@@ -91,6 +91,10 @@ public class FsJobConfigurationManagerTest {
       return null;
     }).when(this.eventBus).post(Mockito.anyObject());
 
+    File tmpDir = Files.createTempDir();
+    tmpDir.deleteOnExit();
+    this.jobConfDir = tmpDir.getAbsolutePath() + "/" + this.getClass().getSimpleName() + "/jobCatalog";
+    this.fsSpecConsumerPathString = tmpDir.getAbsolutePath() + "/fsJobConfigManagerTest";
     this.fs = FileSystem.getLocal(new Configuration(false));
     Path jobConfDirPath = new Path(jobConfDir);
     if (!this.fs.exists(jobConfDirPath)) {

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinTaskRunnerTest.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/GobblinTaskRunnerTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.gobblin.cluster;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.concurrent.ExecutionException;
@@ -41,6 +42,7 @@ import org.testng.annotations.Test;
 import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.common.eventbus.EventBus;
+import com.google.common.io.Files;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigValueFactory;
@@ -68,7 +70,7 @@ public class GobblinTaskRunnerTest {
   public final static Logger LOG = LoggerFactory.getLogger(GobblinTaskRunnerTest.class);
 
   private static final String JOB_ID = "job_taskRunnerTestJob_" + System.currentTimeMillis();
-  private static final String TASK_STATE_FILE = "/tmp/" + GobblinTaskRunnerTest.class.getSimpleName() + "/taskState/_RUNNING";
+  private String taskStateFile;
 
   public static final String HADOOP_OVERRIDE_PROPERTY_NAME = "prop";
 
@@ -88,6 +90,10 @@ public class GobblinTaskRunnerTest {
   public void setUp() throws Exception {
     this.testingZKServer = new TestingServer(-1);
     LOG.info("Testing ZK Server listening on: " + testingZKServer.getConnectString());
+    File tmpDir = Files.createTempDir();
+    tmpDir.deleteOnExit();
+    this.taskStateFile = tmpDir.getAbsolutePath() + "/" + GobblinTaskRunnerTest.class.getSimpleName()
+        + "/taskState/_RUNNING";
 
     URL url = GobblinTaskRunnerTest.class.getClassLoader().getResource(
         GobblinTaskRunnerTest.class.getSimpleName() + ".conf");
@@ -207,7 +213,7 @@ public class GobblinTaskRunnerTest {
   @Test (groups = {"disabledOnTravis"})
   public void testTaskAssignmentAfterHelixConnectionRetry()
       throws Exception {
-    Config jobConfigOverrides = ClusterIntegrationTestUtils.buildSleepingJob(JOB_ID, TASK_STATE_FILE);
+    Config jobConfigOverrides = ClusterIntegrationTestUtils.buildSleepingJob(JOB_ID, this.taskStateFile);
     this.suite = new TaskAssignmentAfterConnectionRetry(jobConfigOverrides);
 
     String zkConnectString = suite.getManagerConfig().getString(GobblinClusterConfigurationKeys.ZK_CONNECTION_STRING_KEY);
@@ -225,7 +231,7 @@ public class GobblinTaskRunnerTest {
 
     //Ensure that the SleepingTask is running
     AssertWithBackoff.create().maxSleepMs(100).timeoutMs(2000).backoffFactor(1).
-        assertTrue(ClusterIntegrationTest.isTaskRunning(TASK_STATE_FILE),"Waiting for the task to enter running state");
+        assertTrue(ClusterIntegrationTest.isTaskRunning(this.taskStateFile),"Waiting for the task to enter running state");
 
     helixManager.disconnect();
   }

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/suite/IntegrationJobCancelSuite.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/suite/IntegrationJobCancelSuite.java
@@ -17,14 +17,22 @@
 
 package org.apache.gobblin.cluster.suite;
 
+import java.io.File;
+
 import org.junit.Assert;
 
+import com.google.common.io.Files;
 import com.typesafe.config.Config;
 
 
 public class IntegrationJobCancelSuite extends IntegrationBasicSuite {
   public static final String JOB_ID = "job_HelloWorldTestJob_1234";
-  public static final String TASK_STATE_FILE = "/tmp/IntegrationJobCancelSuite/taskState/_RUNNING";
+  public static final String TASK_STATE_FILE;
+  static {
+    File tmpDir = Files.createTempDir();
+    tmpDir.deleteOnExit();
+    TASK_STATE_FILE = tmpDir.getAbsolutePath() + "/IntegrationJobCancelSuite/taskState/_RUNNING";
+  }
   private int sleepingTime = 10;
 
   public IntegrationJobCancelSuite() {

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/suite/IntegrationJobRestartViaSpecSuite.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/suite/IntegrationJobRestartViaSpecSuite.java
@@ -17,6 +17,7 @@
 
 package org.apache.gobblin.cluster.suite;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -48,7 +49,12 @@ import org.apache.gobblin.runtime.api.SpecProducer;
 
 public class IntegrationJobRestartViaSpecSuite extends IntegrationJobCancelSuite {
   public static final String JOB_NAME = "HelloWorldTestJob";
-  public static final String FS_SPEC_CONSUMER_DIR = "/tmp/IntegrationJobCancelViaSpecSuite/jobSpecs";
+  public static final String FS_SPEC_CONSUMER_DIR;
+  static {
+    File tmpDir = Files.createTempDir();
+    tmpDir.deleteOnExit();
+    FS_SPEC_CONSUMER_DIR = tmpDir + "/IntegrationJobCancelViaSpecSuite/jobSpecs";
+  }
 
   private final SpecProducer _specProducer;
 

--- a/gobblin-compaction/src/test/java/org/apache/gobblin/compaction/mapreduce/AvroCompactionTaskTest.java
+++ b/gobblin-compaction/src/test/java/org/apache/gobblin/compaction/mapreduce/AvroCompactionTaskTest.java
@@ -147,7 +147,9 @@ public class AvroCompactionTaskTest {
   @Test
   public void testAvroRecompaction() throws Exception {
     FileSystem fs = getFileSystem();
-    String basePath = "/tmp/testRecompaction";
+    File tmpDir = Files.createTempDir();
+    tmpDir.deleteOnExit();
+    String basePath = tmpDir.getAbsolutePath() + "/testRecompaction";
     fs.delete(new Path(basePath), true);
 
     File jobDir = new File(basePath, "Identity/MemberAccount/minutely/2017/04/03/10/20_30/run_2017-04-03-10-20");
@@ -177,7 +179,9 @@ public class AvroCompactionTaskTest {
   @Test
   public void testAvroRecompactionWriteToNewPath() throws Exception {
     FileSystem fs = getFileSystem();
-    String basePath = "/tmp/testRecompactionWriteToNewPath";
+    File tmpDir = Files.createTempDir();
+    tmpDir.deleteOnExit();
+    String basePath = tmpDir.getAbsolutePath() + "/testRecompactionWriteToNewPath";
     fs.delete(new Path(basePath), true);
 
     File jobDir = new File(basePath, "Identity/MemberAccount/minutely/2017/04/03/10/20_30/run_2017-04-03-10-20");
@@ -210,7 +214,9 @@ public class AvroCompactionTaskTest {
 
   public void testAvroRecompactionWithLimitation() throws Exception {
     FileSystem fs = getFileSystem();
-    String basePath = "/tmp/testRecompactionWithLimitation";
+    File tmpDir = Files.createTempDir();
+    tmpDir.deleteOnExit();
+    String basePath = tmpDir.getAbsolutePath() + "/testRecompactionWithLimitation";
     fs.delete(new Path(basePath), true);
 
     File jobDir = new File(basePath, "Identity/MemberAccount/minutely/2017/04/03/10/20_30/run_2017-04-03-10-20");

--- a/gobblin-metrics-libs/gobblin-metrics/src/test/java/org/apache/gobblin/metrics/GobblinMetricsTest.java
+++ b/gobblin-metrics-libs/gobblin-metrics/src/test/java/org/apache/gobblin/metrics/GobblinMetricsTest.java
@@ -17,11 +17,13 @@
 
 package org.apache.gobblin.metrics;
 
+import java.io.File;
 import java.util.Properties;
 
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import com.google.common.io.Files;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigValueFactory;
@@ -72,12 +74,13 @@ public class GobblinMetricsTest {
   public void testMetricFileReporterSuccessful() {
     String id = getClass().getSimpleName() + "-" + System.currentTimeMillis();
     GobblinMetrics gobblinMetrics = GobblinMetrics.get(id);
-
+    File tmpDir = Files.createTempDir();
+    tmpDir.deleteOnExit();
     //Enable file reporter without specifying metrics.log.dir.
     Config config = ConfigFactory.empty()
         .withValue(ConfigurationKeys.METRICS_REPORTING_FILE_ENABLED_KEY, ConfigValueFactory.fromAnyRef(true))
-        .withValue(ConfigurationKeys.METRICS_LOG_DIR_KEY, ConfigValueFactory.fromAnyRef("/tmp"))
-        .withValue(ConfigurationKeys.FAILURE_LOG_DIR_KEY, ConfigValueFactory.fromAnyRef("/tmp"));
+        .withValue(ConfigurationKeys.METRICS_LOG_DIR_KEY, ConfigValueFactory.fromAnyRef(tmpDir.getAbsolutePath()))
+        .withValue(ConfigurationKeys.FAILURE_LOG_DIR_KEY, ConfigValueFactory.fromAnyRef(tmpDir.getAbsolutePath()));
 
     Properties properties = ConfigUtils.configToProperties(config);
     //Ensure MultiReporterException is thrown

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagerTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagerTest.java
@@ -38,6 +38,7 @@ import org.testng.annotations.Test;
 
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
+import com.google.common.io.Files;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigValueFactory;
@@ -57,7 +58,7 @@ import org.apache.gobblin.service.monitoring.JobStatusRetriever;
 
 
 public class DagManagerTest {
-  private final String dagStateStoreDir = "/tmp/dagManagerTest/dagStateStore";
+  private String dagStateStoreDir;
   private DagStateStore _dagStateStore;
   private JobStatusRetriever _jobStatusRetriever;
   private DagManager.DagManagerThread _dagManagerThread;
@@ -69,7 +70,9 @@ public class DagManagerTest {
 
   @BeforeClass
   public void setUp() throws Exception {
-    FileUtils.deleteDirectory(new File(this.dagStateStoreDir));
+    File tmpDir = Files.createTempDir();
+    tmpDir.deleteOnExit();
+    this.dagStateStoreDir = tmpDir.getAbsolutePath() + "/dagManagerTest/dagStateStore";
     Config config = ConfigFactory.empty()
         .withValue(FSDagStateStore.DAG_STATESTORE_DIR, ConfigValueFactory.fromAnyRef(this.dagStateStoreDir));
 

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/FSDagStateStoreTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/FSDagStateStoreTest.java
@@ -32,6 +32,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.Lists;
+import com.google.common.io.Files;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigValueFactory;
@@ -45,7 +46,7 @@ import org.apache.gobblin.service.modules.spec.JobExecutionPlan;
 
 public class FSDagStateStoreTest {
   private DagStateStore _dagStateStore;
-  private final String dagStateStoreDir = "/tmp/fsDagStateStoreTest/dagStateStore";
+  private String dagStateStoreDir;
   private File checkpointDir;
   private Map<URI, TopologySpec> topologySpecMap;
   private TopologySpec topologySpec;
@@ -54,8 +55,11 @@ public class FSDagStateStoreTest {
   @BeforeClass
   public void setUp()
       throws IOException, URISyntaxException {
+    File tmpDir = Files.createTempDir();
+    tmpDir.deleteOnExit();
+    this.dagStateStoreDir = tmpDir.getAbsolutePath() + "/fsDagStateStoreTest/dagStateStore";
     this.checkpointDir = new File(dagStateStoreDir);
-    FileUtils.deleteDirectory(this.checkpointDir);
+
     Config config = ConfigFactory.empty().withValue(FSDagStateStore.DAG_STATESTORE_DIR, ConfigValueFactory.fromAnyRef(
         this.dagStateStoreDir));
     this.topologySpecMap = new HashMap<>();
@@ -133,10 +137,5 @@ public class FSDagStateStoreTest {
       Assert.assertTrue(Boolean.parseBoolean(dag.getNodes().get(0).getValue().getJobFuture().get().get().toString()));
       Assert.assertTrue(Boolean.parseBoolean(dag.getNodes().get(1).getValue().getJobFuture().get().get().toString()));
     }
-  }
-
-  @AfterClass
-  public void cleanUp() throws IOException {
-    FileUtils.deleteDirectory(this.checkpointDir);
   }
 }

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/FsJobStatusRetrieverTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/monitoring/FsJobStatusRetrieverTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.gobblin.service.monitoring;
 
+import com.google.common.io.Files;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigValueFactory;
@@ -29,12 +30,13 @@ import org.testng.annotations.Test;
 
 
 public class FsJobStatusRetrieverTest extends JobStatusRetrieverTest {
-
-  private String stateStoreDir = "/tmp/jobStatusRetrieverTest/statestore";
+  private String stateStoreDir;
 
   @BeforeClass
   public void setUp() throws Exception {
-    cleanUpDir();
+    File tmpDir = Files.createTempDir();
+    tmpDir.deleteOnExit();
+    this.stateStoreDir = tmpDir.getAbsolutePath() + "/jobStatusRetrieverTest/statestore";
     Config config = ConfigFactory.empty().withValue(FsJobStatusRetriever.CONF_PREFIX + "." + ConfigurationKeys.STATE_STORE_ROOT_DIR_KEY,
         ConfigValueFactory.fromAnyRef(stateStoreDir));
     this.jobStatusRetriever = new FsJobStatusRetriever(config);

--- a/gobblin-utility/src/test/java/org/apache/gobblin/util/logs/LogCopierTest.java
+++ b/gobblin-utility/src/test/java/org/apache/gobblin/util/logs/LogCopierTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.gobblin.util.logs;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.Set;
 
@@ -31,6 +32,7 @@ import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
+import com.google.common.io.Files;
 
 
 public class LogCopierTest {
@@ -45,11 +47,13 @@ public class LogCopierTest {
   public void setUp() throws IOException {
     this.srcFs = FileSystem.getLocal(new Configuration());
     this.destFs = FileSystem.getLocal(new Configuration());
-    this.srcLogDir = new Path("/tmp/LogCopierTest/srcLogDir");
+    File tmpDir = Files.createTempDir();
+    tmpDir.deleteOnExit();
+    this.srcLogDir = new Path(tmpDir.getAbsolutePath() + "/LogCopierTest/srcLogDir");
     if (!srcFs.exists(srcLogDir)) {
       srcFs.mkdirs(srcLogDir);
     }
-    this.destLogDir = new Path("/tmp/LogCopierTest/destLogDir");
+    this.destLogDir = new Path(tmpDir.getAbsolutePath() + "/LogCopierTest/destLogDir");
     if (!destFs.exists(destLogDir)) {
       destFs.mkdirs(destLogDir);
     }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1292


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Several unit tests in Gobblin make use of hardcoded tmp directory locations. If these locations are not cleaned up, they have the potential to cause test failures in subsequent builds. Further, hardcoded locations may potentially collide with other tests which may accidentally use the same location. This task modifies a host of tests to use dynamically generated temp directories which are automatically cleaned up when tests complete.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
This PR modifies existing unit tests.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

