### PR TITLE
GOBBLIN-1316: Copy field and schema level properties when switching namespace in a schema

### DIFF
--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/AvroUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/AvroUtils.java
@@ -782,18 +782,12 @@ public class AvroUtils {
             Field newField = new Field(oldField.name(), switchNamespace(oldField.schema(), namespaceOverride), oldField.doc(),
                 oldField.defaultValue(), oldField.order());
             // Copy field level properties
-            for (Map.Entry<String, JsonNode> prop : oldField.getJsonProps().entrySet()) {
-              newField.addProp(prop.getKey(), prop.getValue());
-            }
+            copyFieldProperties(oldField, newField);
             newFields.add(newField);
           }
         }
         newSchema = Schema.createRecord(schema.getName(), schema.getDoc(), newNamespace,
             schema.isError());
-        // Copy schema level properties
-        for (Map.Entry<String, JsonNode> prop : schema.getJsonProps().entrySet()) {
-          newSchema.addProp(prop.getKey(), prop.getValue());
-        }
         newSchema.setFields(newFields);
         break;
       case UNION:

--- a/gobblin-utility/src/main/java/org/apache/gobblin/util/AvroUtils.java
+++ b/gobblin-utility/src/main/java/org/apache/gobblin/util/AvroUtils.java
@@ -781,11 +781,19 @@ public class AvroUtils {
           for (Schema.Field oldField : schema.getFields()) {
             Field newField = new Field(oldField.name(), switchNamespace(oldField.schema(), namespaceOverride), oldField.doc(),
                 oldField.defaultValue(), oldField.order());
+            // Copy field level properties
+            for (Map.Entry<String, JsonNode> prop : oldField.getJsonProps().entrySet()) {
+              newField.addProp(prop.getKey(), prop.getValue());
+            }
             newFields.add(newField);
           }
         }
         newSchema = Schema.createRecord(schema.getName(), schema.getDoc(), newNamespace,
             schema.isError());
+        // Copy schema level properties
+        for (Map.Entry<String, JsonNode> prop : schema.getJsonProps().entrySet()) {
+          newSchema.addProp(prop.getKey(), prop.getValue());
+        }
         newSchema.setFields(newFields);
         break;
       case UNION:

--- a/gobblin-utility/src/test/java/org/apache/gobblin/util/AvroUtilsTest.java
+++ b/gobblin-utility/src/test/java/org/apache/gobblin/util/AvroUtilsTest.java
@@ -51,12 +51,11 @@ import org.apache.hadoop.fs.Path;
 import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.node.ArrayNode;
-import org.codehaus.jackson.node.JsonNodeFactory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import com.beust.jcommander.internal.Lists;
 import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
 import lombok.extern.slf4j.Slf4j;
@@ -237,8 +236,6 @@ public class AvroUtilsTest {
     String originalNamespace = "originalNamespace";
     String originalName = "originalName";
     String newNamespace = "newNamespace";
-    //Schema schema = SchemaBuilder.builder(originalNamespace).record(originalName).fields().
-    //    requiredDouble("double").optionalFloat("float").endRecord();
 
     Schema schema = Schema.createRecord(originalName, "", originalNamespace, false);
     schema.addProp("prop1", "val1");

--- a/gobblin-utility/src/test/java/org/apache/gobblin/util/AvroUtilsTest.java
+++ b/gobblin-utility/src/test/java/org/apache/gobblin/util/AvroUtilsTest.java
@@ -51,9 +51,11 @@ import org.apache.hadoop.fs.Path;
 import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.node.ArrayNode;
+import org.codehaus.jackson.node.JsonNodeFactory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import com.beust.jcommander.internal.Lists;
 import com.google.common.base.Optional;
 import com.google.common.collect.Maps;
 
@@ -235,8 +237,21 @@ public class AvroUtilsTest {
     String originalNamespace = "originalNamespace";
     String originalName = "originalName";
     String newNamespace = "newNamespace";
-    Schema schema = SchemaBuilder.builder(originalNamespace).record(originalName).fields().
-        requiredDouble("double").optionalFloat("float").endRecord();
+    //Schema schema = SchemaBuilder.builder(originalNamespace).record(originalName).fields().
+    //    requiredDouble("double").optionalFloat("float").endRecord();
+
+    Schema schema = Schema.createRecord(originalName, "", originalNamespace, false);
+    schema.addProp("prop1", "val1");
+    schema.addProp("prop2", "val2");
+    List<Schema.Field> fieldList = Lists.newArrayList();
+    Schema.Field field1 =
+        new Schema.Field("key", Schema.create(Schema.Type.LONG), "", 0L);
+    field1.addProp("primaryKey", "true");
+    fieldList.add(field1);
+    Schema.Field field2 = new Schema.Field("double", Schema.create(Schema.Type.DOUBLE), "", 0.0);
+    fieldList.add(field2);
+
+    schema.setFields(Lists.newArrayList(fieldList));
 
     Map<String, String> map = Maps.newHashMap();
     map.put(originalNamespace, newNamespace);
@@ -247,6 +262,8 @@ public class AvroUtilsTest {
     for(Schema.Field field : newSchema.getFields()) {
       Assert.assertEquals(field, schema.getField(field.name()));
     }
+
+    Assert.assertTrue(schema.getObjectProps().equals(newSchema.getObjectProps()));
   }
 
   @Test public void testSerializeAsPath() throws Exception {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1316


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
When a namespace override is applied to an input schema, the new schema does not currently contain the field and schema level properties of the original schema. 


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Unit test in AvroUtilsTest.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

