### PR TITLE
[GOBBLIN-1300] Rethrow exceptions when storing job status in state store

### DIFF
--- a/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/runtime/KafkaAvroJobStatusMonitorTest.java
+++ b/gobblin-modules/gobblin-kafka-09/src/test/java/org/apache/gobblin/runtime/KafkaAvroJobStatusMonitorTest.java
@@ -176,7 +176,7 @@ public class KafkaAvroJobStatusMonitorTest {
     Assert.assertEquals(state.getProp(JobStatusRetriever.EVENT_NAME_FIELD), ExecutionStatus.COMPLETE.name());
 
     messageAndMetadata = iterator.next();
-    Assert.assertNull(jobStatusMonitor.parseJobStatus(messageAndMetadata.message()));
+    Assert.assertNull(jobStatusMonitor.parseJobStatus(convertMessageAndMetadataToDecodableKafkaRecord(messageAndMetadata)));
 
     // Check that state didn't get set to running since it was already complete
     messageAndMetadata = iterator.next();

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaAvroJobStatusMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaAvroJobStatusMonitor.java
@@ -23,14 +23,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 
-import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.io.BinaryDecoder;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.specific.SpecificDatumReader;
 
 import com.codahale.metrics.Meter;
-import com.google.common.base.Charsets;
 import com.typesafe.config.Config;
 
 import lombok.Getter;
@@ -88,17 +86,10 @@ public class KafkaAvroJobStatusMonitor extends KafkaJobStatusMonitor {
 
   @Override
   public org.apache.gobblin.configuration.State parseJobStatus(byte[] message) {
-    InputStream is = new ByteArrayInputStream(message);
     try {
+      InputStream is = new ByteArrayInputStream(message);
       schemaVersionWriter.readSchemaVersioningInformation(new DataInputStream(is));
-    } catch (IOException e) {
-      String messageStr = new String(message.getValue(), Charsets.UTF_8);
-      log.error(String.format("Failed to parse kafka message with offset %d: %s.", message.getOffset(), messageStr), ioe);
-      return null;
-    }
-
-    Decoder decoder = DecoderFactory.get().binaryDecoder(is, this.decoder.get());
-    try {
+      Decoder decoder = DecoderFactory.get().binaryDecoder(is, this.decoder.get());
       GobblinTrackingEvent decodedMessage = this.reader.get().read(null, decoder);
       return parseJobStatus(decodedMessage);
     } catch (Exception exc) {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaJobStatusMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaJobStatusMonitor.java
@@ -130,7 +130,7 @@ public abstract class KafkaJobStatusMonitor extends HighLevelConsumer<byte[], by
   @Override
   protected void processMessage(DecodeableKafkaRecord<byte[],byte[]> message) {
     try {
-      org.apache.gobblin.configuration.State jobStatus = parseJobStatus(message.getValue());
+      org.apache.gobblin.configuration.State jobStatus = parseJobStatus(message);
       if (jobStatus != null) {
         try(Timer.Context context = getMetricContext().timer(GET_AND_SET_JOB_STATUS).time()) {
           addJobStatusToStateStore(jobStatus, this.stateStore);
@@ -138,7 +138,7 @@ public abstract class KafkaJobStatusMonitor extends HighLevelConsumer<byte[], by
       }
     } catch (IOException ioe) {
       // Throw RuntimeException to avoid advancing kafka offsets without updating state store
-      throw new RuntimeException("Failed to add job status to state store", ioe);
+      throw new RuntimeException("Failed to add job status to state store for kafka offset " + message.getOffset(), ioe);
     }
   }
 
@@ -232,6 +232,6 @@ public abstract class KafkaJobStatusMonitor extends HighLevelConsumer<byte[], by
     return Long.parseLong(Splitter.on(STATE_STORE_KEY_SEPARATION_CHARACTER).splitToList(tableName).get(0));
   }
 
-  public abstract org.apache.gobblin.configuration.State parseJobStatus(byte[] message);
+  public abstract org.apache.gobblin.configuration.State parseJobStatus(DecodeableKafkaRecord<byte[],byte[]> message);
 
 }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaJobStatusMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaJobStatusMonitor.java
@@ -137,8 +137,8 @@ public abstract class KafkaJobStatusMonitor extends HighLevelConsumer<byte[], by
         }
       }
     } catch (IOException ioe) {
-      String messageStr = new String(message.getValue(), Charsets.UTF_8);
-      log.error(String.format("Failed to parse kafka message with offset %d: %s.", message.getOffset(), messageStr), ioe);
+      // Throw RuntimeException to avoid advancing kafka offsets without updating state store
+      throw new RuntimeException("Failed to add job status to state store", ioe);
     }
   }
 
@@ -232,6 +232,6 @@ public abstract class KafkaJobStatusMonitor extends HighLevelConsumer<byte[], by
     return Long.parseLong(Splitter.on(STATE_STORE_KEY_SEPARATION_CHARACTER).splitToList(tableName).get(0));
   }
 
-  public abstract org.apache.gobblin.configuration.State parseJobStatus(byte[] message) throws IOException;
+  public abstract org.apache.gobblin.configuration.State parseJobStatus(byte[] message);
 
 }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1300


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Exceptions from parsing the message should be caught, but not exceptions when storing job status in state store.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
trivial

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

