### PR TITLE
[GOBBLIN-1297] Register/unregister eventbus with dagManager on leadership change

### DIFF
--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GobblinServiceManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/core/GobblinServiceManager.java
@@ -123,7 +123,7 @@ public class GobblinServiceManager implements ApplicationLauncher, StandardMetri
 
   // An EventBus used for communications between services running in the ApplicationMaster
   @Getter
-  protected final EventBus eventBus = new EventBus(GobblinServiceManager.class.getSimpleName());
+  protected EventBus eventBus = new EventBus(GobblinServiceManager.class.getSimpleName());
 
   protected final FileSystem fs;
   protected final Path serviceWorkDir;
@@ -136,7 +136,7 @@ public class GobblinServiceManager implements ApplicationLauncher, StandardMetri
   protected final boolean isRestLIServerEnabled;
   protected final boolean isTopologySpecFactoryEnabled;
   protected final boolean isGitConfigMonitorEnabled;
-  protected final boolean isDagManagerEnabled;
+  protected boolean isDagManagerEnabled;
   protected final boolean isJobStatusMonitorEnabled;
 
   protected TopologyCatalog topologyCatalog;
@@ -161,6 +161,7 @@ public class GobblinServiceManager implements ApplicationLauncher, StandardMetri
 
   protected GitConfigMonitor gitConfigMonitor;
 
+  @Getter
   protected DagManager dagManager;
 
   protected KafkaJobStatusMonitor jobStatusMonitor;
@@ -417,6 +418,7 @@ public class GobblinServiceManager implements ApplicationLauncher, StandardMetri
         //Activate DagManager only if TopologyCatalog is initialized. If not; skip activation.
         if (this.topologyCatalog.getInitComplete().getCount() == 0) {
           this.dagManager.setActive(true);
+          this.eventBus.register(this.dagManager);
         }
       }
     } else if (this.helixManager.isPresent()) {
@@ -438,6 +440,7 @@ public class GobblinServiceManager implements ApplicationLauncher, StandardMetri
 
       if (this.isDagManagerEnabled) {
         this.dagManager.setActive(false);
+        this.eventBus.unregister(this.dagManager);
       }
     }
   }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1297


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
To be able to kill a flow, the eventbus in GobblinServiceManager must be registered with the dagManager, but this currently only happens on startup. On leadership change, the eventbus of the new leader should be registered and the eventbus of the slave should be unregistered.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Trivial

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

