### PR TITLE
[GOBBLIN-1369] Fix wrong method name: exractSampleRecordCountFromQuery

### DIFF
--- a/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/source/jdbc/JdbcExtractor.java
+++ b/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/source/jdbc/JdbcExtractor.java
@@ -306,7 +306,7 @@ public abstract class JdbcExtractor extends QueryBasedExtractor<JsonArray, JsonE
         ConfigurationKeys.ENABLE_DELIMITED_IDENTIFIER, ConfigurationKeys.DEFAULT_ENABLE_DELIMITED_IDENTIFIER);
     JsonObject defaultWatermark = this.getDefaultWatermark();
     String derivedWatermarkColumnName = defaultWatermark.get("columnName").getAsString();
-    this.setSampleRecordCount(this.exractSampleRecordCountFromQuery(inputQuery));
+    this.setSampleRecordCount(this.extractSampleRecordCountFromQuery(inputQuery));
     inputQuery = this.removeSampleClauseFromQuery(inputQuery);
     JsonArray targetSchema = new JsonArray();
     List<String> headerColumns = new ArrayList<>();

--- a/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/source/jdbc/JdbcSpecificLayer.java
+++ b/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/source/jdbc/JdbcSpecificLayer.java
@@ -36,7 +36,7 @@ public interface JdbcSpecificLayer {
    * @param query
    * @return record count
    */
-  public long exractSampleRecordCountFromQuery(String query);
+  public long extractSampleRecordCountFromQuery(String query);
 
   /**
    * Remove sample clause in input query

--- a/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/source/jdbc/MysqlExtractor.java
+++ b/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/source/jdbc/MysqlExtractor.java
@@ -231,7 +231,7 @@ public class MysqlExtractor extends JdbcExtractor {
   }
 
   @Override
-  public long exractSampleRecordCountFromQuery(String query) {
+  public long extractSampleRecordCountFromQuery(String query) {
     if (StringUtils.isBlank(query)) {
       return SAMPLERECORDCOUNT;
     }

--- a/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/source/jdbc/OracleExtractor.java
+++ b/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/source/jdbc/OracleExtractor.java
@@ -205,7 +205,7 @@ public class OracleExtractor extends JdbcExtractor {
   }
 
   @Override
-  public long exractSampleRecordCountFromQuery(String query) {
+  public long extractSampleRecordCountFromQuery(String query) {
     if (StringUtils.isBlank(query)) {
       return SAMPLERECORDCOUNT;
     }

--- a/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/source/jdbc/PostgresqlExtractor.java
+++ b/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/source/jdbc/PostgresqlExtractor.java
@@ -212,7 +212,7 @@ public class PostgresqlExtractor extends JdbcExtractor {
   }
 
   @Override
-  public long exractSampleRecordCountFromQuery(String query) {
+  public long extractSampleRecordCountFromQuery(String query) {
     if (StringUtils.isBlank(query)) {
       return SAMPLERECORDCOUNT;
     }

--- a/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/source/jdbc/SqlServerExtractor.java
+++ b/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/source/jdbc/SqlServerExtractor.java
@@ -203,7 +203,7 @@ public class SqlServerExtractor extends JdbcExtractor {
   }
 
   @Override
-  public long exractSampleRecordCountFromQuery(String query) {
+  public long extractSampleRecordCountFromQuery(String query) {
     if (StringUtils.isBlank(query)) {
       return SAMPLERECORDCOUNT;
     }

--- a/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/source/jdbc/TeradataExtractor.java
+++ b/gobblin-modules/gobblin-sql/src/main/java/org/apache/gobblin/source/jdbc/TeradataExtractor.java
@@ -209,7 +209,7 @@ public class TeradataExtractor extends JdbcExtractor {
   }
 
   @Override
-  public long exractSampleRecordCountFromQuery(String query) {
+  public long extractSampleRecordCountFromQuery(String query) {
     if (isNullOrEmpty(query)) {
       return SAMPLE_RECORD_COUNT;
     }

--- a/gobblin-modules/gobblin-sql/src/test/java/org/apache/gobblin/source/jdbc/OracleExtractorTest.java
+++ b/gobblin-modules/gobblin-sql/src/test/java/org/apache/gobblin/source/jdbc/OracleExtractorTest.java
@@ -94,12 +94,12 @@ public class OracleExtractorTest {
 
   @Test
   public void testExractSampleRecordCountFromQuery() {
-    long res1 = oracleExtractor.exractSampleRecordCountFromQuery(QUERY_1);
-    long res2 = oracleExtractor.exractSampleRecordCountFromQuery(QUERY_2);
-    long res3 = oracleExtractor.exractSampleRecordCountFromQuery(QUERY_3);
-    long res4 = oracleExtractor.exractSampleRecordCountFromQuery(QUERY_4);
-    long res5 = oracleExtractor.exractSampleRecordCountFromQuery(QUERY_EMPTY);
-    long res6 = oracleExtractor.exractSampleRecordCountFromQuery(QUERY_REG);
+    long res1 = oracleExtractor.extractSampleRecordCountFromQuery(QUERY_1);
+    long res2 = oracleExtractor.extractSampleRecordCountFromQuery(QUERY_2);
+    long res3 = oracleExtractor.extractSampleRecordCountFromQuery(QUERY_3);
+    long res4 = oracleExtractor.extractSampleRecordCountFromQuery(QUERY_4);
+    long res5 = oracleExtractor.extractSampleRecordCountFromQuery(QUERY_EMPTY);
+    long res6 = oracleExtractor.extractSampleRecordCountFromQuery(QUERY_REG);
 
     assertEquals(res1, (long) 532);
     assertEquals(res2, (long) 5);

--- a/gobblin-modules/gobblin-sql/src/test/java/org/apache/gobblin/source/jdbc/PostgresqlExtractorTest.java
+++ b/gobblin-modules/gobblin-sql/src/test/java/org/apache/gobblin/source/jdbc/PostgresqlExtractorTest.java
@@ -91,11 +91,11 @@ public class PostgresqlExtractorTest {
   @Test
   public void testExractSampleRecordCountFromQuery()
       throws Exception {
-    long res1 = postgresqlExtractor.exractSampleRecordCountFromQuery(QUERY_1);
-    long res2 = postgresqlExtractor.exractSampleRecordCountFromQuery(QUERY_2);
-    long res3 = postgresqlExtractor.exractSampleRecordCountFromQuery(QUERY_3);
-    long res4 = postgresqlExtractor.exractSampleRecordCountFromQuery(QUERY_EMPTY);
-    long res5 = postgresqlExtractor.exractSampleRecordCountFromQuery(QUERY_REG);
+    long res1 = postgresqlExtractor.extractSampleRecordCountFromQuery(QUERY_1);
+    long res2 = postgresqlExtractor.extractSampleRecordCountFromQuery(QUERY_2);
+    long res3 = postgresqlExtractor.extractSampleRecordCountFromQuery(QUERY_3);
+    long res4 = postgresqlExtractor.extractSampleRecordCountFromQuery(QUERY_EMPTY);
+    long res5 = postgresqlExtractor.extractSampleRecordCountFromQuery(QUERY_REG);
 
     assertEquals(res1, (long) 532);
     assertEquals(res2, (long) 50);


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1369


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

o.a.g.source.jdbc.JdbcSpecificLayer has a (maybe) misspelled method exractSampleRecordCountFromQuery. This PR fixes it.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No additional test since it's a simple refactoring. I ran `./gradlew :gobblin-modules:gobblin-sql:test` locally and ensured all tests passed.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

