### PR TITLE
[GOBBLIN-1367] Fix PostgresqlExtractor's unnecessary string replacement

### DIFF
--- a/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/source/jdbc/PostgresqlExtractor.java
+++ b/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/source/jdbc/PostgresqlExtractor.java
@@ -110,7 +110,7 @@ public class PostgresqlExtractor extends JdbcExtractor {
     if (StringUtils.isBlank(watermarkFilter)) {
       watermarkFilter = "1=1";
     }
-    query = query.replace(this.getOutputColumnProjection(), columnProjection)
+    query = StringUtils.replaceOnce(query, this.getOutputColumnProjection(), columnProjection)
         .replace(ConfigurationKeys.DEFAULT_SOURCE_QUERYBASED_WATERMARK_PREDICATE_SYMBOL, watermarkFilter);
 
     commands.add(getCommand(query, JdbcCommand.JdbcCommandType.QUERY));
@@ -131,7 +131,7 @@ public class PostgresqlExtractor extends JdbcExtractor {
       watermarkFilter = "1=1";
     }
 
-    query = query.replace(this.getOutputColumnProjection(), columnProjection)
+    query = StringUtils.replaceOnce(query, this.getOutputColumnProjection(), columnProjection)
         .replace(ConfigurationKeys.DEFAULT_SOURCE_QUERYBASED_WATERMARK_PREDICATE_SYMBOL, watermarkFilter);
     String sampleFilter = this.constructSampleClause();
     query = query + sampleFilter;


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1367


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

PostgresqlExtractor fails if the name of schema or table contains the one of its column as substring. This PR fixes it.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

* o.a.g.source.jdbc.PostgresqlExtractorTest.testGetHighWatermarkMetadata
* o.a.g.source.jdbc.PostgresqlExtractorTest.testGetCountMetadata

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

