### PR TITLE
[GOBBLIN-1303] Catch error when failing to clean staging data

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/AbstractJobLauncher.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/AbstractJobLauncher.java
@@ -559,43 +559,43 @@ public abstract class AbstractJobLauncher implements JobLauncher {
               }
             });
           }
-        }
-      }
 
-      for (JobState.DatasetState datasetState : this.jobContext.getDatasetStatesByUrns().values()) {
-        // Set the overall job state to FAILED if the job failed to process any dataset
-        if (datasetState.getState() == JobState.RunningState.FAILED) {
-          jobState.setState(JobState.RunningState.FAILED);
-          LOG.warn("At least one dataset state is FAILED. Setting job state to FAILED.");
-          break;
-        }
-      }
-
-      notifyListeners(this.jobContext, jobListener, TimingEvent.LauncherTimings.JOB_COMPLETE, new JobListenerAction() {
-        @Override
-        public void apply(JobListener jobListener, JobContext jobContext)
-            throws Exception {
-          jobListener.onJobCompletion(jobContext);
-        }
-      });
-
-      if (jobState.getState() == JobState.RunningState.FAILED) {
-        notifyListeners(this.jobContext, jobListener, TimingEvent.LauncherTimings.JOB_FAILED, new JobListenerAction() {
-          @Override
-          public void apply(JobListener jobListener, JobContext jobContext)
-              throws Exception {
-            jobListener.onJobFailure(jobContext);
+          for (JobState.DatasetState datasetState : this.jobContext.getDatasetStatesByUrns().values()) {
+            // Set the overall job state to FAILED if the job failed to process any dataset
+            if (datasetState.getState() == JobState.RunningState.FAILED) {
+              jobState.setState(JobState.RunningState.FAILED);
+              LOG.warn("At least one dataset state is FAILED. Setting job state to FAILED.");
+              break;
+            }
           }
-        });
-        throw new JobException(String.format("Job %s failed", jobId));
-      } else {
-        notifyListeners(this.jobContext, jobListener, TimingEvent.LauncherTimings.JOB_SUCCEEDED, new JobListenerAction() {
-          @Override
-          public void apply(JobListener jobListener, JobContext jobContext)
-              throws Exception {
-            jobListener.onJobFailure(jobContext);
+
+          notifyListeners(this.jobContext, jobListener, TimingEvent.LauncherTimings.JOB_COMPLETE, new JobListenerAction() {
+            @Override
+            public void apply(JobListener jobListener, JobContext jobContext)
+                throws Exception {
+              jobListener.onJobCompletion(jobContext);
+            }
+          });
+
+          if (jobState.getState() == JobState.RunningState.FAILED) {
+            notifyListeners(this.jobContext, jobListener, TimingEvent.LauncherTimings.JOB_FAILED, new JobListenerAction() {
+              @Override
+              public void apply(JobListener jobListener, JobContext jobContext)
+                  throws Exception {
+                jobListener.onJobFailure(jobContext);
+              }
+            });
+            throw new JobException(String.format("Job %s failed", jobId));
+          } else {
+            notifyListeners(this.jobContext, jobListener, TimingEvent.LauncherTimings.JOB_SUCCEEDED, new JobListenerAction() {
+              @Override
+              public void apply(JobListener jobListener, JobContext jobContext)
+                  throws Exception {
+                jobListener.onJobFailure(jobContext);
+              }
+            });
           }
-        });
+        }
       }
     } finally {
       // Stop metrics reporting


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1303


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Currently if there is a failure in cleanupStagingData, it is not caught, so the rest of launchJob (which includes sending GobblinTrackingEvents) will not be run

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
trivial

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

