### PR TITLE
GOBBLIN-1355: Make task interruption optional on Gobblin task cancellation

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -251,6 +251,9 @@ public class ConfigurationKeys {
   public static final String JOB_FAILURE_EXCEPTION_KEY = "job.failure.exception";
   public static final String TASK_RETRIES_KEY = "task.retries";
   public static final String TASK_IGNORE_CLOSE_FAILURES = "task.ignoreCloseFailures";
+  //A boolean config to allow skipping task interrupt on cancellation. Useful for example when thread manages
+  // a Kafka consumer which when interrupted during a poll() leaves the consumer in a corrupt state that prevents
+  // the consumer being closed subsequently, leading to a potential resource leak.
   public static final String TASK_INTERRUPT_ON_CANCEL = "task.interruptOnCancel";
   public static final String JOB_FAILURES_KEY = "job.failures";
   public static final String JOB_TRACKING_URL_KEY = "job.tracking.url";

--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -251,6 +251,7 @@ public class ConfigurationKeys {
   public static final String JOB_FAILURE_EXCEPTION_KEY = "job.failure.exception";
   public static final String TASK_RETRIES_KEY = "task.retries";
   public static final String TASK_IGNORE_CLOSE_FAILURES = "task.ignoreCloseFailures";
+  public static final String TASK_INTERRUPT_ON_CANCEL = "task.interruptOnCancel";
   public static final String JOB_FAILURES_KEY = "job.failures";
   public static final String JOB_TRACKING_URL_KEY = "job.tracking.url";
   public static final String FORK_STATE_KEY = "fork.state";


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1355


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Currently, the thread running a Gobblin task is interrupted when a task cancellation is invoked. When such a task is managing a Kafka consumer for instance, the interrupt leaves the consumer instance in a corrupt state, particularly if the consumer is in the middle of a poll() when the interrupt occurs. This in turn prevents the subsequent clean up of the consumer instance resulting in a potential resource leak. 

With this change, we provide the option to avoid interrupting the thread in aforementioned scenarios and let the poll() return before the thread is shutdown. 


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Trivial change.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

