### PR TITLE
[GOBBLIN-1342] Add API to resume a flow

### DIFF
--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/TimingEvent.java
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/org/apache/gobblin/metrics/event/TimingEvent.java
@@ -40,6 +40,7 @@ public class TimingEvent extends GobblinEventBuilder implements Closeable {
     public static final String WORK_UNITS_CREATION = "WorkUnitsCreationTimer";
     public static final String WORK_UNITS_PREPARATION = "WorkUnitsPreparationTimer";
     public static final String JOB_PENDING = "JobPending";
+    public static final String JOB_PENDING_RESUME = "JobPendingResume";
     public static final String JOB_ORCHESTRATED = "JobOrchestrated";
     public static final String JOB_PREPARE = "JobPrepareTimer";
     public static final String JOB_START = "JobStartTimer";
@@ -71,6 +72,7 @@ public class TimingEvent extends GobblinEventBuilder implements Closeable {
     public static final String FLOW_FAILED = "FlowFailed";
     public static final String FLOW_RUNNING = "FlowRunning";
     public static final String FLOW_CANCELLED = "FlowCancelled";
+    public static final String FLOW_PENDING_RESUME = "FlowPendingResume";
   }
 
   public static class FlowEventConstants {

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-api/src/main/idl/org.apache.gobblin.service.flowexecutions.restspec.json
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-api/src/main/idl/org.apache.gobblin.service.flowexecutions.restspec.json
@@ -10,10 +10,13 @@
       "type" : "org.apache.gobblin.service.FlowStatusId",
       "params" : "com.linkedin.restli.common.EmptyRecord"
     },
-    "supports" : [ "delete", "get" ],
+    "supports" : [ "delete", "get", "partial_update" ],
     "methods" : [ {
       "method" : "get",
       "doc" : "Retrieve the FlowExecution with the given key"
+    }, {
+      "method" : "partial_update",
+      "doc" : "Resume a failed {@link FlowExecution} from the point before failure. This is specified by a partial update patch which\n sets executionStatus to RUNNING."
     }, {
       "method" : "delete",
       "doc" : "Kill the FlowExecution with the given key"

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-api/src/main/pegasus/org/apache/gobblin/service/ExecutionStatus.pdl
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-api/src/main/pegasus/org/apache/gobblin/service/ExecutionStatus.pdl
@@ -21,6 +21,11 @@ enum ExecutionStatus {
   PENDING_RETRY
 
   /**
+   * Flow or job is currently resuming.
+   */
+  PENDING_RESUME
+
+  /**
    * Job(s) orchestrated to spec executors.
    */
   ORCHESTRATED

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-api/src/main/snapshot/org.apache.gobblin.service.flowexecutions.snapshot.json
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-api/src/main/snapshot/org.apache.gobblin.service.flowexecutions.snapshot.json
@@ -13,7 +13,7 @@
     "name" : "ExecutionStatus",
     "namespace" : "org.apache.gobblin.service",
     "doc" : "Execution status for a flow or job",
-    "symbols" : [ "COMPILED", "PENDING", "PENDING_RETRY", "ORCHESTRATED", "RUNNING", "COMPLETE", "FAILED", "CANCELLED" ],
+    "symbols" : [ "COMPILED", "PENDING", "PENDING_RETRY", "PENDING_RESUME", "ORCHESTRATED", "RUNNING", "COMPLETE", "FAILED", "CANCELLED" ],
     "symbolDocs" : {
       "CANCELLED" : "Flow cancelled.",
       "COMPILED" : "Flow compiled to jobs.",
@@ -21,6 +21,7 @@
       "FAILED" : "Flow or job failed",
       "ORCHESTRATED" : "Job(s) orchestrated to spec executors.",
       "PENDING" : "Flow or job is in pending state.",
+      "PENDING_RESUME" : "Flow or job is currently resuming.",
       "PENDING_RETRY" : "Flow or job is pending retry.",
       "RUNNING" : "Flow or job is currently executing"
     }
@@ -215,10 +216,13 @@
         "type" : "org.apache.gobblin.service.FlowStatusId",
         "params" : "com.linkedin.restli.common.EmptyRecord"
       },
-      "supports" : [ "delete", "get" ],
+      "supports" : [ "delete", "get", "partial_update" ],
       "methods" : [ {
         "method" : "get",
         "doc" : "Retrieve the FlowExecution with the given key"
+      }, {
+        "method" : "partial_update",
+        "doc" : "Resume a failed {@link FlowExecution} from the point before failure. This is specified by a partial update patch which\n sets executionStatus to RUNNING."
       }, {
         "method" : "delete",
         "doc" : "Kill the FlowExecution with the given key"

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-api/src/main/snapshot/org.apache.gobblin.service.flowstatuses.snapshot.json
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-api/src/main/snapshot/org.apache.gobblin.service.flowstatuses.snapshot.json
@@ -13,7 +13,7 @@
     "name" : "ExecutionStatus",
     "namespace" : "org.apache.gobblin.service",
     "doc" : "Execution status for a flow or job",
-    "symbols" : [ "COMPILED", "PENDING", "PENDING_RETRY", "ORCHESTRATED", "RUNNING", "COMPLETE", "FAILED", "CANCELLED" ],
+    "symbols" : [ "COMPILED", "PENDING", "PENDING_RETRY", "PENDING_RESUME", "ORCHESTRATED", "RUNNING", "COMPLETE", "FAILED", "CANCELLED" ],
     "symbolDocs" : {
       "CANCELLED" : "Flow cancelled.",
       "COMPILED" : "Flow compiled to jobs.",
@@ -21,6 +21,7 @@
       "FAILED" : "Flow or job failed",
       "ORCHESTRATED" : "Job(s) orchestrated to spec executors.",
       "PENDING" : "Flow or job is in pending state.",
+      "PENDING_RESUME" : "Flow or job is currently resuming.",
       "PENDING_RETRY" : "Flow or job is pending retry.",
       "RUNNING" : "Flow or job is currently executing"
     }

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowExecutionResourceHandler.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowExecutionResourceHandler.java
@@ -46,6 +46,11 @@ public interface FlowExecutionResourceHandler {
   public List<FlowExecution> getLatestFlowExecution(PagingContext context, FlowId flowId, Integer count, String tag, String executionStatus);
 
   /**
+   * Resume a failed {@link FlowExecution} from the point before failure
+   */
+  public UpdateResponse resume(ComplexResourceKey<FlowStatusId, EmptyRecord> key);
+
+  /**
    * Kill a running {@link FlowExecution}
    */
   public UpdateResponse delete(ComplexResourceKey<FlowStatusId, EmptyRecord> key);

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowExecutionResourceLocalHandler.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowExecutionResourceLocalHandler.java
@@ -15,39 +15,26 @@
  * limitations under the License.
  */
 package org.apache.gobblin.service;
+
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
-
-import org.apache.commons.lang3.StringEscapeUtils;
 
 import com.google.common.base.Strings;
 import com.linkedin.data.template.SetMode;
-import com.linkedin.data.template.StringMap;
 import com.linkedin.restli.common.ComplexResourceKey;
 import com.linkedin.restli.common.EmptyRecord;
 import com.linkedin.restli.common.HttpStatus;
-import com.linkedin.restli.common.PatchRequest;
-import com.linkedin.restli.server.CreateKVResponse;
 import com.linkedin.restli.server.PagingContext;
 import com.linkedin.restli.server.RestLiServiceException;
 import com.linkedin.restli.server.UpdateResponse;
-import com.linkedin.restli.server.annotations.Context;
-import com.linkedin.restli.server.annotations.Optional;
-import com.linkedin.restli.server.annotations.QueryParam;
 
 import lombok.extern.slf4j.Slf4j;
 
-import org.apache.gobblin.configuration.ConfigurationKeys;
-import org.apache.gobblin.runtime.api.FlowSpec;
-import org.apache.gobblin.runtime.spec_catalog.AddSpecResponse;
-import org.apache.gobblin.runtime.spec_catalog.FlowCatalog;
 import org.apache.gobblin.service.monitoring.FlowStatus;
 import org.apache.gobblin.service.monitoring.FlowStatusGenerator;
 import org.apache.gobblin.service.monitoring.JobStatusRetriever;
-import org.apache.gobblin.service.monitoring.KillFlowEvent;
 
 
 @Slf4j
@@ -79,6 +66,11 @@ public class FlowExecutionResourceLocalHandler implements FlowExecutionResourceH
 
     throw new RestLiServiceException(HttpStatus.S_404_NOT_FOUND, "No flow execution found for flowId " + flowId
         + ". The flowId may be incorrect, or the flow execution may have been cleaned up.");
+  }
+
+  @Override
+  public UpdateResponse resume(ComplexResourceKey<FlowStatusId, EmptyRecord> key) {
+    throw new UnsupportedOperationException("Resume should be handled in GobblinServiceFlowConfigResourceHandler");
   }
 
   @Override

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/ResumeFlowEvent.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/ResumeFlowEvent.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.service.monitoring;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+
+@AllArgsConstructor
+@Data
+public class ResumeFlowEvent {
+  private String flowGroup;
+  private String flowName;
+  private Long flowExecutionId;
+}

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagerUtils.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManagerUtils.java
@@ -185,7 +185,8 @@ public class DagManagerUtils {
       DagNode<JobExecutionPlan> node = nodesToExpand.poll();
       ExecutionStatus executionStatus = getExecutionStatus(node);
       boolean addFlag = true;
-      if (executionStatus == ExecutionStatus.PENDING || executionStatus == ExecutionStatus.PENDING_RETRY) {
+      if (executionStatus == ExecutionStatus.PENDING || executionStatus == ExecutionStatus.PENDING_RETRY
+          || executionStatus == ExecutionStatus.PENDING_RESUME) {
         //Add a node to be executed next, only if all of its parent nodes are COMPLETE.
         List<DagNode<JobExecutionPlan>> parentNodes = dag.getParents(node);
         for (DagNode<JobExecutionPlan> parentNode : parentNodes) {
@@ -243,12 +244,14 @@ public class DagManagerUtils {
   }
 
   /**
-   * flow start time is assumed to be same the flow execution id which is timestamp flow request was received
+   * Flow start time is the same as the flow execution id which is the timestamp flow request was received, unless it
+   * is a resumed flow, in which case it is {@link JobExecutionPlan#getFlowStartTime()}
    * @param dagNode dag node in context
-   * @return flow execution id
+   * @return flow start time
    */
   static long getFlowStartTime(DagNode<JobExecutionPlan> dagNode) {
-    return getFlowExecId(dagNode);
+    long flowStartTime = dagNode.getValue().getFlowStartTime();
+    return flowStartTime == 0L ? getFlowExecId(dagNode) : flowStartTime;
   }
 
   /**

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/Orchestrator.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/Orchestrator.java
@@ -302,7 +302,7 @@ public class Orchestrator implements SpecCatalogListener, Instrumentable {
 
       if (this.dagManager.isPresent()) {
         //Send the dag to the DagManager.
-        this.dagManager.get().addDag(jobExecutionPlanDag, true);
+        this.dagManager.get().addDag(jobExecutionPlanDag, true, true);
       } else {
         // Schedule all compiled JobSpecs on their respective Executor
         for (Dag.DagNode<JobExecutionPlan> dagNode : jobExecutionPlanDag.getNodes()) {

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/spec/JobExecutionPlan.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/spec/JobExecutionPlan.java
@@ -57,7 +57,7 @@ import static org.apache.gobblin.runtime.AbstractJobLauncher.GOBBLIN_JOB_TEMPLAT
  * where the {@link JobSpec} will be executed.
  */
 @Data
-@EqualsAndHashCode(exclude = {"executionStatus", "currentAttempts", "jobFuture"})
+@EqualsAndHashCode(exclude = {"executionStatus", "currentAttempts", "jobFuture", "flowStartTime"})
 public class JobExecutionPlan {
   public static final String JOB_MAX_ATTEMPTS = "job.maxAttempts";
 
@@ -67,6 +67,7 @@ public class JobExecutionPlan {
   private final int maxAttempts;
   private int currentAttempts = 0;
   private Optional<Future> jobFuture = Optional.absent();
+  private long flowStartTime = 0L;
 
   public static class Factory {
     public static final String JOB_NAME_COMPONENT_SEPARATION_CHAR = "_";

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/spec/JobExecutionPlanListDeserializer.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/spec/JobExecutionPlanListDeserializer.java
@@ -111,6 +111,11 @@ public class JobExecutionPlanListDeserializer implements JsonDeserializer<List<J
       JobExecutionPlan jobExecutionPlan = new JobExecutionPlan(jobSpec, specExecutor);
       jobExecutionPlan.setExecutionStatus(executionStatus);
 
+      JsonElement flowStartTime = serializedJobExecutionPlan.get(SerializationConstants.FLOW_START_TIME_KEY);
+      if (flowStartTime != null) {
+        jobExecutionPlan.setFlowStartTime(flowStartTime.getAsLong());
+      }
+
       try {
         String jobExecutionFuture = serializedJobExecutionPlan.get(SerializationConstants.JOB_EXECUTION_FUTURE).getAsString();
         Future future = specExecutor.getProducer().get().deserializeAddSpecResponse(jobExecutionFuture);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/spec/JobExecutionPlanListSerializer.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/spec/JobExecutionPlanListSerializer.java
@@ -83,6 +83,8 @@ public class JobExecutionPlanListSerializer implements JsonSerializer<List<JobEx
       String executionStatus = jobExecutionPlan.getExecutionStatus().name();
       jobExecutionPlanJson.addProperty(SerializationConstants.EXECUTION_STATUS_KEY, executionStatus);
 
+      jobExecutionPlanJson.addProperty(SerializationConstants.FLOW_START_TIME_KEY, jobExecutionPlan.getFlowStartTime());
+
       try {
         String jobExecutionFuture = jobExecutionPlan.getSpecExecutor().getProducer().get()
             .serializeAddSpecResponse(jobExecutionPlan.getJobFuture().orNull());

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/spec/SerializationConstants.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/spec/SerializationConstants.java
@@ -32,4 +32,5 @@ public class SerializationConstants {
 
   public static final String EXECUTION_STATUS_KEY = "executionStatus";
   public static final String JOB_EXECUTION_FUTURE = "jobExecutionFuture";
+  public static final String FLOW_START_TIME_KEY = "flowStartTime";
 }

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaAvroJobStatusMonitor.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/monitoring/KafkaAvroJobStatusMonitor.java
@@ -126,6 +126,10 @@ public class KafkaAvroJobStatusMonitor extends KafkaJobStatusMonitor {
       case TimingEvent.LauncherTimings.JOB_PENDING:
         properties.put(JobStatusRetriever.EVENT_NAME_FIELD, ExecutionStatus.PENDING.name());
         break;
+      case TimingEvent.FlowTimings.FLOW_PENDING_RESUME:
+      case TimingEvent.LauncherTimings.JOB_PENDING_RESUME:
+        properties.put(JobStatusRetriever.EVENT_NAME_FIELD, ExecutionStatus.PENDING_RESUME.name());
+        break;
       case TimingEvent.LauncherTimings.JOB_ORCHESTRATED:
         properties.put(JobStatusRetriever.EVENT_NAME_FIELD, ExecutionStatus.ORCHESTRATED.name());
         properties.put(TimingEvent.JOB_ORCHESTRATED_TIME, properties.getProperty(TimingEvent.METADATA_END_TIME));

--- a/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagerFlowTest.java
+++ b/gobblin-service/src/test/java/org/apache/gobblin/service/modules/orchestration/DagManagerFlowTest.java
@@ -94,9 +94,9 @@ public class DagManagerFlowTest {
         .thenReturn(Collections.singletonList(flowExecutionId3));
 
     // mock add spec
-    dagManager.addDag(dag1, true);
-    dagManager.addDag(dag2, true);
-    dagManager.addDag(dag3, true);
+    dagManager.addDag(dag1, true, true);
+    dagManager.addDag(dag2, true, true);
+    dagManager.addDag(dag3, true, true);
 
     // check existence of dag in dagToJobs map
     AssertWithBackoff.create().maxSleepMs(5000).backoffFactor(1).
@@ -152,7 +152,7 @@ public class DagManagerFlowTest {
         .thenReturn(Collections.singletonList(flowExecutionId));
 
     // mock add spec
-    dagManager.addDag(dag, true);
+    dagManager.addDag(dag, true, true);
 
     // check existence of dag in dagToJobs map
     AssertWithBackoff.create().maxSleepMs(5000).backoffFactor(1).
@@ -196,7 +196,7 @@ public class DagManagerFlowTest {
     dag.getStartNodes().get(0).getValue().getJobSpec().setConfig(jobConfig);
 
     // mock add spec
-    dagManager.addDag(dag, true);
+    dagManager.addDag(dag, true, true);
 
     // check existence of dag in dagToSLA map
     AssertWithBackoff.create().maxSleepMs(5000).backoffFactor(1).
@@ -233,7 +233,7 @@ public class DagManagerFlowTest {
     dag.getStartNodes().get(0).getValue().getJobSpec().setConfig(jobConfig);
 
     // mock add spec
-    dagManager.addDag(dag, true);
+    dagManager.addDag(dag, true, true);
 
     // check existence of dag in dagToSLA map
     AssertWithBackoff.create().maxSleepMs(5000).backoffFactor(1).


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1342


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

This PR adds flow resume functionality, which means after a flow fails, resume can be called on it, and the flow will be reattempted from the point before it failed (i.e. not rerunning the successful jobs).

How it works:
- Whenever a flow fails, on cleanup, it is now added to a `failedDagStateStore`, similar to the normal dag state store. (It is also kept in an in-memory `failedDags` map to avoid querying the store for every resume request).
- User triggers a resume request by calling partial update on the FlowExecutions endpoint, updating the status from `FAILED` to `RUNNING`. This is a little confusing, but as per [this discussion](https://softwareengineering.stackexchange.com/questions/261552/which-http-verb-should-i-use-to-trigger-an-action-in-a-rest-web-service) it seems to be the most correct way to represent a triggered action like this in rest.
- The request is forwarded to the `DagManager` as a `ResumeFlowEvent` through the eventbus, similar to how killing a flow works.
- `DagManager` adds it to a `resumeQueue` to be picked up by a thread
- The thread calls `beginResumingDag` on the dag, which sets the status of both the flow and each FAILED/CANCELLED job to `PENDING_RESUME` (and also sends events so this will be updated in the status store). The dag is then added to another map `resumingDags`
- In `finishResumingDags`, the dags in `resumingDags` are checked by querying the status store. If the dag has reached the correct state, then it is passed back to `initialize` to be launched. This is separated from `beginResumingDag` because it takes some time for the status to be updated in the status store.

Other related changes:
- Fixed a bug where `addDag` sets all jobs to `PENDING`, even if the dag is already running. This would cause their initial jobs to get relaunched on service restart.
- Added a `flowStartTime` variable in `JobExecutionPlan` which is set on flow resume so that flow SLA will not be calculated based on the original flow.
- Added `PENDING_RESUME` to execution status enum, it is a special status required because resuming flows are allowed to move "backwards" in status from `FAILED` to `PENDING`.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Add unit test

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

