### PR TITLE
[GOBBLIN-1338] Log and suppress exceptions in FsDataWriter.getFinalState

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/writer/FsDataWriter.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/writer/FsDataWriter.java
@@ -318,12 +318,20 @@ public abstract class FsDataWriter<D> implements DataWriter<D>, FinalState, Meta
   public State getFinalState() {
     State state = new State();
 
-    state.setProp("RecordsWritten", recordsWritten());
+    try {
+      state.setProp("RecordsWritten", recordsWritten());
+    } catch (Exception exception) {
+      // If Writer fails to return recordsWritten, it might not be implemented, or implemented incorrectly.
+      // Omit property instead of failing.
+      LOG.warn("Failed to get final state recordsWritten", exception);
+    }
+
     try {
       state.setProp("BytesWritten", bytesWritten());
     } catch (Exception exception) {
       // If Writer fails to return bytesWritten, it might not be implemented, or implemented incorrectly.
       // Omit property instead of failing.
+      LOG.warn("Failed to get final state bytesWritten", exception);
     }
 
     return state;

--- a/gobblin-core/src/main/java/org/apache/gobblin/writer/PartitionedDataWriter.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/writer/PartitionedDataWriter.java
@@ -355,7 +355,7 @@ public class PartitionedDataWriter<S, D> extends WriterWrapper<D> implements Fin
       state.setProp("RecordsWritten", recordsWritten());
       state.setProp("BytesWritten", bytesWritten());
     } catch (Exception exception) {
-      log.warn("Failed to get final state." + exception.getMessage());
+      log.warn("Failed to get final state.", exception);
       // If Writer fails to return bytesWritten, it might not be implemented, or implemented incorrectly.
       // Omit property instead of failing.
     }

--- a/gobblin-core/src/test/java/org/apache/gobblin/writer/FsDataWriterTest.java
+++ b/gobblin-core/src/test/java/org/apache/gobblin/writer/FsDataWriterTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.writer;
+
+import java.io.IOException;
+import org.apache.gobblin.configuration.State;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+/**
+ * Test {@link FsDataWriter}
+ */
+public class FsDataWriterTest {
+
+  @Test
+  public void testExceptionOnGetRecordsWritten() throws IOException {
+    FsDataWriter writer = Mockito.mock(FsDataWriter.class);
+    final long BYTES_WRITTEN = 1000;
+
+    Mockito.when(writer.getFinalState()).thenCallRealMethod();
+    Mockito.when(writer.recordsWritten()).thenThrow(new RuntimeException("Test exception"));
+    Mockito.when(writer.bytesWritten()).thenReturn(BYTES_WRITTEN);
+
+
+    State finalState = writer.getFinalState();
+
+    Assert.assertNull(finalState.getProp("RecordsWritten"));
+    Assert.assertEquals(finalState.getPropAsLong("BytesWritten"), BYTES_WRITTEN);
+  }
+
+  @Test
+  public void testExceptionOnGetBytesWritten() throws IOException {
+    FsDataWriter writer = Mockito.mock(FsDataWriter.class);
+    final long RECORDS_WRITTEN = 1000;
+
+    Mockito.when(writer.getFinalState()).thenCallRealMethod();
+    Mockito.when(writer.bytesWritten()).thenThrow(new RuntimeException("Test exception"));
+    Mockito.when(writer.recordsWritten()).thenReturn(RECORDS_WRITTEN);
+
+
+    State finalState = writer.getFinalState();
+
+    Assert.assertNull(finalState.getProp("BytesWritten"));
+    Assert.assertEquals(finalState.getPropAsLong("RecordsWritten"), RECORDS_WRITTEN);
+  }
+}


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1338


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
FsDataWriter#getFinalState() sometimes encounters an exception when calling recordsWritten(). This can cause other final state values to not be set.

The exception should be suppressed like is already the case for when bytesWritten() is called in this method.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

