### PR TITLE
[GOBBLIN-1298] return JsonElement instead of null for the last element in resultChaining iterator

### DIFF
--- a/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/ResultChainingIterator.java
+++ b/gobblin-salesforce/src/main/java/org/apache/gobblin/salesforce/ResultChainingIterator.java
@@ -70,7 +70,6 @@ public class ResultChainingIterator implements Iterator<JsonElement> {
     if (!iter.hasNext()) {
       // `jsonElement` has last record, print out total and isDeleted=true records(soft deleted) total
       log.info("====Total records: [{}] isDeleted=true records: [{}]====", recordCount, isDeletedRecordCount);
-      return null;
     }
     return jsonElement;
   }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- This is related to this ticket: https://issues.apache.org/jira/browse/GOBBLIN-1298

### Description
- https://github.com/apache/incubator-gobblin/commit/4045e6853943d1d57ea4813df7a744e7a38d1ae9 this commit introduced a bug in the result chaining iterator, and would always omit the last record because it is returning null (instead of returning JsonElement). That is what I've seen in gobblin client side for SFDC extractor log & actual behavior, where there is always one record didn't get ingested. 
Therefore in this commit, instead of returning null, the code would only print out the records and return the last jsonElement. 

### Tests
- [ ] My PR does not need testing for this extremely good reason:
There is no existing unit test and I think based on the behavior this bug is pretty obvious. 
