### PR TITLE
[GOBBLIN-1329] Supressing Stacktrace in HelixResult to avoid ZK disk usage overloading

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixTask.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/GobblinHelixTask.java
@@ -181,12 +181,11 @@ public class GobblinHelixTask implements Task {
       log.error("Actual task {} failed in creation due to {}, will request new container to schedule it",
           this.taskId, te.getMessage());
       this.taskMetrics.helixTaskTotalCancelled.incrementAndGet();
-      return new TaskResult(TaskResult.Status.FAILED, "Root cause:" + ExceptionUtils.getRootCauseMessage(te)
-          + ", refer to container log for the whole stacktrace");
+      return new TaskResult(TaskResult.Status.FAILED, "Root cause:" + ExceptionUtils.getRootCauseMessage(te));
     } catch (Throwable t) {
       log.error(String.format("Actual task %s failed due to:", this.taskId), t);
       this.taskMetrics.helixTaskTotalCancelled.incrementAndGet();
-      return new TaskResult(TaskResult.Status.FAILED, "Refer to container log for exception details.");
+      return new TaskResult(TaskResult.Status.FAILED, "");
     } finally {
       this.taskMetrics.helixTaskTotalRunning.decrementAndGet();
       this.taskMetrics.updateTimeForTaskExecution(startTime);


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
https://issues.apache.org/jira/browse/GOBBLIN-1329


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

Instead of printing the whole stack trace which could be pretty long, in the `TaskResult` returned from `GobblinHelixTask`, we log the whole stack trace in the container but avoid include that as part of `TaskResult` returned back to Helix, which could result in flooding log in ZK. 



### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

