### PR TITLE
[GOBBLIN-1319] fix cancellation in gobblin cluster jobs

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/runtime/api/SpecExecutor.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/runtime/api/SpecExecutor.java
@@ -59,7 +59,8 @@ public interface SpecExecutor {
     ADD(1, "add"),
     UPDATE(2, "update"),
     DELETE(3, "delete"),
-    UNKNOWN(4, "unknown");
+    UNKNOWN(4, "unknown"),
+    CANCEL(5, "cancel");
 
     private int _id;
     private String _verb;

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/FsJobConfigurationManager.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/FsJobConfigurationManager.java
@@ -114,6 +114,9 @@ public class FsJobConfigurationManager extends JobConfigurationManager {
           this.jobCatalogOptional.get().remove(jobSpec.getUri());
         }
         postDeleteJobConfigArrival(jobSpec.getUri().toString(), jobSpec.getConfigAsProperties());
+      } else if (verb.equals(SpecExecutor.Verb.CANCEL)) {
+          // Handle cancel
+          postCancelJobConfigArrival(jobSpec.getUri().toString());
       }
 
       try {

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJob.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixJob.java
@@ -44,7 +44,7 @@ import org.apache.gobblin.scheduler.JobScheduler;
 @Alpha
 @Slf4j
 public class GobblinHelixJob extends BaseGobblinJob implements InterruptableJob {
-  private Future cancellable = null;
+  private Future<?> cancellable = null;
 
   @Override
   public void executeImpl(JobExecutionContext context) throws JobExecutionException {
@@ -56,7 +56,7 @@ public class GobblinHelixJob extends BaseGobblinJob implements InterruptableJob 
     final JobListener jobListener = (JobListener) dataMap.get(JobScheduler.JOB_LISTENER_KEY);
 
     try {
-      if (Boolean.valueOf(jobProps.getProperty(GobblinClusterConfigurationKeys.JOB_EXECUTE_IN_SCHEDULING_THREAD,
+      if (Boolean.parseBoolean(jobProps.getProperty(GobblinClusterConfigurationKeys.JOB_EXECUTE_IN_SCHEDULING_THREAD,
               Boolean.toString(GobblinClusterConfigurationKeys.JOB_EXECUTE_IN_SCHEDULING_THREAD_DEFAULT)))) {
         jobScheduler.runJob(jobProps, jobListener);
       } else {

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/HelixJobsMapping.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/HelixJobsMapping.java
@@ -116,27 +116,27 @@ public class HelixJobsMapping {
     this.stateStore.delete(this.distributedStateStoreName, jobName);
   }
 
-  public void setPlanningJobId (String jobName, String planningJobId) throws IOException {
-    State state = getOrCreate(distributedStateStoreName, jobName);
-    state.setId(jobName);
+  public void setPlanningJobId (String jobUri, String planningJobId) throws IOException {
+    State state = getOrCreate(distributedStateStoreName, jobUri);
+    state.setId(jobUri);
     state.setProp(GobblinClusterConfigurationKeys.PLANNING_ID_KEY, planningJobId);
     // fs state store use hdfs rename, which assumes the target file doesn't exist.
     if (stateStore instanceof FsStateStore) {
-      this.deleteMapping(jobName);
+      this.deleteMapping(jobUri);
     }
-    this.stateStore.put(distributedStateStoreName, jobName, state);
+    this.stateStore.put(distributedStateStoreName, jobUri, state);
   }
 
-  public void setActualJobId (String jobName, String planningJobId, String actualJobId) throws IOException {
-    State state = getOrCreate(distributedStateStoreName, jobName);
-    state.setId(jobName);
+  public void setActualJobId (String jobUri, String planningJobId, String actualJobId) throws IOException {
+    State state = getOrCreate(distributedStateStoreName, jobUri);
+    state.setId(jobUri);
     state.setProp(GobblinClusterConfigurationKeys.PLANNING_ID_KEY, planningJobId);
     state.setProp(ConfigurationKeys.JOB_ID_KEY, actualJobId);
     // fs state store use hdfs rename, which assumes the target file doesn't exist.
     if (stateStore instanceof FsStateStore) {
-      this.deleteMapping(jobName);
+      this.deleteMapping(jobUri);
     }
-    this.stateStore.put(distributedStateStoreName, jobName, state);
+    this.stateStore.put(distributedStateStoreName, jobUri, state);
   }
 
   private Optional<String> getId (String jobName, String idName) throws IOException {
@@ -154,8 +154,8 @@ public class HelixJobsMapping {
     return this.stateStore.getAll(distributedStateStoreName);
   }
 
-  public Optional<String> getActualJobId (String jobName) throws IOException {
-    return getId(jobName, ConfigurationKeys.JOB_ID_KEY);
+  public Optional<String> getActualJobId (String jobUri) throws IOException {
+    return getId(jobUri, ConfigurationKeys.JOB_ID_KEY);
   }
 
   public Optional<String> getPlanningJobId (String jobName) throws IOException {

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/HelixJobsMapping.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/HelixJobsMapping.java
@@ -120,34 +120,47 @@ public class HelixJobsMapping {
     State state = getOrCreate(distributedStateStoreName, jobUri);
     state.setId(jobUri);
     state.setProp(GobblinClusterConfigurationKeys.PLANNING_ID_KEY, planningJobId);
-    // fs state store use hdfs rename, which assumes the target file doesn't exist.
-    if (stateStore instanceof FsStateStore) {
-      this.deleteMapping(jobUri);
-    }
-    this.stateStore.put(distributedStateStoreName, jobUri, state);
+    writeToStateStore(jobUri, state);
+  }
+
+  public void setActualJobId (String jobUri, String actualJobId) throws IOException {
+    setActualJobId(jobUri, null, actualJobId);
   }
 
   public void setActualJobId (String jobUri, String planningJobId, String actualJobId) throws IOException {
     State state = getOrCreate(distributedStateStoreName, jobUri);
     state.setId(jobUri);
-    state.setProp(GobblinClusterConfigurationKeys.PLANNING_ID_KEY, planningJobId);
+    if (null != planningJobId) {
+      state.setProp(GobblinClusterConfigurationKeys.PLANNING_ID_KEY, planningJobId);
+    }
     state.setProp(ConfigurationKeys.JOB_ID_KEY, actualJobId);
+    writeToStateStore(jobUri, state);
+  }
+
+  public void setDistributedJobMode(String jobUri, boolean distributedJobMode) throws IOException {
+    State state = getOrCreate(distributedStateStoreName, jobUri);
+    state.setId(jobUri);
+    state.setProp(GobblinClusterConfigurationKeys.DISTRIBUTED_JOB_LAUNCHER_ENABLED, distributedJobMode);
+    writeToStateStore(jobUri, state);
+  }
+
+  private void writeToStateStore(String jobUri, State state) throws IOException {
     // fs state store use hdfs rename, which assumes the target file doesn't exist.
-    if (stateStore instanceof FsStateStore) {
+    if (this.stateStore instanceof FsStateStore) {
       this.deleteMapping(jobUri);
     }
     this.stateStore.put(distributedStateStoreName, jobUri, state);
   }
 
-  private Optional<String> getId (String jobName, String idName) throws IOException {
-    State state = this.stateStore.get(distributedStateStoreName, jobName, jobName);
+  private Optional<String> getId (String jobUri, String idName) throws IOException {
+    State state = this.stateStore.get(distributedStateStoreName, jobUri, jobUri);
     if (state == null) {
       return Optional.empty();
     }
 
     String id = state.getProp(idName);
 
-    return id == null? Optional.empty() : Optional.of(id);
+    return id == null ? Optional.empty() : Optional.of(id);
   }
 
   public List<State> getAllStates() throws IOException {
@@ -158,7 +171,18 @@ public class HelixJobsMapping {
     return getId(jobUri, ConfigurationKeys.JOB_ID_KEY);
   }
 
-  public Optional<String> getPlanningJobId (String jobName) throws IOException {
-    return getId(jobName, GobblinClusterConfigurationKeys.PLANNING_ID_KEY);
+  public Optional<String> getPlanningJobId (String jobUri) throws IOException {
+    return getId(jobUri, GobblinClusterConfigurationKeys.PLANNING_ID_KEY);
+  }
+
+  public Optional<String> getDistributedJobMode(String jobUri) throws IOException {
+    State state = this.stateStore.get(distributedStateStoreName, jobUri, jobUri);
+    if (state == null) {
+      return Optional.empty();
+    }
+
+    String id = state.getProp(GobblinClusterConfigurationKeys.DISTRIBUTED_JOB_LAUNCHER_ENABLED);
+
+    return id == null ? Optional.empty() : Optional.of(id);
   }
 }

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/JobConfigurationManager.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/JobConfigurationManager.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Properties;
 
+import org.apache.gobblin.cluster.event.CancelJobConfigArrivalEvent;
 import org.apache.gobblin.runtime.job_spec.JobSpecResolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -131,5 +132,10 @@ public class JobConfigurationManager extends AbstractIdleService implements Stan
   protected void postDeleteJobConfigArrival(String jobName, @Nullable Properties jobConfig) {
     LOGGER.info(String.format("Posting delete JobConfig with name: %s and config: %s", jobName, jobConfig));
     this.eventBus.post(new DeleteJobConfigArrivalEvent(jobName, jobConfig));
+  }
+
+  protected void postCancelJobConfigArrival(String jobUri) {
+    LOGGER.info(String.format("Posting cancel JobConfig with name: %s", jobUri));
+    this.eventBus.post(new CancelJobConfigArrivalEvent(jobUri));
   }
 }

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/ScheduledJobConfigurationManager.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/ScheduledJobConfigurationManager.java
@@ -140,7 +140,11 @@ public class ScheduledJobConfigurationManager extends JobConfigurationManager {
         Spec anonymousSpec = (Spec) entry.getValue();
         postDeleteJobConfigArrival(anonymousSpec.getUri().toString(), new Properties());
         jobSpecs.remove(entry.getValue().getUri());
-      }
+      } else if (verb.equals(SpecExecutor.Verb.CANCEL)) {
+        // Handle cancel
+        Spec anonymousSpec = entry.getValue();
+        postCancelJobConfigArrival(anonymousSpec.getUri().toString());
+        }
     }
   }
 

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/StreamingJobConfigurationManager.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/StreamingJobConfigurationManager.java
@@ -158,8 +158,11 @@ public class StreamingJobConfigurationManager extends JobConfigurationManager {
         postUpdateJobConfigArrival(jobSpec.getUri().toString(), jobSpec.getConfigAsProperties());
       } else if (verb.equals(SpecExecutor.Verb.DELETE)) {
         // Handle delete
-        Spec anonymousSpec = (Spec) entry.getValue();
+        Spec anonymousSpec = entry.getValue();
         postDeleteJobConfigArrival(anonymousSpec.getUri().toString(), new Properties());
+      } else if (verb.equals(SpecExecutor.Verb.CANCEL)) {
+        Spec anonymousSpec = entry.getValue();
+        postCancelJobConfigArrival(anonymousSpec.getUri().toString());
       }
     }
   }

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/event/CancelJobConfigArrivalEvent.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/event/CancelJobConfigArrivalEvent.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.cluster.event;
+
+import java.util.Properties;
+
+
+public class CancelJobConfigArrivalEvent {
+  private final String jobUri;
+
+  public CancelJobConfigArrivalEvent(String jobUri) {
+    this.jobUri = jobUri;
+  }
+
+  /**
+   * Get the job uri.
+   *
+   * @return the job uri
+   */
+  public String getJoburi() {
+    return this.jobUri;
+  }
+}

--- a/gobblin-modules/gobblin-service-kafka/src/main/java/org/apache/gobblin/service/StreamingKafkaSpecConsumer.java
+++ b/gobblin-modules/gobblin-service-kafka/src/main/java/org/apache/gobblin/service/StreamingKafkaSpecConsumer.java
@@ -179,6 +179,18 @@ public class StreamingKafkaSpecConsumer extends AbstractIdleService implements S
       }
     }
 
+    @Override
+    public void onCancelJob(URI cancelledJobURI) {
+      super.onCancelJob(cancelledJobURI);
+      try {
+        JobSpec.Builder jobSpecBuilder = JobSpec.builder(cancelledJobURI);
+        jobSpecBuilder.withConfigAsProperties(new Properties());
+        _jobSpecQueue.put(new ImmutablePair<>(SpecExecutor.Verb.CANCEL, jobSpecBuilder.build()));
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
+
     @Override public void onUpdateJob(JobSpec updatedJob) {
       super.onUpdateJob(updatedJob);
 

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/JobCatalogListener.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/JobCatalogListener.java
@@ -37,6 +37,9 @@ public interface JobCatalogListener {
    */
   public void onDeleteJob(URI deletedJobURI, String deletedJobVersion);
 
+  default void onCancelJob(URI cancelledJobURI) {
+  }
+
   /**
    * Invoked when the contents of a JobSpec gets updated in the catalog.
    */
@@ -72,6 +75,21 @@ public interface JobCatalogListener {
 
     @Override public Void apply(JobCatalogListener listener) {
       listener.onDeleteJob(_deletedJobURI, _deletedJobVersion);
+      return null;
+    }
+  }
+
+  public static class CancelJobCallback extends Callback<JobCatalogListener, Void> {
+    private final URI _cancelledJobURI;
+
+    public CancelJobCallback(URI cancelledJobURI) {
+      super(Objects.toStringHelper("onCancelJob").add("cancelJob", cancelledJobURI).toString());
+      _cancelledJobURI = cancelledJobURI;
+    }
+
+    @Override
+    public Void apply(JobCatalogListener listener) {
+      listener.onCancelJob(_cancelledJobURI);
       return null;
     }
   }

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/MutableJobCatalog.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/MutableJobCatalog.java
@@ -48,6 +48,10 @@ public interface MutableJobCatalog extends JobCatalog {
    * */
   public void put(JobSpec jobSpec);
 
+  default void remove(URI uri, boolean alwaysTriggerListeners) {
+    throw new UnsupportedOperationException("Method not implemented by " + this.getClass());
+  }
+
   /**
    * Removes an existing JobSpec with the given URI. A no-op if such JobSpec does not exist.
    */

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/job_catalog/JobCatalogListenersList.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/job_catalog/JobCatalogListenersList.java
@@ -99,6 +99,17 @@ public class JobCatalogListenersList implements JobCatalogListener, JobCatalogLi
   }
 
   @Override
+  public synchronized void onCancelJob(URI cancelledJobURI) {
+    Preconditions.checkNotNull(cancelledJobURI);
+
+    try {
+      _disp.execCallbacks(new CancelJobCallback(cancelledJobURI));
+    } catch (InterruptedException e) {
+      getLog().warn("onCancelJob interrupted.");
+    }
+  }
+
+  @Override
   public void close()
       throws IOException {
     _disp.close();

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/job_catalog/NonObservingFSJobCatalog.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/job_catalog/NonObservingFSJobCatalog.java
@@ -102,6 +102,10 @@ public class NonObservingFSJobCatalog extends FSJobCatalog {
    */
   @Override
   public synchronized void remove(URI jobURI) {
+      remove(jobURI, false);
+  }
+
+  public synchronized void remove(URI jobURI, boolean alwaysTriggerListeners) {
     Preconditions.checkState(state() == State.RUNNING, String.format("%s is not running.", this.getClass().getName()));
     try {
       long startTime = System.currentTimeMillis();
@@ -119,6 +123,12 @@ public class NonObservingFSJobCatalog extends FSJobCatalog {
       throw new RuntimeException("When removing a JobConf. file, issues unexpected happen:" + e.getMessage());
     } catch (SpecNotFoundException e) {
       LOGGER.warn("No file with URI:" + jobURI + " is found. Deletion failed.");
+    } finally {
+      // HelixRetriggeringJobCallable deletes the job file after submitting it to helix,
+      // so we will have to trigger listeners regardless the existence of job file to cancel the job
+      if (alwaysTriggerListeners) {
+        this.listeners.onCancelJob(jobURI);
+      }
     }
   }
 }

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/job_monitor/KafkaJobMonitor.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/job_monitor/KafkaJobMonitor.java
@@ -108,7 +108,7 @@ public abstract class KafkaJobMonitor extends HighLevelConsumer<byte[], byte[]> 
         } else if (parsedMessage instanceof Either.Right) {
           this.removedSpecs.inc();
           URI jobSpecUri = ((Either.Right<JobSpec, URI>) parsedMessage).getRight();
-          this.jobCatalog.remove(jobSpecUri);
+          this.jobCatalog.remove(jobSpecUri, true);
           // Delete the job state if it is a delete spec request
           deleteStateStore(jobSpecUri);
         }

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/job_monitor/MockedKafkaJobMonitor.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/job_monitor/MockedKafkaJobMonitor.java
@@ -90,7 +90,7 @@ public class MockedKafkaJobMonitor extends KafkaJobMonitor {
         jobSpecs.remove(uri);
         return null;
       }
-    }).when(jobCatalog).remove(Mockito.any(URI.class));
+    }).when(jobCatalog).remove(Mockito.any(URI.class), Mockito.anyBoolean());
 
     return jobCatalog;
   }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!
@yukuai518 @sv2000  please review

### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1319


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
- jobsMapping in GobblinHelixJobScheduler was using job name to store the mapping of job to planning/actual job. this pr is changing it to use job uri instead, because cancellation request just have a uri
- provide a clean separate path for cancellation on cluster side, so that 'delete' calls from within the cluster and from gobblin service can be treated differently
- storing non distributed mode jobs also in JobsMapping in order to provide a cleaner control over cancellation. Storing helix jobs' metadata in a mysql table will also let users cancel the flow if cluster-manager restarts after initial flow submission.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
verified with integration test

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

