### PR TITLE
[GOBBLIN-1334] Adds removing job watermark to the state store cli

### DIFF
--- a/gobblin-metastore/src/main/java/org/apache/gobblin/runtime/StateStoreBasedWatermarkStorage.java
+++ b/gobblin-metastore/src/main/java/org/apache/gobblin/runtime/StateStoreBasedWatermarkStorage.java
@@ -137,6 +137,10 @@ public class StateStoreBasedWatermarkStorage implements WatermarkStorage {
     return committed;
   }
 
+  public void removeAllJobWatermark() throws IOException {
+    this._stateStore.delete(_storeName);
+  }
+
   public Iterable<CheckpointableWatermarkState> getAllCommittedWatermarks() throws IOException {
     return _stateStore.getAll(_storeName);
   }

--- a/gobblin-runtime/build.gradle
+++ b/gobblin-runtime/build.gradle
@@ -87,6 +87,7 @@ dependencies {
   compile externalDependency.kryo
 
   testCompile project(path: ":gobblin-metastore", configuration: "testFixtures")
+  testCompile project(":gobblin-modules:gobblin-helix")
   testCompile externalDependency.jhyde
   testCompile externalDependency.testng
   testCompile externalDependency.hamcrest

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/StateStoreBasedWatermarkStorageCliTest.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/StateStoreBasedWatermarkStorageCliTest.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gobblin.runtime;
+
+import com.google.common.collect.ImmutableList;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import org.apache.curator.test.TestingServer;
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.source.extractor.CheckpointableWatermark;
+import org.apache.gobblin.source.extractor.DefaultCheckpointableWatermark;
+import org.apache.gobblin.source.extractor.extract.LongWatermark;
+import org.junit.Before;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class StateStoreBasedWatermarkStorageCliTest {
+
+  private static final String TEST_JOB_ID = "TestJob1";
+
+  private TestingServer testingServer;
+  private long startTime = System.currentTimeMillis();
+  StateStoreBasedWatermarkStorageCli cli;
+  PrintStream console;
+  ByteArrayOutputStream bytes;
+
+  @BeforeClass
+  public void setup() throws Exception {
+    this.testingServer = new TestingServer(-1);
+    this.bytes = new ByteArrayOutputStream();
+    this.console = System.out;
+    this.cli = new StateStoreBasedWatermarkStorageCli();
+    System.setOut(new PrintStream(this.bytes));
+  }
+
+  @AfterMethod
+  public void cleanOutput() {
+    this.bytes.reset();
+  }
+
+  @AfterClass
+  public void cleanup() throws IOException {
+    this.bytes.close();
+    System.setOut(console);
+    if (testingServer != null) {
+      testingServer.close();
+    }
+  }
+
+  @Test
+  public void testHelpOutput() {
+    String[] args = {"watermarks", "--help"};
+    cli.run(args);
+    Assert.assertTrue(this.bytes.toString().contains("usage: gobblin watermarks\n"));
+  }
+
+  @Test
+  public void testJobMissingOutput() {
+    String[] args = {"watermarks", "--rootDir", "testFolder1"};
+    cli.run(args);
+    Assert.assertTrue(this.bytes.toString().contains("Need Job Name to be specified --jobName\n"));
+  }
+
+  @Test
+  public void testMissingRootDirOption() {
+    String[] args = {"watermarks", "--jobName", "TestJob1"};
+    cli.run(args);
+    Assert.assertTrue(this.bytes.toString().contains("Need root directory specified\n"));
+  }
+
+  @Test
+  public void testViewWatermarks() throws IOException {
+    String[] args = {"watermarks", "--jobName", TEST_JOB_ID, "--rootDir", "/streamingWatermarks", "--zk", testingServer.getConnectString()};
+    CheckpointableWatermark watermark = new DefaultCheckpointableWatermark("source", new LongWatermark(startTime));
+
+    TaskState taskState = new TaskState();
+    taskState.setJobId(TEST_JOB_ID);
+    taskState.setProp(ConfigurationKeys.JOB_NAME_KEY, TEST_JOB_ID);
+    // watermark storage configuration
+    taskState.setProp(StateStoreBasedWatermarkStorage.WATERMARK_STORAGE_TYPE_KEY, "zk");
+    taskState.setProp(StateStoreBasedWatermarkStorage.WATERMARK_STORAGE_CONFIG_PREFIX +
+        "state.store.zk.connectString", testingServer.getConnectString());
+
+    StateStoreBasedWatermarkStorage watermarkStorage = new StateStoreBasedWatermarkStorage(taskState);
+    watermarkStorage.commitWatermarks(ImmutableList.of(watermark));
+
+    cli.run(args);
+    Assert.assertTrue(this.bytes.toString().contains("{source={\"object-type\":\"org.apache.gobblin.source.extractor.DefaultCheckpointableWatermark\",\"object-data\":{\"source\":\"source\",\"comparable\":{\"object-type\":\"org.apache.gobblin.source.extractor.extract.LongWatermark\",\"object-data\":{\"value\":" + this.startTime + "}}}}}\n"));
+  }
+
+  @Test(dependsOnMethods="testViewWatermarks")
+  public void testDeleteWatermark() {
+    String[] args = {"watermarks", "--jobName", TEST_JOB_ID, "--rootDir", "/streamingWatermarks", "--zk", testingServer.getConnectString(), "--delete"};
+    CheckpointableWatermark watermark = new DefaultCheckpointableWatermark("source", new LongWatermark(startTime));
+
+    TaskState taskState = new TaskState();
+    taskState.setJobId(TEST_JOB_ID);
+    taskState.setProp(ConfigurationKeys.JOB_NAME_KEY, TEST_JOB_ID);
+    // watermark storage configuration
+    taskState.setProp(StateStoreBasedWatermarkStorage.WATERMARK_STORAGE_TYPE_KEY, "zk");
+    taskState.setProp(StateStoreBasedWatermarkStorage.WATERMARK_STORAGE_CONFIG_PREFIX +
+        "state.store.zk.connectString", testingServer.getConnectString());
+
+    StateStoreBasedWatermarkStorage watermarkStorage = new StateStoreBasedWatermarkStorage(taskState);
+
+    cli.run(args);
+    Assert.assertTrue(this.bytes.toString().contains("No watermarks found."));
+  }
+}


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1334


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
 Extends the Watermark CLI tool to have delete capabilities based on job ID. Also performs some refactoring to clean up and test the CLI tool.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  - adds tests for `StateStoreWatermarkStorage`
  - adds tests for `StateStoreBasedWatermarkStorageCli`

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

