### PR TITLE
GOBBLIN-1337: Fix string representation of KafkaPartition in KafkaTopicGroupingWorkUnitPacker

### DIFF
--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaTopicGroupingWorkUnitPacker.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaTopicGroupingWorkUnitPacker.java
@@ -251,7 +251,7 @@ public class KafkaTopicGroupingWorkUnitPacker extends KafkaWorkUnitPacker {
       List<WorkUnit> workUnits = entry.getValue();
       for (WorkUnit workUnit : workUnits) {
         int partitionId = Integer.parseInt(workUnit.getProp(KafkaSource.PARTITION_ID));
-        String topicPartition = new KafkaPartition.Builder().withTopicName(topic).withId(partitionId).toString();
+        String topicPartition = new KafkaPartition.Builder().withTopicName(topic).withId(partitionId).build().toString();
         KafkaStreamingExtractor.KafkaWatermark watermark = lastCommittedWatermarks.get(topicPartition);
         workUnit.setProp(PARTITION_WATERMARK, GSON.toJson(watermark));
         workUnit.setProp(PACKING_START_TIME_MILLIS, this.packingStartTimeMillis);


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1337


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Current implementation does not call build() on the KafkaPartition.Builder before calling toString().

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Trivial change.

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

