### PR TITLE
GOBBLIN-1351: Ensure KafkaStreamingExtractor shutdown is invoked on task shutdown

### DIFF
--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaStreamingExtractor.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaStreamingExtractor.java
@@ -119,6 +119,15 @@ public class KafkaStreamingExtractor<S> extends FlushingExtractor<S, DecodeableK
 
   @Override
   public void shutdown() {
+    this.scheduledExecutorService.shutdownNow();
+    try {
+      boolean shutdown = this.scheduledExecutorService.awaitTermination(5, TimeUnit.SECONDS);
+      if (!shutdown) {
+        log.error("Could not shutdown metrics collection threads in 5 seconds.");
+      }
+    } catch (InterruptedException e) {
+      log.error("Interrupted when attempting to shutdown metrics collection threads.");
+    }
     this.shutdownRequested.set(true);
   }
 


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1351


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
KafkaStreamingExtractor extends InstrumentedExtractorBase which currently does not invoke the shutdown() method when a task shutdown is requested. 


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Existing tests.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

