### PR TITLE
[GOBBLIN-1296] Solve the dependency issue in gobblin stand alone mode

### DIFF
--- a/gobblin-distribution/build.gradle
+++ b/gobblin-distribution/build.gradle
@@ -25,6 +25,7 @@ configurations {
     if (rootProject.hasProperty('excludeHiveDeps')) {
       exclude group: "org.apache.hive"
     }
+    exclude group: 'org.slf4j', module: 'log4j-over-slf4j'
   }
 }
 

--- a/gradle/scripts/globalDependencies.gradle
+++ b/gradle/scripts/globalDependencies.gradle
@@ -47,7 +47,7 @@ subprojects {
         // Required to add JDK's tool jar, which is required to run byteman tests.
         testCompile (files(((URLClassLoader) ToolProvider.getSystemToolClassLoader()).getURLs()))
       }
-      if (!project.name.contains('gobblin-aws')) {
+      if (!project.name.contains('gobblin-aws') && !project.name.contains('gobblin-distribution')) {
         configurations.compile.dependencies*.each {
           //exclude this jar because we introduce log4j-over-slf4j, these two jars cannot present at the same time
           it.exclude group: 'org.slf4j', module: 'slf4j-log4j12'


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1296


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Exclude the bridge jar in gobblin-distribution module to solve the issue that gobblin standalone mode cannot run due to "Detected both log4j-over-slf4j.jar AND slf4j-log4j12.jar on the class path"

Options

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Run `/bin/gobblin cli run distcp `  locally to make sure standalone mode can work well

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

