### PR TITLE
GOBBLIN-1352: Ensure Helix workflows are cleaned up on cluster start up in centralized mode

### DIFF
--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/HelixRetriggeringJobCallable.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/HelixRetriggeringJobCallable.java
@@ -198,7 +198,7 @@ class HelixRetriggeringJobCallable implements Callable {
   }
 
   @VisibleForTesting
-  static GobblinHelixJobLauncher buildJobLauncher(GobblinHelixJobScheduler jobScheduler, Properties jobProps) throws Exception {
+  static GobblinHelixJobLauncher buildJobLauncherForCentralizedMode(GobblinHelixJobScheduler jobScheduler, Properties jobProps) throws Exception {
     //In centralized job launcher mode, the JOB_ID_KEY should be null and should be set as part of
     //job launcher instantiation. This ensures that workflows in centralized mode are cleaned up properly
     // when cluster is restarted.
@@ -215,7 +215,7 @@ class HelixRetriggeringJobCallable implements Callable {
    private void runJobLauncherLoop() throws JobException {
     try {
       while (true) {
-        currentJobLauncher = buildJobLauncher(jobScheduler, jobProps);
+        currentJobLauncher = buildJobLauncherForCentralizedMode(jobScheduler, jobProps);
         // in "run once" case, job scheduler will remove current job from the scheduler
         boolean isEarlyStopped = this.jobScheduler.runJob(jobProps, jobListener, currentJobLauncher);
         boolean isRetriggerEnabled = this.isRetriggeringEnabled();

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/HelixRetriggeringJobCallable.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/HelixRetriggeringJobCallable.java
@@ -29,6 +29,8 @@ import org.apache.hadoop.fs.Path;
 import org.apache.helix.HelixException;
 import org.apache.helix.HelixManager;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.google.common.io.Closer;
 import com.google.common.util.concurrent.Striped;
 import com.typesafe.config.Config;
@@ -195,33 +197,25 @@ class HelixRetriggeringJobCallable implements Callable {
     }
   }
 
+  @VisibleForTesting
+  static GobblinHelixJobLauncher buildJobLauncher(GobblinHelixJobScheduler jobScheduler, Properties jobProps) throws Exception {
+    //In centralized job launcher mode, the JOB_ID_KEY should be null and should be set as part of
+    //job launcher instantiation. This ensures that workflows in centralized mode are cleaned up properly
+    // when cluster is restarted.
+    Preconditions.checkArgument(jobProps.getProperty(ConfigurationKeys.JOB_ID_KEY) == null);
+    return jobScheduler.buildJobLauncher(jobProps);
+  }
+
   /**
-   * <p> In some cases, the job launcher will be early stopped.
-   * It can be due to the large volume of input source data.
-   * In such case, we need to re-launch the same job until
-   * the job launcher determines it is safe to stop.
+   * A method to run a Gobblin job with ability to re-trigger the job if neeeded. This method instantiates a
+   * {@link GobblinHelixJobLauncher} and submits the underlying Gobblin job to a {link GobblinHelixJobScheduler}.
+   * The method will re-submit the job if it has been terminated "early" e.g. before all data has been pulled.
+   * This method should be called only when distributed job launcher mode is disabled.
    */
-  private void runJobLauncherLoop() throws JobException {
+   private void runJobLauncherLoop() throws JobException {
     try {
-      // Check if any existing planning job is running
-      Optional<String> actualJobIdFromStore = jobsMapping.getActualJobId(this.jobUri);
-
-      if (actualJobIdFromStore.isPresent() && !canRun(actualJobIdFromStore.get(), this.jobHelixManager)) {
-        return;
-      }
-
-      String actualJobId = jobProps.containsKey(ConfigurationKeys.JOB_ID_KEY)
-              ? jobProps.getProperty(ConfigurationKeys.JOB_ID_KEY) : HelixJobsMapping.createActualJobId(jobProps);
-      log.info("Job {} creates actual job {}", this.jobUri, actualJobId);
-
-      jobProps.setProperty(ConfigurationKeys.JOB_ID_KEY, actualJobId);
-
-      /* create the job launcher after setting ConfigurationKeys.JOB_ID_KEY */
-      currentJobLauncher = this.jobScheduler.buildJobLauncher(jobProps);
-
-      this.jobsMapping.setActualJobId(this.jobUri, actualJobId);
-
       while (true) {
+        currentJobLauncher = buildJobLauncher(jobScheduler, jobProps);
         // in "run once" case, job scheduler will remove current job from the scheduler
         boolean isEarlyStopped = this.jobScheduler.runJob(jobProps, jobListener, currentJobLauncher);
         boolean isRetriggerEnabled = this.isRetriggeringEnabled();
@@ -231,18 +225,11 @@ class HelixRetriggeringJobCallable implements Callable {
           break;
         }
       }
-
     } catch (Exception e) {
       log.error("Failed to run job {}", jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY), e);
       throw new JobException("Failed to run job " + jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY), e);
     } finally {
       currentJobLauncher = null;
-      // always cleanup the job mapping for current job name.
-      try {
-        this.jobsMapping.deleteMapping(jobUri);
-      } catch (Exception e) {
-        throw new JobException("Cannot delete jobs mapping for job : " + jobUri);
-      }
     }
   }
 

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/HelixRetriggeringJobCallable.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/HelixRetriggeringJobCallable.java
@@ -199,10 +199,14 @@ class HelixRetriggeringJobCallable implements Callable {
 
   @VisibleForTesting
   static GobblinHelixJobLauncher buildJobLauncherForCentralizedMode(GobblinHelixJobScheduler jobScheduler, Properties jobProps) throws Exception {
-    //In centralized job launcher mode, the JOB_ID_KEY should be null and should be set as part of
-    //job launcher instantiation. This ensures that workflows in centralized mode are cleaned up properly
-    // when cluster is restarted.
-    Preconditions.checkArgument(jobProps.getProperty(ConfigurationKeys.JOB_ID_KEY) == null);
+    //In centralized job launcher mode, the JOB_ID_KEY should be null or should not contain the
+    //"ActualJob" substring, which is intended for the distributed job launcher mode.
+    //This ensures that workflows in centralized mode are cleaned up properly when cluster is restarted.
+    String jobId = jobProps.getProperty(ConfigurationKeys.JOB_ID_KEY);
+    if (jobId != null) {
+      Preconditions.checkArgument(!jobId.contains(GobblinClusterConfigurationKeys.ACTUAL_JOB_NAME_PREFIX),
+          "Job Id should not contain ActualJob in centralized mode.");
+    }
     return jobScheduler.buildJobLauncher(jobProps);
   }
 

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/HelixRetriggeringJobCallableTest.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/HelixRetriggeringJobCallableTest.java
@@ -58,8 +58,6 @@ public class HelixRetriggeringJobCallableTest {
         ConfigValueFactory.fromAnyRef(TMP_DIR));
     MutableJobCatalog jobCatalog = new NonObservingFSJobCatalog(config);
     SchedulerService schedulerService = new SchedulerService(new Properties());
-    //HelixManager helixManager = Mockito.mock(HelixManager.class);
-    //EventBus eventBus = Mockito.mock(EventBus.class);
     Path appWorkDir = new Path(TMP_DIR);
     GobblinHelixJobScheduler jobScheduler = new GobblinHelixJobScheduler(ConfigFactory.empty(), getMockHelixManager(), Optional.empty(), null,
         appWorkDir, Lists.emptyList(), schedulerService, jobCatalog);

--- a/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/HelixRetriggeringJobCallableTest.java
+++ b/gobblin-cluster/src/test/java/org/apache/gobblin/cluster/HelixRetriggeringJobCallableTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.cluster;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.Properties;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.helix.HelixManager;
+import org.assertj.core.util.Lists;
+import org.junit.Assert;
+import org.mockito.Mockito;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.google.common.eventbus.EventBus;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigValueFactory;
+
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.runtime.api.MutableJobCatalog;
+import org.apache.gobblin.runtime.job_catalog.NonObservingFSJobCatalog;
+import org.apache.gobblin.scheduler.SchedulerService;
+
+import static org.testng.Assert.*;
+
+
+public class HelixRetriggeringJobCallableTest {
+  public static final String TMP_DIR = "/tmp/" + HelixRetriggeringJobCallable.class.getSimpleName();
+
+  @BeforeClass
+  public void setUp() {
+    File tmpDir = new File(TMP_DIR);
+    if (!tmpDir.exists()) {
+      tmpDir.mkdirs();
+    }
+  }
+
+  @Test
+  public void testBuildJobLauncher()
+      throws Exception {
+    Config config = ConfigFactory.empty().withValue(ConfigurationKeys.JOB_CONFIG_FILE_GENERAL_PATH_KEY,
+        ConfigValueFactory.fromAnyRef(TMP_DIR));
+    MutableJobCatalog jobCatalog = new NonObservingFSJobCatalog(config);
+    SchedulerService schedulerService = new SchedulerService(new Properties());
+    //HelixManager helixManager = Mockito.mock(HelixManager.class);
+    //EventBus eventBus = Mockito.mock(EventBus.class);
+    Path appWorkDir = new Path(TMP_DIR);
+    GobblinHelixJobScheduler jobScheduler = new GobblinHelixJobScheduler(ConfigFactory.empty(), null, Optional.empty(), null,
+        appWorkDir, Lists.emptyList(), schedulerService, jobCatalog);
+    Properties jobProps = new Properties();
+    jobProps.setProperty(ConfigurationKeys.JOB_NAME_KEY, "dummyJob");
+    GobblinHelixJobLauncher jobLauncher = jobScheduler.buildJobLauncher(jobProps);
+    String jobId = jobLauncher.getJobId();
+    Assert.assertNotNull(jobId);
+    Assert.assertFalse(jobId.contains(GobblinClusterConfigurationKeys.ACTUAL_JOB_NAME_PREFIX));
+  }
+}

--- a/gobblin-cluster/src/test/resources/log4j.xml
+++ b/gobblin-cluster/src/test/resources/log4j.xml
@@ -44,6 +44,15 @@
     <appender-ref ref="console" />
   </root>
 
+  <!-- Set log level for Helix/ZK logs to ERROR to avoid Travis build failures due to exceeding maximum log length. -->
+  <logger name="org.apache.helix">
+    <level value="ERROR"/>
+  </logger>
+
+  <logger name="org.apache.zookeeper">
+    <level value="ERROR"/>
+  </logger>
+
   <!-- Swallow annoying exceptions when creating a configuration. -->
   <logger name="org.apache.hadoop.conf.Configuration">
     <level value="FATAL"/>


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1352


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
As part of the changes introduced in GOBBLIN-1319, the Helix workflow names were modified to include a special prefix. However, this prefix is intended for use in distributed mode. As a consequence of this change, the workflows are no longer being cleaned up on cluster start up leading to a leak in Znodes. Further, since the workflows are left in the START state, the Yarn autoscaling manager requests more containers than needed.



### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Added unit test.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

