### PR TITLE
[GOBBLIN-1295] Provide escape for string that hive doesn't do properly

### DIFF
--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/AvroUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/AvroUtils.java
@@ -891,7 +891,8 @@ public class AvroUtils {
    * Therefore the escaping behavior won't cause correctness issues.
    */
   public static String sanitizeSchemaString(String schemaString) {
-    return schemaString.replaceAll(";",  "\\\\;").replaceAll("'", "\\\\'");
+    return schemaString.replace("\\\"", "\\\\\\\"").replace(";",  "\\;")
+        .replace("'", "\\'");
   }
 
   /**

--- a/gobblin-utility/src/test/java/org/apache/gobblin/util/AvroUtilsTest.java
+++ b/gobblin-utility/src/test/java/org/apache/gobblin/util/AvroUtilsTest.java
@@ -272,6 +272,19 @@ public class AvroUtilsTest {
     Assert.assertEquals(actualString, expectedString);
     // Verify that there's only one slash being added.
     Assert.assertEquals(actualString.length(), invalidString.length() + 2);
+
+    // An instance of invalid string that contains a slash followed by a quote, both of which should be escaped.
+    String invalidStringWithSlash = "abc\\\"";
+    // Should have a slash before the actual slash, and a slash before the actual quote.
+    actualString = AvroUtils.sanitizeSchemaString(invalidStringWithSlash);
+    // Meaning for each slash:
+    // first two: escape in java and the actual escape the output string
+    // second pair: escape in java and the actual slash
+    // third pair: escape for the actual quote
+    // last pair: java escape slash with the actual quote.
+    expectedString = "abc\\\\\\\"";
+    Assert.assertEquals(actualString, expectedString);
+    Assert.assertEquals(actualString.length(), invalidStringWithSlash.length() + 2);
   }
 
   public static List<GenericRecord> getRecordFromFile(String path)


### PR DESCRIPTION
…perly

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- https://issues.apache.org/jira/browse/GOBBLIN-1295


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

