### PR TITLE
[GOBBLIN-1362] Fix bug where state is set twice when no workunits created

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/AbstractJobLauncher.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/AbstractJobLauncher.java
@@ -558,42 +558,42 @@ public abstract class AbstractJobLauncher implements JobLauncher {
                 jobListener.onJobFailure(jobContext);
               }
             });
-          }
-
-          for (JobState.DatasetState datasetState : this.jobContext.getDatasetStatesByUrns().values()) {
-            // Set the overall job state to FAILED if the job failed to process any dataset
-            if (datasetState.getState() == JobState.RunningState.FAILED) {
-              jobState.setState(JobState.RunningState.FAILED);
-              LOG.warn("At least one dataset state is FAILED. Setting job state to FAILED.");
-              break;
-            }
-          }
-
-          notifyListeners(this.jobContext, jobListener, TimingEvent.LauncherTimings.JOB_COMPLETE, new JobListenerAction() {
-            @Override
-            public void apply(JobListener jobListener, JobContext jobContext)
-                throws Exception {
-              jobListener.onJobCompletion(jobContext);
-            }
-          });
-
-          if (jobState.getState() == JobState.RunningState.FAILED) {
-            notifyListeners(this.jobContext, jobListener, TimingEvent.LauncherTimings.JOB_FAILED, new JobListenerAction() {
-              @Override
-              public void apply(JobListener jobListener, JobContext jobContext)
-                  throws Exception {
-                jobListener.onJobFailure(jobContext);
-              }
-            });
-            throw new JobException(String.format("Job %s failed", jobId));
           } else {
-            notifyListeners(this.jobContext, jobListener, TimingEvent.LauncherTimings.JOB_SUCCEEDED, new JobListenerAction() {
+            for (JobState.DatasetState datasetState : this.jobContext.getDatasetStatesByUrns().values()) {
+              // Set the overall job state to FAILED if the job failed to process any dataset
+              if (datasetState.getState() == JobState.RunningState.FAILED) {
+                jobState.setState(JobState.RunningState.FAILED);
+                LOG.warn("At least one dataset state is FAILED. Setting job state to FAILED.");
+                break;
+              }
+            }
+
+            notifyListeners(this.jobContext, jobListener, TimingEvent.LauncherTimings.JOB_COMPLETE, new JobListenerAction() {
               @Override
               public void apply(JobListener jobListener, JobContext jobContext)
                   throws Exception {
-                jobListener.onJobFailure(jobContext);
+                jobListener.onJobCompletion(jobContext);
               }
             });
+
+            if (jobState.getState() == JobState.RunningState.FAILED) {
+              notifyListeners(this.jobContext, jobListener, TimingEvent.LauncherTimings.JOB_FAILED, new JobListenerAction() {
+                @Override
+                public void apply(JobListener jobListener, JobContext jobContext)
+                    throws Exception {
+                  jobListener.onJobFailure(jobContext);
+                }
+              });
+              throw new JobException(String.format("Job %s failed", jobId));
+            } else {
+              notifyListeners(this.jobContext, jobListener, TimingEvent.LauncherTimings.JOB_SUCCEEDED, new JobListenerAction() {
+                @Override
+                public void apply(JobListener jobListener, JobContext jobContext)
+                    throws Exception {
+                  jobListener.onJobFailure(jobContext);
+                }
+              });
+            }
           }
         }
       }


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1362


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

Move the normal notifyListeners calls to an else block, so that it will only be run if isWorkUnitsEmpty is false. Otherwise the state will try to be set twice in the case of no workunits.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

