### PR TITLE
[GOBBLIN-1339] Add cluster name to dataset descriptor

### DIFF
--- a/gobblin-api/src/test/java/org/apache/gobblin/dataset/DescriptorTest.java
+++ b/gobblin-api/src/test/java/org/apache/gobblin/dataset/DescriptorTest.java
@@ -27,6 +27,7 @@ public class DescriptorTest {
   public void testDatasetDescriptor() {
     DatasetDescriptor dataset = new DatasetDescriptor("hdfs", "/data/tracking/PageViewEvent");
     dataset.addMetadata("fsUri", "hdfs://test.com:2018");
+    Assert.assertNull(dataset.getClusterName());
 
     DatasetDescriptor copy = dataset.copy();
     Assert.assertEquals(copy.getName(), dataset.getName());
@@ -34,6 +35,28 @@ public class DescriptorTest {
     Assert.assertEquals(copy.getMetadata(), dataset.getMetadata());
     Assert.assertEquals(dataset, copy);
     Assert.assertEquals(dataset.hashCode(), copy.hashCode());
+
+    //noinspection deprecation
+    Assert.assertEquals(dataset, DatasetDescriptor.fromDataMap(copy.toDataMap()));
+  }
+
+  @Test
+  public void testDatasetDescriptorWithCluster() {
+    DatasetDescriptor dataset = new DatasetDescriptor("hdfs","hadoop.test", "/data/tracking/PageViewEvent");
+    dataset.addMetadata("fsUri", "hdfs://test.com:2018");
+
+    Assert.assertEquals(dataset.getClusterName(),"hadoop.test");
+
+    DatasetDescriptor copy = dataset.copy();
+    Assert.assertEquals(copy.getName(), dataset.getName());
+    Assert.assertEquals(copy.getPlatform(), dataset.getPlatform());
+    Assert.assertEquals(copy.getMetadata(), dataset.getMetadata());
+    Assert.assertEquals(copy.getClusterName(), dataset.getClusterName());
+    Assert.assertEquals(dataset, copy);
+    Assert.assertEquals(dataset.hashCode(), copy.hashCode());
+
+    //noinspection deprecation
+    Assert.assertEquals(dataset, DatasetDescriptor.fromDataMap(copy.toDataMap()));
   }
 
   @Test

--- a/gobblin-api/src/test/java/org/apache/gobblin/dataset/DescriptorTest.java
+++ b/gobblin-api/src/test/java/org/apache/gobblin/dataset/DescriptorTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.gobblin.dataset;
 
+import java.net.URI;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -27,7 +28,7 @@ public class DescriptorTest {
   public void testDatasetDescriptor() {
     DatasetDescriptor dataset = new DatasetDescriptor("hdfs", "/data/tracking/PageViewEvent");
     dataset.addMetadata("fsUri", "hdfs://test.com:2018");
-    Assert.assertNull(dataset.getClusterName());
+    Assert.assertNull(dataset.getStorageUrl());
 
     DatasetDescriptor copy = dataset.copy();
     Assert.assertEquals(copy.getName(), dataset.getName());
@@ -42,16 +43,17 @@ public class DescriptorTest {
 
   @Test
   public void testDatasetDescriptorWithCluster() {
-    DatasetDescriptor dataset = new DatasetDescriptor("hdfs","hadoop.test", "/data/tracking/PageViewEvent");
+    DatasetDescriptor dataset =
+        new DatasetDescriptor("hdfs", URI.create("hdfs://hadoop.test"), "/data/tracking/PageViewEvent");
     dataset.addMetadata("fsUri", "hdfs://test.com:2018");
 
-    Assert.assertEquals(dataset.getClusterName(),"hadoop.test");
+    Assert.assertEquals(dataset.getStorageUrl().toString(),"hdfs://hadoop.test");
 
     DatasetDescriptor copy = dataset.copy();
     Assert.assertEquals(copy.getName(), dataset.getName());
     Assert.assertEquals(copy.getPlatform(), dataset.getPlatform());
     Assert.assertEquals(copy.getMetadata(), dataset.getMetadata());
-    Assert.assertEquals(copy.getClusterName(), dataset.getClusterName());
+    Assert.assertEquals(copy.getStorageUrl(), dataset.getStorageUrl());
     Assert.assertEquals(dataset, copy);
     Assert.assertEquals(dataset.hashCode(), copy.hashCode());
 

--- a/gobblin-core/src/main/java/org/apache/gobblin/publisher/BaseDataPublisher.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/publisher/BaseDataPublisher.java
@@ -17,42 +17,13 @@
 
 package org.apache.gobblin.publisher;
 
-import java.io.IOException;
-import java.net.URI;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-
-import org.apache.commons.io.IOUtils;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FSDataInputStream;
-import org.apache.hadoop.fs.FSDataOutputStream;
-import org.apache.hadoop.fs.FileStatus;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.permission.FsPermission;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
+import com.google.common.collect.*;
 import com.google.common.io.Closer;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigRenderOptions;
-
+import org.apache.commons.io.IOUtils;
 import org.apache.gobblin.config.ConfigBuilder;
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.SourceState;
@@ -65,15 +36,23 @@ import org.apache.gobblin.dataset.PartitionDescriptor;
 import org.apache.gobblin.metadata.MetadataMerger;
 import org.apache.gobblin.metadata.types.StaticStringMetadataMerger;
 import org.apache.gobblin.metrics.event.lineage.LineageInfo;
-import org.apache.gobblin.util.ForkOperatorUtils;
-import org.apache.gobblin.util.HadoopUtils;
-import org.apache.gobblin.util.ParallelRunner;
-import org.apache.gobblin.util.WriterUtils;
+import org.apache.gobblin.util.*;
 import org.apache.gobblin.util.reflection.GobblinConstructorUtils;
 import org.apache.gobblin.writer.FsDataWriter;
 import org.apache.gobblin.writer.FsWriterMetrics;
 import org.apache.gobblin.writer.PartitionIdentifier;
 import org.apache.gobblin.writer.PartitionedDataWriter;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.*;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
 
 import static org.apache.gobblin.util.retry.RetryerFactory.*;
 
@@ -325,7 +304,8 @@ public class BaseDataPublisher extends SingleTaskDataPublisher {
   protected DatasetDescriptor createDestinationDescriptor(WorkUnitState state, int branchId) {
     Path publisherOutputDir = getPublisherOutputDir(state, branchId);
     FileSystem fs = this.publisherFileSystemByBranches.get(branchId);
-    DatasetDescriptor destination = new DatasetDescriptor(fs.getScheme(), publisherOutputDir.toString());
+    String clusterName = ClustersNames.getInstance().getClusterName(publisherOutputDir.toString());
+    DatasetDescriptor destination = new DatasetDescriptor(fs.getScheme(), clusterName, publisherOutputDir.toString());
     destination.addMetadata(DatasetConstants.FS_URI, fs.getUri().toString());
     destination.addMetadata(DatasetConstants.BRANCH, String.valueOf(branchId));
     return destination;

--- a/gobblin-core/src/main/java/org/apache/gobblin/publisher/BaseDataPublisher.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/publisher/BaseDataPublisher.java
@@ -18,11 +18,28 @@
 package org.apache.gobblin.publisher;
 
 import com.google.common.base.Optional;
-import com.google.common.collect.*;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.google.common.io.Closer;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigRenderOptions;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.IOUtils;
 import org.apache.gobblin.config.ConfigBuilder;
 import org.apache.gobblin.configuration.ConfigurationKeys;
@@ -36,23 +53,24 @@ import org.apache.gobblin.dataset.PartitionDescriptor;
 import org.apache.gobblin.metadata.MetadataMerger;
 import org.apache.gobblin.metadata.types.StaticStringMetadataMerger;
 import org.apache.gobblin.metrics.event.lineage.LineageInfo;
-import org.apache.gobblin.util.*;
+import org.apache.gobblin.util.ForkOperatorUtils;
+import org.apache.gobblin.util.HadoopUtils;
+import org.apache.gobblin.util.ParallelRunner;
+import org.apache.gobblin.util.WriterUtils;
 import org.apache.gobblin.util.reflection.GobblinConstructorUtils;
 import org.apache.gobblin.writer.FsDataWriter;
 import org.apache.gobblin.writer.FsWriterMetrics;
 import org.apache.gobblin.writer.PartitionIdentifier;
 import org.apache.gobblin.writer.PartitionedDataWriter;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.*;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.net.URI;
-import java.nio.charset.StandardCharsets;
-import java.util.*;
-import java.util.concurrent.TimeUnit;
 
 import static org.apache.gobblin.util.retry.RetryerFactory.*;
 
@@ -304,8 +322,7 @@ public class BaseDataPublisher extends SingleTaskDataPublisher {
   protected DatasetDescriptor createDestinationDescriptor(WorkUnitState state, int branchId) {
     Path publisherOutputDir = getPublisherOutputDir(state, branchId);
     FileSystem fs = this.publisherFileSystemByBranches.get(branchId);
-    String clusterName = ClustersNames.getInstance().getClusterName(publisherOutputDir.toString());
-    DatasetDescriptor destination = new DatasetDescriptor(fs.getScheme(), clusterName, publisherOutputDir.toString());
+    DatasetDescriptor destination = new DatasetDescriptor(fs.getScheme(), fs.getUri(), publisherOutputDir.toString());
     destination.addMetadata(DatasetConstants.FS_URI, fs.getUri().toString());
     destination.addMetadata(DatasetConstants.BRANCH, String.valueOf(branchId));
     return destination;

--- a/gobblin-core/src/main/java/org/apache/gobblin/source/PartitionedFileSourceBase.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/PartitionedFileSourceBase.java
@@ -18,6 +18,12 @@
 package org.apache.gobblin.source;
 
 import com.google.common.base.Throwables;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.SourceState;
@@ -35,7 +41,6 @@ import org.apache.gobblin.source.workunit.Extract;
 import org.apache.gobblin.source.workunit.Extract.TableType;
 import org.apache.gobblin.source.workunit.MultiWorkUnitWeightedQueue;
 import org.apache.gobblin.source.workunit.WorkUnit;
-import org.apache.gobblin.util.ClustersNames;
 import org.apache.gobblin.util.DatePartitionType;
 import org.apache.gobblin.writer.partitioner.TimeBasedAvroWriterPartitioner;
 import org.apache.hadoop.fs.FileSystem;
@@ -45,12 +50,6 @@ import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 
 /**
@@ -244,8 +243,9 @@ public abstract class PartitionedFileSourceBase<SCHEMA, DATA> extends FileBasedS
     String platform = state.getProp(ConfigurationKeys.SOURCE_FILEBASED_PLATFORM, DatasetConstants.PLATFORM_HDFS);
     Path dataDir = new Path(state.getProp(ConfigurationKeys.SOURCE_FILEBASED_DATA_DIRECTORY));
     String dataset = Path.getPathWithoutSchemeAndAuthority(dataDir).toString();
-    String clusterName = ClustersNames.getInstance().getClusterName(dataDir.toString());
-    DatasetDescriptor datasetDescriptor = new DatasetDescriptor(platform, clusterName, dataset);
+    URI fileSystemUrl =
+        URI.create(state.getProp(ConfigurationKeys.SOURCE_FILEBASED_FS_URI, ConfigurationKeys.LOCAL_FS_URI));
+    DatasetDescriptor datasetDescriptor = new DatasetDescriptor(platform, fileSystemUrl, dataset);
 
     String partitionName = workUnit.getProp(ConfigurationKeys.WORK_UNIT_DATE_PARTITION_NAME);
     PartitionDescriptor descriptor = new PartitionDescriptor(partitionName, datasetDescriptor);

--- a/gobblin-core/src/main/java/org/apache/gobblin/source/PartitionedFileSourceBase.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/PartitionedFileSourceBase.java
@@ -17,24 +17,8 @@
 
 package org.apache.gobblin.source;
 
-import java.io.IOException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
-import org.joda.time.Duration;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.google.common.base.Throwables;
-
 import lombok.extern.slf4j.Slf4j;
-
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.SourceState;
 import org.apache.gobblin.configuration.State;
@@ -51,8 +35,22 @@ import org.apache.gobblin.source.workunit.Extract;
 import org.apache.gobblin.source.workunit.Extract.TableType;
 import org.apache.gobblin.source.workunit.MultiWorkUnitWeightedQueue;
 import org.apache.gobblin.source.workunit.WorkUnit;
+import org.apache.gobblin.util.ClustersNames;
 import org.apache.gobblin.util.DatePartitionType;
 import org.apache.gobblin.writer.partitioner.TimeBasedAvroWriterPartitioner;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.joda.time.Duration;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 
 /**
@@ -246,7 +244,8 @@ public abstract class PartitionedFileSourceBase<SCHEMA, DATA> extends FileBasedS
     String platform = state.getProp(ConfigurationKeys.SOURCE_FILEBASED_PLATFORM, DatasetConstants.PLATFORM_HDFS);
     Path dataDir = new Path(state.getProp(ConfigurationKeys.SOURCE_FILEBASED_DATA_DIRECTORY));
     String dataset = Path.getPathWithoutSchemeAndAuthority(dataDir).toString();
-    DatasetDescriptor datasetDescriptor = new DatasetDescriptor(platform, dataset);
+    String clusterName = ClustersNames.getInstance().getClusterName(dataDir.toString());
+    DatasetDescriptor datasetDescriptor = new DatasetDescriptor(platform, clusterName, dataset);
 
     String partitionName = workUnit.getProp(ConfigurationKeys.WORK_UNIT_DATE_PARTITION_NAME);
     PartitionDescriptor descriptor = new PartitionDescriptor(partitionName, datasetDescriptor);

--- a/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/filebased/FileBasedSource.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/filebased/FileBasedSource.java
@@ -17,28 +17,12 @@
 
 package org.apache.gobblin.source.extractor.filebased;
 
-import java.io.File;
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
-
-import org.apache.commons.lang3.StringUtils;
-import org.apache.hadoop.fs.Path;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
-
 import com.google.common.base.Optional;
 import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-
+import org.apache.commons.lang3.StringUtils;
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.SourceState;
 import org.apache.gobblin.configuration.State;
@@ -51,6 +35,20 @@ import org.apache.gobblin.source.workunit.Extract;
 import org.apache.gobblin.source.workunit.Extract.TableType;
 import org.apache.gobblin.source.workunit.MultiWorkUnit;
 import org.apache.gobblin.source.workunit.WorkUnit;
+import org.apache.gobblin.util.ClustersNames;
+import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 
 
 /**
@@ -251,7 +249,8 @@ public abstract class FileBasedSource<S, D> extends AbstractSource<S, D> {
     String platform = state.getProp(ConfigurationKeys.SOURCE_FILEBASED_PLATFORM, DatasetConstants.PLATFORM_HDFS);
     Path dataDir = new Path(state.getProp(ConfigurationKeys.SOURCE_FILEBASED_DATA_DIRECTORY));
     String dataset = Path.getPathWithoutSchemeAndAuthority(dataDir).toString();
-    DatasetDescriptor source = new DatasetDescriptor(platform, dataset);
+    String clusterName = ClustersNames.getInstance().getClusterName(dataDir.toString());
+    DatasetDescriptor source = new DatasetDescriptor(platform, clusterName, dataset);
     lineageInfo.get().setSource(source, workUnit);
   }
 

--- a/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/filebased/FileBasedSource.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/source/extractor/filebased/FileBasedSource.java
@@ -22,6 +22,14 @@ import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.SourceState;
@@ -35,20 +43,10 @@ import org.apache.gobblin.source.workunit.Extract;
 import org.apache.gobblin.source.workunit.Extract.TableType;
 import org.apache.gobblin.source.workunit.MultiWorkUnit;
 import org.apache.gobblin.source.workunit.WorkUnit;
-import org.apache.gobblin.util.ClustersNames;
 import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
-
-import java.io.File;
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
 
 
 /**
@@ -249,8 +247,9 @@ public abstract class FileBasedSource<S, D> extends AbstractSource<S, D> {
     String platform = state.getProp(ConfigurationKeys.SOURCE_FILEBASED_PLATFORM, DatasetConstants.PLATFORM_HDFS);
     Path dataDir = new Path(state.getProp(ConfigurationKeys.SOURCE_FILEBASED_DATA_DIRECTORY));
     String dataset = Path.getPathWithoutSchemeAndAuthority(dataDir).toString();
-    String clusterName = ClustersNames.getInstance().getClusterName(dataDir.toString());
-    DatasetDescriptor source = new DatasetDescriptor(platform, clusterName, dataset);
+    URI fileSystemUrl =
+        URI.create(state.getProp(ConfigurationKeys.SOURCE_FILEBASED_FS_URI, ConfigurationKeys.LOCAL_FS_URI));
+    DatasetDescriptor source = new DatasetDescriptor(platform, fileSystemUrl, dataset);
     lineageInfo.get().setSource(source, workUnit);
   }
 

--- a/gobblin-core/src/main/java/org/apache/gobblin/writer/FsDataWriter.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/writer/FsDataWriter.java
@@ -22,6 +22,9 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.io.Closer;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.List;
 import org.apache.gobblin.codec.StreamCodec;
 import org.apache.gobblin.commit.SpeculativeAttemptAwareConstruct;
 import org.apache.gobblin.configuration.ConfigurationKeys;
@@ -30,7 +33,11 @@ import org.apache.gobblin.dataset.DatasetDescriptor;
 import org.apache.gobblin.dataset.Descriptor;
 import org.apache.gobblin.dataset.PartitionDescriptor;
 import org.apache.gobblin.metadata.types.GlobalMetadata;
-import org.apache.gobblin.util.*;
+import org.apache.gobblin.util.FinalState;
+import org.apache.gobblin.util.ForkOperatorUtils;
+import org.apache.gobblin.util.HadoopUtils;
+import org.apache.gobblin.util.JobConfigurationUtils;
+import org.apache.gobblin.util.WriterUtils;
 import org.apache.gobblin.util.recordcount.IngestionRecordCountProvider;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileContext;
@@ -40,10 +47,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.io.OutputStream;
-import java.util.List;
 
 
 /**
@@ -161,9 +164,8 @@ public abstract class FsDataWriter<D> implements DataWriter<D>, FinalState, Meta
   public Descriptor getDataDescriptor() {
     // Dataset is resulted from WriterUtils.getWriterOutputDir(properties, this.numBranches, this.branchId)
     // The writer dataset might not be same as the published dataset
-    String clusterName = ClustersNames.getInstance().getClusterName(outputFile.getParent().toString());
-    DatasetDescriptor datasetDescriptor = new DatasetDescriptor(fs.getScheme(), clusterName,
-            outputFile.getParent().toString());
+    DatasetDescriptor datasetDescriptor =
+        new DatasetDescriptor(fs.getScheme(), fs.getUri(), outputFile.getParent().toString());
 
     if (partitionKey == null) {
       return datasetDescriptor;

--- a/gobblin-core/src/test/java/org/apache/gobblin/publisher/BaseDataPublisherTest.java
+++ b/gobblin-core/src/test/java/org/apache/gobblin/publisher/BaseDataPublisherTest.java
@@ -16,12 +16,19 @@
  */
 package org.apache.gobblin.publisher;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.Files;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+import com.typesafe.config.ConfigFactory;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Type;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -31,19 +38,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
-
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.testng.Assert;
-import org.testng.annotations.Test;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.io.Files;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.reflect.TypeToken;
-import com.typesafe.config.ConfigFactory;
-
 import org.apache.gobblin.broker.SharedResourcesBrokerFactory;
 import org.apache.gobblin.broker.gobblin_scopes.GobblinScopeTypes;
 import org.apache.gobblin.broker.gobblin_scopes.JobScopeInstance;
@@ -65,6 +61,8 @@ import org.apache.gobblin.util.io.GsonInterfaceAdapter;
 import org.apache.gobblin.writer.FsDataWriter;
 import org.apache.gobblin.writer.FsWriterMetrics;
 import org.apache.gobblin.writer.PartitionIdentifier;
+import org.testng.Assert;
+import org.testng.annotations.Test;
 
 
 /**
@@ -615,7 +613,7 @@ public class BaseDataPublisherTest {
     // Find the partition lineage and assert
     for (int i = 0; i < numBranches; i++) {
       String outputPath = String.format("/data/output/branch%d/namespace/table", i);
-      DatasetDescriptor destinationDataset = new DatasetDescriptor("file", outputPath);
+      DatasetDescriptor destinationDataset = new DatasetDescriptor("file", URI.create("file:///"), outputPath);
       destinationDataset.addMetadata("fsUri", "file:///");
       destinationDataset.addMetadata("branch", "" + i);
 

--- a/gobblin-core/src/test/java/org/apache/gobblin/source/extractor/filebased/FileBasedSourceTest.java
+++ b/gobblin-core/src/test/java/org/apache/gobblin/source/extractor/filebased/FileBasedSourceTest.java
@@ -17,6 +17,12 @@
 
 package org.apache.gobblin.source.extractor.filebased;
 
+import com.google.common.collect.Sets;
+import com.typesafe.config.ConfigFactory;
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import java.util.Set;
 import org.apache.gobblin.broker.SharedResourcesBrokerFactory;
 import org.apache.gobblin.broker.gobblin_scopes.GobblinScopeTypes;
 import org.apache.gobblin.broker.gobblin_scopes.JobScopeInstance;
@@ -37,20 +43,12 @@ import org.apache.gobblin.source.extractor.hadoop.AvroFileSource;
 import org.apache.gobblin.source.workunit.Extract;
 import org.apache.gobblin.source.workunit.MultiWorkUnit;
 import org.apache.gobblin.source.workunit.WorkUnit;
-
 import org.apache.hadoop.fs.Path;
 import org.junit.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.testng.collections.Lists;
-
-import java.io.IOException;
-import java.util.List;
-import java.util.Set;
-
-import com.google.common.collect.Sets;
-import com.typesafe.config.ConfigFactory;
 
 
 @Test
@@ -126,7 +124,7 @@ public class FileBasedSourceTest {
     // Avro file based source
     AvroFileSource fileSource = new AvroFileSource();
     List<WorkUnit> workUnits = fileSource.getWorkunits(sourceState);
-    DatasetDescriptor datasetDescriptor = new DatasetDescriptor("hdfs", dataset);
+    DatasetDescriptor datasetDescriptor = new DatasetDescriptor("hdfs", URI.create("file:///"), dataset);
     for (WorkUnit workUnit : workUnits) {
       Assert.assertEquals(workUnit.getProp(SOURCE_LINEAGE_KEY), Descriptor.toJson(datasetDescriptor));
     }
@@ -136,7 +134,7 @@ public class FileBasedSourceTest {
     sourceState.setProp(ConfigurationKeys.SOURCE_FILEBASED_PLATFORM, DatasetConstants.PLATFORM_FILE);
     DatePartitionedJsonFileSource partitionedFileSource = new DatePartitionedJsonFileSource();
     workUnits = partitionedFileSource.getWorkunits(sourceState);
-    datasetDescriptor = new DatasetDescriptor("file", dataset);
+    datasetDescriptor = new DatasetDescriptor("file", URI.create("file:///"), dataset);
 
     Set<String> partitions = Sets.newHashSet("2017-12", "2018-01");
     for (WorkUnit workUnit : workUnits) {

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/CopyableFile.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/CopyableFile.java
@@ -19,13 +19,19 @@ package org.apache.gobblin.data.management.copy;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
-import lombok.*;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.apache.gobblin.data.management.copy.PreserveAttributes.Option;
 import org.apache.gobblin.data.management.partition.File;
 import org.apache.gobblin.dataset.DatasetConstants;
 import org.apache.gobblin.dataset.DatasetDescriptor;
 import org.apache.gobblin.dataset.Descriptor;
-import org.apache.gobblin.util.ClustersNames;
 import org.apache.gobblin.util.ConfigUtils;
 import org.apache.gobblin.util.PathUtils;
 import org.apache.gobblin.util.guid.Guid;
@@ -34,10 +40,6 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
-
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
 
 
 /**
@@ -133,15 +135,13 @@ public class CopyableFile extends CopyEntity implements File {
 
     Path fullSourcePath = Path.getPathWithoutSchemeAndAuthority(origin.getPath());
     String sourceDatasetName = isDir ? fullSourcePath.toString() : fullSourcePath.getParent().toString();
-    String sourceClusterName = ClustersNames.getInstance().getClusterName(fullSourcePath.toString());
-    DatasetDescriptor sourceDataset = new DatasetDescriptor(originFs.getScheme(), sourceClusterName, sourceDatasetName);
+    DatasetDescriptor sourceDataset = new DatasetDescriptor(originFs.getScheme(), originFs.getUri(), sourceDatasetName);
     sourceDataset.addMetadata(DatasetConstants.FS_URI, originFs.getUri().toString());
     sourceData = sourceDataset;
 
     Path fullDestinationPath = Path.getPathWithoutSchemeAndAuthority(destination);
     String destinationDatasetName = isDir ? fullDestinationPath.toString() : fullDestinationPath.getParent().toString();
-    String destinationClusterName = ClustersNames.getInstance().getClusterName(fullDestinationPath.toString());
-    DatasetDescriptor destinationDataset = new DatasetDescriptor(targetFs.getScheme(), destinationClusterName,
+    DatasetDescriptor destinationDataset = new DatasetDescriptor(targetFs.getScheme(), targetFs.getUri(),
             destinationDatasetName);
     destinationDataset.addMetadata(DatasetConstants.FS_URI, targetFs.getUri().toString());
     destinationData = destinationDataset;

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/CopyableFile.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/CopyableFile.java
@@ -17,33 +17,27 @@
 
 package org.apache.gobblin.data.management.copy;
 
-import org.apache.gobblin.data.management.partition.File;
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
+import lombok.*;
 import org.apache.gobblin.data.management.copy.PreserveAttributes.Option;
+import org.apache.gobblin.data.management.partition.File;
 import org.apache.gobblin.dataset.DatasetConstants;
 import org.apache.gobblin.dataset.DatasetDescriptor;
 import org.apache.gobblin.dataset.Descriptor;
+import org.apache.gobblin.util.ClustersNames;
 import org.apache.gobblin.util.ConfigUtils;
 import org.apache.gobblin.util.PathUtils;
 import org.apache.gobblin.util.guid.Guid;
-
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-
-import lombok.AccessLevel;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-
 import org.apache.hadoop.fs.FileChecksum;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
 
-import com.google.common.base.Optional;
-import com.google.common.collect.Lists;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 
 
 /**
@@ -139,13 +133,16 @@ public class CopyableFile extends CopyEntity implements File {
 
     Path fullSourcePath = Path.getPathWithoutSchemeAndAuthority(origin.getPath());
     String sourceDatasetName = isDir ? fullSourcePath.toString() : fullSourcePath.getParent().toString();
-    DatasetDescriptor sourceDataset = new DatasetDescriptor(originFs.getScheme(), sourceDatasetName);
+    String sourceClusterName = ClustersNames.getInstance().getClusterName(fullSourcePath.toString());
+    DatasetDescriptor sourceDataset = new DatasetDescriptor(originFs.getScheme(), sourceClusterName, sourceDatasetName);
     sourceDataset.addMetadata(DatasetConstants.FS_URI, originFs.getUri().toString());
     sourceData = sourceDataset;
 
     Path fullDestinationPath = Path.getPathWithoutSchemeAndAuthority(destination);
     String destinationDatasetName = isDir ? fullDestinationPath.toString() : fullDestinationPath.getParent().toString();
-    DatasetDescriptor destinationDataset = new DatasetDescriptor(targetFs.getScheme(), destinationDatasetName);
+    String destinationClusterName = ClustersNames.getInstance().getClusterName(fullDestinationPath.toString());
+    DatasetDescriptor destinationDataset = new DatasetDescriptor(targetFs.getScheme(), destinationClusterName,
+            destinationDatasetName);
     destinationDataset.addMetadata(DatasetConstants.FS_URI, targetFs.getUri().toString());
     destinationData = destinationDataset;
   }

--- a/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HivePartitionFileSet.java
+++ b/gobblin-data-management/src/main/java/org/apache/gobblin/data/management/copy/hive/HivePartitionFileSet.java
@@ -17,20 +17,16 @@
 
 package org.apache.gobblin.data.management.copy.hive;
 
-import java.io.IOException;
-import java.util.Collection;
-import java.util.List;
-import java.util.Properties;
-
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hive.ql.metadata.HiveException;
-import org.apache.hadoop.hive.ql.metadata.Partition;
-
 import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.io.Closer;
-
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Properties;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.gobblin.data.management.copy.CopyEntity;
 import org.apache.gobblin.data.management.copy.CopyableFile;
 import org.apache.gobblin.data.management.copy.entities.PostPublishStep;
@@ -45,9 +41,9 @@ import org.apache.gobblin.hive.spec.SimpleHiveSpec;
 import org.apache.gobblin.metrics.event.EventSubmitter;
 import org.apache.gobblin.metrics.event.MultiTimingEvent;
 import org.apache.gobblin.util.commit.DeleteFileCommitStep;
-
-import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.metadata.Partition;
 
 
 /**
@@ -124,7 +120,7 @@ public class HivePartitionFileSet extends HiveFileSet {
       HiveSpec partitionHiveSpec = new SimpleHiveSpec.Builder<>(targetPath)
           .withTable(HiveMetaStoreUtils.getHiveTable(hiveCopyEntityHelper.getTargetTable().getTTable()))
           .withPartition(Optional.of(HiveMetaStoreUtils.getHivePartition(targetPartition.getTPartition()))).build();
-      HiveRegisterStep register = new HiveRegisterStep(hiveCopyEntityHelper.getTargetURI(), partitionHiveSpec,
+      HiveRegisterStep register = new HiveRegisterStep(hiveCopyEntityHelper.getTargetMetastoreURI(), partitionHiveSpec,
           hiveCopyEntityHelper.getHiveRegProps());
       copyEntities.add(new PostPublishStep(fileSet, Maps.<String, String> newHashMap(), register, stepPriority++));
 

--- a/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/hive/HiveCopyEntityHelperTest.java
+++ b/gobblin-data-management/src/test/java/org/apache/gobblin/data/management/copy/hive/HiveCopyEntityHelperTest.java
@@ -17,6 +17,9 @@
 
 package org.apache.gobblin.data.management.copy.hive;
 
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -24,7 +27,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-
+import lombok.AllArgsConstructor;
+import org.apache.gobblin.configuration.State;
+import org.apache.gobblin.data.management.copy.CopyEntity;
+import org.apache.gobblin.data.management.copy.entities.PostPublishStep;
+import org.apache.gobblin.data.management.copy.hive.HiveCopyEntityHelper.DeregisterFileDeleteMethod;
+import org.apache.gobblin.hive.HiveRegProps;
+import org.apache.gobblin.metrics.event.MultiTimingEvent;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocalFileSystem;
@@ -36,19 +45,6 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import com.google.common.base.Optional;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-
-import lombok.AllArgsConstructor;
-
-import org.apache.gobblin.configuration.State;
-import org.apache.gobblin.data.management.copy.CopyEntity;
-import org.apache.gobblin.data.management.copy.entities.PostPublishStep;
-import org.apache.gobblin.data.management.copy.hive.HiveCopyEntityHelper.DeregisterFileDeleteMethod;
-import org.apache.gobblin.hive.HiveRegProps;
-import org.apache.gobblin.metrics.event.MultiTimingEvent;
 
 
 public class HiveCopyEntityHelperTest {
@@ -313,7 +309,7 @@ public class HiveCopyEntityHelperTest {
 
     HiveCopyEntityHelper helper = Mockito.mock(HiveCopyEntityHelper.class);
     Mockito.when(helper.getDeleteMethod()).thenReturn(DeregisterFileDeleteMethod.NO_DELETE);
-    Mockito.when(helper.getTargetURI()).thenReturn(Optional.of("/targetURI"));
+    Mockito.when(helper.getTargetMetastoreURI()).thenReturn(Optional.of("/targetURI"));
     Mockito.when(helper.getHiveRegProps()).thenReturn(new HiveRegProps(new State()));
     Mockito.when(helper.getDataset()).thenReturn(dataset);
 

--- a/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/source/extractor/extract/jdbc/MysqlSource.java
+++ b/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/source/extractor/extract/jdbc/MysqlSource.java
@@ -17,24 +17,22 @@
 
 package org.apache.gobblin.source.extractor.extract.jdbc;
 
-import org.apache.gobblin.configuration.ConfigurationKeys;
-import org.apache.gobblin.configuration.SourceState;
-import org.apache.gobblin.dataset.DatasetConstants;
-import org.apache.gobblin.dataset.DatasetDescriptor;
-import org.apache.gobblin.metrics.event.lineage.LineageInfo;
-import org.apache.gobblin.source.extractor.Extractor;
-import org.apache.gobblin.source.extractor.exception.ExtractPrepareException;
-import java.io.IOException;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
+import java.io.IOException;
+import java.net.URI;
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.configuration.SourceState;
 import org.apache.gobblin.configuration.WorkUnitState;
+import org.apache.gobblin.dataset.DatasetConstants;
+import org.apache.gobblin.dataset.DatasetDescriptor;
+import org.apache.gobblin.source.extractor.Extractor;
+import org.apache.gobblin.source.extractor.exception.ExtractPrepareException;
 import org.apache.gobblin.source.extractor.extract.QueryBasedSource;
 import org.apache.gobblin.source.jdbc.MysqlExtractor;
 import org.apache.gobblin.source.workunit.WorkUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -61,9 +59,10 @@ public class MysqlSource extends QueryBasedSource<JsonArray, JsonElement> {
     String host = sourceState.getProp(ConfigurationKeys.SOURCE_CONN_HOST_NAME);
     String port = sourceState.getProp(ConfigurationKeys.SOURCE_CONN_PORT);
     String database = sourceState.getProp(ConfigurationKeys.SOURCE_QUERYBASED_SCHEMA);
-    String connectionUrl = "jdbc:mysql://" + host.trim() + ":" + port + "/" + database.trim();
-    DatasetDescriptor source =
-        new DatasetDescriptor(DatasetConstants.PLATFORM_MYSQL, database + "." + entity.getSourceEntityName());
+    String serverUrl = "mysql://" + host.trim() + ":" + port;
+    String connectionUrl = "jdbc:" + serverUrl + "/" + database.trim();
+    DatasetDescriptor source = new DatasetDescriptor(DatasetConstants.PLATFORM_MYSQL, URI.create(serverUrl),
+        database + "." + entity.getSourceEntityName());
     source.addMetadata(DatasetConstants.CONNECTION_URL, connectionUrl);
     if (lineageInfo.isPresent()) {
       lineageInfo.get().setSource(source, workUnit);


### PR DESCRIPTION
We use dataset descriptors to track lineage. Previously, it
only included the platform name (hive,hdfs) and path of the
dataset. As a result, we could not differentiate the data copy
between multiple production clusters, as the dataset descriptors
were the same for them. We add an optional storage system url to
address that.

This change will be used for data copy audit system.

Hive and file-based copy code is updated to include storage urls.

