### PR TITLE
[GOBBLIN-1361] Avoid conflicting ivysettings.xml in classpath 

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/fork/Fork.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/fork/Fork.java
@@ -216,7 +216,7 @@ public class Fork<S, D> implements Closeable, FinalState, RecordStreamConsumer<S
         if (r instanceof RecordEnvelope) {
           this.writer.get().writeEnvelope((RecordEnvelope) r);
         } else if (r instanceof ControlMessage) {
-          // Nack with error and reraise the error if the control messsage handling raises an error.
+          // Nack with error and reraise the error if the control message handling raises an error.
           // This is to avoid missing an ack/nack in the error path.
           try {
             this.writer.get().getMessageHandler().handleMessage((ControlMessage) r);


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
 https://issues.apache.org/jira/browse/GOBBLIN-1361


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
We have seen many cases that when we need to load `ivysettings.xml` from classpath, there's already one provided by pending applications (e.g. Hive has one of its jar containing the `ivysettings.xml`), it is quite tricky to avoid conflicts with existing settings file. Instead we added a new file name to be loaded in the `DownloadUtils` to avoid conflicting names with guarantee of backward-compatibility. 


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

