### PR TITLE
[GOBBLIN-1366] Add an option to skip initialization of hadoop tokens …

### DIFF
--- a/gobblin-modules/gobblin-azkaban/src/main/java/org/apache/gobblin/azkaban/AzkabanJobLauncher.java
+++ b/gobblin-modules/gobblin-azkaban/src/main/java/org/apache/gobblin/azkaban/AzkabanJobLauncher.java
@@ -112,6 +112,9 @@ public class AzkabanJobLauncher extends AbstractJob implements ApplicationLaunch
   private static final String AZKABAN_GOBBLIN_JOB_SLA_IN_SECONDS = "gobblin.azkaban.SLAInSeconds";
   private static final String DEFAULT_AZKABAN_GOBBLIN_JOB_SLA_IN_SECONDS = "-1"; // No SLA.
 
+  public static final String GOBBLIN_INITIALIZE_HADOOP_TOKENS = "gobblin.initializeHadoopTokens";
+  public static final String DEFAULT_GOBBLIN_INITIALIZE_HADOOP_TOKENS = "true";
+
   private final Closer closer = Closer.create();
   private final JobLauncher jobLauncher;
   private final JobListener jobListener;
@@ -169,22 +172,24 @@ public class AzkabanJobLauncher extends AbstractJob implements ApplicationLaunch
     this.props
         .setProperty(ConfigurationKeys.JOB_TRACKING_URL_KEY, Strings.nullToEmpty(conf.get(AZKABAN_LINK_JOBEXEC_URL)));
 
-    if (System.getenv(HADOOP_TOKEN_FILE_LOCATION) != null) {
-      LOG.info("Job type " + props.getProperty(JOB_TYPE) + " provided Hadoop token in the environment variable "
-          + HADOOP_TOKEN_FILE_LOCATION);
-      this.props.setProperty(MAPREDUCE_JOB_CREDENTIALS_BINARY, System.getenv(HADOOP_TOKEN_FILE_LOCATION));
-    } else {
-      // see javadoc for more information
-      LOG.info("Job type " + props.getProperty(JOB_TYPE) + " did not provide Hadoop token in the environment variable "
-          + HADOOP_TOKEN_FILE_LOCATION + ". Negotiating Hadoop tokens.");
+    if (Boolean.parseBoolean(this.props.getProperty(GOBBLIN_INITIALIZE_HADOOP_TOKENS,
+        DEFAULT_GOBBLIN_INITIALIZE_HADOOP_TOKENS))) {
+      if (System.getenv(HADOOP_TOKEN_FILE_LOCATION) != null) {
+        LOG.info("Job type " + props.getProperty(JOB_TYPE) + " provided Hadoop token in the environment variable " + HADOOP_TOKEN_FILE_LOCATION);
+        this.props.setProperty(MAPREDUCE_JOB_CREDENTIALS_BINARY, System.getenv(HADOOP_TOKEN_FILE_LOCATION));
+      } else {
+        // see javadoc for more information
+        LOG.info(
+            "Job type " + props.getProperty(JOB_TYPE) + " did not provide Hadoop token in the environment variable " + HADOOP_TOKEN_FILE_LOCATION + ". Negotiating Hadoop tokens.");
 
-      File tokenFile = File.createTempFile("mr-azkaban", ".token");
-      TokenUtils.getHadoopTokens(new State(props), Optional.of(tokenFile), new Credentials());
+        File tokenFile = File.createTempFile("mr-azkaban", ".token");
+        TokenUtils.getHadoopTokens(new State(props), Optional.of(tokenFile), new Credentials());
 
-      System.setProperty(HADOOP_TOKEN_FILE_LOCATION, tokenFile.getAbsolutePath());
-      System.setProperty(MAPREDUCE_JOB_CREDENTIALS_BINARY, tokenFile.getAbsolutePath());
-      this.props.setProperty(MAPREDUCE_JOB_CREDENTIALS_BINARY, tokenFile.getAbsolutePath());
-      this.props.setProperty("env." + HADOOP_TOKEN_FILE_LOCATION, tokenFile.getAbsolutePath());
+        System.setProperty(HADOOP_TOKEN_FILE_LOCATION, tokenFile.getAbsolutePath());
+        System.setProperty(MAPREDUCE_JOB_CREDENTIALS_BINARY, tokenFile.getAbsolutePath());
+        this.props.setProperty(MAPREDUCE_JOB_CREDENTIALS_BINARY, tokenFile.getAbsolutePath());
+        this.props.setProperty("env." + HADOOP_TOKEN_FILE_LOCATION, tokenFile.getAbsolutePath());
+      }
     }
 
     Properties jobProps = this.props;

--- a/gobblin-modules/gobblin-azkaban/src/main/java/org/apache/gobblin/azkaban/AzkabanJobLauncher.java
+++ b/gobblin-modules/gobblin-azkaban/src/main/java/org/apache/gobblin/azkaban/AzkabanJobLauncher.java
@@ -112,8 +112,8 @@ public class AzkabanJobLauncher extends AbstractJob implements ApplicationLaunch
   private static final String AZKABAN_GOBBLIN_JOB_SLA_IN_SECONDS = "gobblin.azkaban.SLAInSeconds";
   private static final String DEFAULT_AZKABAN_GOBBLIN_JOB_SLA_IN_SECONDS = "-1"; // No SLA.
 
-  public static final String GOBBLIN_INITIALIZE_HADOOP_TOKENS = "gobblin.initializeHadoopTokens";
-  public static final String DEFAULT_GOBBLIN_INITIALIZE_HADOOP_TOKENS = "true";
+  public static final String GOBBLIN_AZKABAN_INITIALIZE_HADOOP_TOKENS = "gobblin.azkaban.initializeHadoopTokens";
+  public static final String DEFAULT_GOBBLIN_AZKABAN_INITIALIZE_HADOOP_TOKENS = "true";
 
   private final Closer closer = Closer.create();
   private final JobLauncher jobLauncher;
@@ -172,8 +172,8 @@ public class AzkabanJobLauncher extends AbstractJob implements ApplicationLaunch
     this.props
         .setProperty(ConfigurationKeys.JOB_TRACKING_URL_KEY, Strings.nullToEmpty(conf.get(AZKABAN_LINK_JOBEXEC_URL)));
 
-    if (Boolean.parseBoolean(this.props.getProperty(GOBBLIN_INITIALIZE_HADOOP_TOKENS,
-        DEFAULT_GOBBLIN_INITIALIZE_HADOOP_TOKENS))) {
+    if (Boolean.parseBoolean(this.props.getProperty(GOBBLIN_AZKABAN_INITIALIZE_HADOOP_TOKENS,
+        DEFAULT_GOBBLIN_AZKABAN_INITIALIZE_HADOOP_TOKENS))) {
       if (System.getenv(HADOOP_TOKEN_FILE_LOCATION) != null) {
         LOG.info("Job type " + props.getProperty(JOB_TYPE) + " provided Hadoop token in the environment variable " + HADOOP_TOKEN_FILE_LOCATION);
         this.props.setProperty(MAPREDUCE_JOB_CREDENTIALS_BINARY, System.getenv(HADOOP_TOKEN_FILE_LOCATION));

--- a/gobblin-modules/gobblin-azkaban/src/test/java/org/apache/gobblin/azkaban/AzkabanJobLauncherTest.java
+++ b/gobblin-modules/gobblin-azkaban/src/test/java/org/apache/gobblin/azkaban/AzkabanJobLauncherTest.java
@@ -55,7 +55,7 @@ public class AzkabanJobLauncherTest {
     }
 
     // No error expected since initialization is skipped
-    props.setProperty(AzkabanJobLauncher.GOBBLIN_INITIALIZE_HADOOP_TOKENS, "false");
+    props.setProperty(AzkabanJobLauncher.GOBBLIN_AZKABAN_INITIALIZE_HADOOP_TOKENS, "false");
     new AzkabanJobLauncher("test", props);
   }
 

--- a/gobblin-modules/gobblin-azkaban/src/test/java/org/apache/gobblin/azkaban/AzkabanJobLauncherTest.java
+++ b/gobblin-modules/gobblin-azkaban/src/test/java/org/apache/gobblin/azkaban/AzkabanJobLauncherTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.azkaban;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.configuration.SourceState;
+import org.apache.gobblin.configuration.WorkUnitState;
+import org.apache.gobblin.runtime.JobLauncherFactory;
+import org.apache.gobblin.source.Source;
+import org.apache.gobblin.source.extractor.Extractor;
+import org.apache.gobblin.source.extractor.extract.AbstractSource;
+import org.apache.gobblin.source.workunit.WorkUnit;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+@Test
+public class AzkabanJobLauncherTest {
+
+  @Test
+  public void testDisableTokenInitialization() throws Exception {
+    Properties props = new Properties();
+
+    props.setProperty(ConfigurationKeys.JOB_NAME_KEY, "job1");
+    props.setProperty(ConfigurationKeys.JOB_LAUNCHER_TYPE_KEY, JobLauncherFactory.JobLauncherType.LOCAL.name());
+    props.setProperty(ConfigurationKeys.JOB_LOCK_ENABLED_KEY, "false");
+    props.setProperty(ConfigurationKeys.STATE_STORE_ENABLED, "false");
+    props.setProperty(ConfigurationKeys.SOURCE_CLASS_KEY, DummySource.class.getName());
+
+    // Should get an error since tokens are initialized by default
+    try {
+      new AzkabanJobLauncher("test", props);
+      Assert.fail();
+    } catch (IllegalArgumentException e) {
+      Assert.assertTrue(e.getMessage().contains("Missing required property keytab.user"));
+    }
+
+    // No error expected since initialization is skipped
+    props.setProperty(AzkabanJobLauncher.GOBBLIN_INITIALIZE_HADOOP_TOKENS, "false");
+    new AzkabanJobLauncher("test", props);
+  }
+
+  /**
+   * A dummy implementation of {@link Source}.
+   */
+  public static class DummySource extends AbstractSource<String, Integer> {
+    @Override
+    public List<WorkUnit> getWorkunits(SourceState sourceState) {
+      return Collections.EMPTY_LIST;
+    }
+
+    @Override
+    public Extractor<String, Integer> getExtractor(WorkUnitState state) throws IOException {
+      return null;
+    }
+
+    @Override
+    public void shutdown(SourceState state) {
+    }
+  }
+}


### PR DESCRIPTION
…in the AzkabanJobLauncher

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1366


### Description
- [X] Here are some details about my PR, including screenshots (if applicable):
The AzkabanJobLauncher was changed recently to remove the dependency on the job type for determining token initialization.

This breaks some use cases where no tokens are required.

Add the gobblin.initializeHadoopTokens option with a default of true to allow opting out of token initialization.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

