### PR TITLE
[GOBBLIN-1344] Enable configurable schema source db and table when registering hive schema

### DIFF
--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/metastore/HiveMetaStoreBasedRegister.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/metastore/HiveMetaStoreBasedRegister.java
@@ -94,7 +94,6 @@ public class HiveMetaStoreBasedRegister extends HiveRegister {
   public static final String HIVE_REGISTER_METRICS_PREFIX = "hiveRegister.";
   public static final String ADD_PARTITION_TIMER = HIVE_REGISTER_METRICS_PREFIX + "addPartitionTimerTimer";
   public static final String SCHEMA_SOURCE_DB = HIVE_REGISTER_METRICS_PREFIX + "schema.source.dbName";
-  public static final String SCHEMA_SOURCE_TABLE = HIVE_REGISTER_METRICS_PREFIX + "schema.source.tableName";
   public static final String GET_HIVE_PARTITION = HIVE_REGISTER_METRICS_PREFIX + "getPartitionTimer";
   public static final String ALTER_PARTITION = HIVE_REGISTER_METRICS_PREFIX + "alterPartitionTimer";
   public static final String TABLE_EXISTS = HIVE_REGISTER_METRICS_PREFIX + "tableExistsTimer";
@@ -103,6 +102,7 @@ public class HiveMetaStoreBasedRegister extends HiveRegister {
   public static final String CREATE_HIVE_DATABASE = HIVE_REGISTER_METRICS_PREFIX + "createDatabaseTimer";
   public static final String CREATE_HIVE_TABLE = HIVE_REGISTER_METRICS_PREFIX + "createTableTimer";
   public static final String GET_HIVE_TABLE = HIVE_REGISTER_METRICS_PREFIX + "getTableTimer";
+  public static final String GET_SCHEMA_SOURCE_HIVE_TABLE = HIVE_REGISTER_METRICS_PREFIX + "getSchemaSourceTableTimer";
   public static final String GET_AND_SET_LATEST_SCHEMA = HIVE_REGISTER_METRICS_PREFIX + "getAndSetLatestSchemaTimer";
   public static final String DROP_TABLE = HIVE_REGISTER_METRICS_PREFIX + "dropTableTimer";
   public static final String PATH_REGISTER_TIMER = HIVE_REGISTER_METRICS_PREFIX + "pathRegisterTimer";
@@ -292,10 +292,11 @@ public class HiveMetaStoreBasedRegister extends HiveRegister {
           existingTable = HiveMetaStoreUtils.getHiveTable(client.getTable(dbName, tableName));
         }
         HiveTable schemaSourceTable = existingTable;
-        if (state.contains(SCHEMA_SOURCE_DB) || state.contains(SCHEMA_SOURCE_TABLE)) {
-          try (Timer.Context context = this.metricContext.timer(GET_HIVE_TABLE).time()) {
+        if (state.contains(SCHEMA_SOURCE_DB)) {
+          try (Timer.Context context = this.metricContext.timer(GET_SCHEMA_SOURCE_HIVE_TABLE).time()) {
+            // We assume the schema source table has the same table name as the origin table, so only the db name can be configured
             schemaSourceTable = HiveMetaStoreUtils.getHiveTable(client.getTable(state.getProp(SCHEMA_SOURCE_DB, dbName),
-                state.getProp(SCHEMA_SOURCE_TABLE, tableName)));
+                tableName));
           }
         }
         if(shouldUpdateLatestSchema) {

--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/metastore/HiveMetaStoreBasedRegister.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/metastore/HiveMetaStoreBasedRegister.java
@@ -93,6 +93,8 @@ public class HiveMetaStoreBasedRegister extends HiveRegister {
 
   public static final String HIVE_REGISTER_METRICS_PREFIX = "hiveRegister.";
   public static final String ADD_PARTITION_TIMER = HIVE_REGISTER_METRICS_PREFIX + "addPartitionTimerTimer";
+  public static final String SCHEMA_SOURCE_DB = HIVE_REGISTER_METRICS_PREFIX + "schema.source.dbName";
+  public static final String SCHEMA_SOURCE_TABLE = HIVE_REGISTER_METRICS_PREFIX + "schema.source.tableName";
   public static final String GET_HIVE_PARTITION = HIVE_REGISTER_METRICS_PREFIX + "getPartitionTimer";
   public static final String ALTER_PARTITION = HIVE_REGISTER_METRICS_PREFIX + "alterPartitionTimer";
   public static final String TABLE_EXISTS = HIVE_REGISTER_METRICS_PREFIX + "tableExistsTimer";
@@ -144,6 +146,7 @@ public class HiveMetaStoreBasedRegister extends HiveRegister {
 
 
   private final boolean optimizedChecks;
+  private final State state;
   //If this is true, after we know the partition is existing, we will skip the partition in stead of getting the existing
   // partition and computing the diff to see if it needs to be updated. Use this only when you can make sure the metadata
   //for a partition is immutable
@@ -154,6 +157,7 @@ public class HiveMetaStoreBasedRegister extends HiveRegister {
   private String topicName = "";
   public HiveMetaStoreBasedRegister(State state, Optional<String> metastoreURI) throws IOException {
     super(state);
+    this.state = state;
     this.locks = new HiveLock(state.getProperties());
 
     this.optimizedChecks = state.getPropAsBoolean(OPTIMIZED_CHECK_ENABLED, true);
@@ -229,8 +233,16 @@ public class HiveMetaStoreBasedRegister extends HiveRegister {
             AvroSerdeUtils.AvroTableProperties.SCHEMA_LITERAL.getPropName()));
         String existingSchemaCreationTime = AvroUtils.getSchemaCreationTime(existingTableSchema);
         // If no schema set for the table spec, we fall back to existing schema
+        if (spec.getTable().getSerDeProps().getProp(AvroSerdeUtils.AvroTableProperties.SCHEMA_LITERAL.getPropName()) == null) {
+          spec.getTable()
+              .getSerDeProps()
+              .setProp(AvroSerdeUtils.AvroTableProperties.SCHEMA_LITERAL.getPropName(), existingTableSchema);
+          table.getSd().setSerdeInfo(HiveMetaStoreUtils.getSerDeInfo(spec.getTable()));
+          return;
+        }
         Schema writerSchema = new Schema.Parser().parse((
             spec.getTable().getSerDeProps().getProp(AvroSerdeUtils.AvroTableProperties.SCHEMA_LITERAL.getPropName(), existingTableSchema.toString())));
+        spec.getTable().getSerDeProps().getProp(AvroSerdeUtils.AvroTableProperties.SCHEMA_LITERAL.getPropName());
         String writerSchemaCreationTime = AvroUtils.getSchemaCreationTime(writerSchema);
         if(existingSchemaCreationTime != null && !existingSchemaCreationTime.equals(writerSchemaCreationTime)) {
           // If creation time of writer schema does not equal to the existing schema, we compare with schema fetched from
@@ -280,8 +292,16 @@ public class HiveMetaStoreBasedRegister extends HiveRegister {
         try (Timer.Context context = this.metricContext.timer(GET_HIVE_TABLE).time()) {
           existingTable = HiveMetaStoreUtils.getHiveTable(client.getTable(dbName, tableName));
         }
+        HiveTable schemaSourceTable = existingTable;
+        if (state.contains(SCHEMA_SOURCE_DB) || state.contains(SCHEMA_SOURCE_TABLE)) {
+          try (Timer.Context context = this.metricContext.timer(GET_HIVE_TABLE).time()) {
+            schemaSourceTable = HiveMetaStoreUtils.getHiveTable(client.getTable(state.getProp(SCHEMA_SOURCE_DB, dbName),
+                state.getProp(SCHEMA_SOURCE_TABLE, tableName)));
+          }
+        }
         if(shouldUpdateLatestSchema) {
           updateSchema(spec, table, existingTable);
+          updateSchema(spec, table, schemaSourceTable);
         }
         if (needToUpdateTable(existingTable, HiveMetaStoreUtils.getHiveTable(table))) {
           try (Timer.Context context = this.metricContext.timer(ALTER_TABLE).time()) {

--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/metastore/HiveMetaStoreBasedRegister.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/metastore/HiveMetaStoreBasedRegister.java
@@ -241,8 +241,7 @@ public class HiveMetaStoreBasedRegister extends HiveRegister {
           return;
         }
         Schema writerSchema = new Schema.Parser().parse((
-            spec.getTable().getSerDeProps().getProp(AvroSerdeUtils.AvroTableProperties.SCHEMA_LITERAL.getPropName(), existingTableSchema.toString())));
-        spec.getTable().getSerDeProps().getProp(AvroSerdeUtils.AvroTableProperties.SCHEMA_LITERAL.getPropName());
+            spec.getTable().getSerDeProps().getProp(AvroSerdeUtils.AvroTableProperties.SCHEMA_LITERAL.getPropName())));
         String writerSchemaCreationTime = AvroUtils.getSchemaCreationTime(writerSchema);
         if(existingSchemaCreationTime != null && !existingSchemaCreationTime.equals(writerSchemaCreationTime)) {
           // If creation time of writer schema does not equal to the existing schema, we compare with schema fetched from

--- a/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/metastore/HiveMetaStoreBasedRegister.java
+++ b/gobblin-hive-registration/src/main/java/org/apache/gobblin/hive/metastore/HiveMetaStoreBasedRegister.java
@@ -299,7 +299,6 @@ public class HiveMetaStoreBasedRegister extends HiveRegister {
           }
         }
         if(shouldUpdateLatestSchema) {
-          updateSchema(spec, table, existingTable);
           updateSchema(spec, table, schemaSourceTable);
         }
         if (needToUpdateTable(existingTable, HiveMetaStoreUtils.getHiveTable(table))) {


### PR DESCRIPTION
…gistering hive schema

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1344


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
We need to set schema.literal for hive table, but in ORC compaction pipeline, there is no context for avro schema. So for de-duped DB which is registered by compaction pipeline, we need to be able to configure the schema source db/table to get the avro schema registered by data ingestion pipeline

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

