### PR TITLE
[GOBBLIN-1359] Fix the error that IOException thrown by writer be swallowed by Reactivex

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/writer/PartitionedDataWriter.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/writer/PartitionedDataWriter.java
@@ -52,6 +52,7 @@ import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.dataset.Descriptor;
 import org.apache.gobblin.dataset.PartitionDescriptor;
+import org.apache.gobblin.exception.NonTransientException;
 import org.apache.gobblin.instrumented.writer.InstrumentedDataWriterDecorator;
 import org.apache.gobblin.instrumented.writer.InstrumentedPartitionedDataWriterDecorator;
 import org.apache.gobblin.records.ControlMessageHandler;
@@ -245,7 +246,7 @@ public class PartitionedDataWriter<S, D> extends WriterWrapper<D> implements Fin
       // If the write take a long time, which is 1/3 of cache expiration time, we fail the writer to avoid data loss
       // and further slowness on the same HDFS block
       if (timeForWriting / 1000 > this.writeTimeoutInterval ) {
-        throw new IOException(String.format("Write record took %s s, but threshold is %s s",
+        throw new NonTransientException(String.format("Write record took %s s, but threshold is %s s",
             timeForWriting / 1000, writeTimeoutInterval));
       }
     } catch (ExecutionException ee) {

--- a/gobblin-core/src/main/java/org/apache/gobblin/writer/PartitionedDataWriter.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/writer/PartitionedDataWriter.java
@@ -246,6 +246,7 @@ public class PartitionedDataWriter<S, D> extends WriterWrapper<D> implements Fin
       // If the write take a long time, which is 1/3 of cache expiration time, we fail the writer to avoid data loss
       // and further slowness on the same HDFS block
       if (timeForWriting / 1000 > this.writeTimeoutInterval ) {
+        //Use NonTransientException to avoid writer retry, in this case, retry will also cause data loss
         throw new NonTransientException(String.format("Write record took %s s, but threshold is %s s",
             timeForWriting / 1000, writeTimeoutInterval));
       }

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/fork/Fork.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/fork/Fork.java
@@ -229,7 +229,7 @@ public class Fork<S, D> implements Closeable, FinalState, RecordStreamConsumer<S
         }
       }, e -> {
           logger.error("Failed to process record.", e);
-          throw((Exception) e);
+          throw(new RuntimeException(e));
           },
         () -> {
           if (this.writer.isPresent()) {

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/fork/Fork.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/fork/Fork.java
@@ -229,7 +229,7 @@ public class Fork<S, D> implements Closeable, FinalState, RecordStreamConsumer<S
         }
       }, e -> {
           logger.error("Failed to process record.", e);
-          throw(new RuntimeException(e));
+          throw((Exception) e);
           },
         () -> {
           if (this.writer.isPresent()) {

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/fork/Fork.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/fork/Fork.java
@@ -227,7 +227,10 @@ public class Fork<S, D> implements Closeable, FinalState, RecordStreamConsumer<S
 
           r.ack();
         }
-      }, e -> logger.error("Failed to process record.", e),
+      }, e -> {
+          logger.error("Failed to process record.", e);
+          throw(new RuntimeException(e));
+          },
         () -> {
           if (this.writer.isPresent()) {
             this.writer.get().close();


### PR DESCRIPTION
…llowed by Reactivex

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1359


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Fix the bug in Reactivex code which swallows the exception and leaves the task hanging

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Create dummy IOException in writer and make sure it can cause the task failure

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

