### PR TITLE
[GOBBLIN-1348] Uses own logic for generating tags instead of the docker meta action

### DIFF
--- a/.github/workflows/docker_build_publish.yaml
+++ b/.github/workflows/docker_build_publish.yaml
@@ -21,10 +21,14 @@ on:
     # Publish only on `master`
     branches:
       - master
-
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'gobblin-docker/**'
+      - '.github/workflows/docker_build_publish.yaml'
   release:
-    tags:
-      - 'v*'
+    types: [published, edited]
 
 env:
   IMAGE_NAME: apache/gobblin
@@ -36,29 +40,35 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
+      - name: Build Docker Tag
+        id: build_tag
+        run: |
+          SHA=`echo ${{ github.sha }} | head -c 7`
+          if [[ ${{ github.event_name }} == 'release' ]]; then
+            TAG="${{ env.IMAGE_NAME }}:sha-$SHA, ${{ env.IMAGE_NAME }}:${{ github.event.release.tag_name }}, ${{ env.IMAGE_NAME }}:latest"
+          else
+            TAG="${{ env.IMAGE_NAME }}:sha-$SHA"
+          fi
+          echo "tag=$TAG"
+          echo "::set-output name=tag::$TAG"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Docker meta
-        id: docker_meta
-        uses: crazy-max/ghaction-docker-meta@v1
-        with:
-          images: ${{ env.IMAGE_NAME }} # list of Docker images to use as base name for tags
-          tag-sha: true # add git short SHA as Docker tag
       - name: Login to DockerHub
         uses: docker/login-action@v1
+        if: github.event_name != 'pull_request'
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-#      - name: Login to GitHub Container Registry
-#        if: github.event_name != 'pull_request'
-#        uses: docker/login-action@v1
-#        with:
-#          registry: ghcr.io
-#          username: ${{ github.repository_owner }}
-#          password: ${{ secrets.CR_PAT }}
+      #      - name: Login to GitHub Container Registry
+      #        if: github.event_name != 'pull_request'
+      #        uses: docker/login-action@v1
+      #        with:
+      #          registry: ghcr.io
+      #          username: ${{ github.repository_owner }}
+      #          password: ${{ secrets.CR_PAT }}
       - name: Build Images and Publish
         uses: docker/build-push-action@v2
         with:
-          tags: ${{ steps.docker_meta.outputs.tags }}
-          push: true
+          tags: ${{ steps.build_tag.outputs.tag }}
+          push: ${{ github.event_name != 'pull_request' }}
           file: ./gobblin-docker/gobblin/alpine-gobblin-latest/Dockerfile


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1348


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
- Removes use of non-verified third party github action to generate tags, and instead generates tags explicitly in a previous job
- Runs the action if the github action is modified or if docker files are modified, allowing earlier detection of bugs

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

