### PR TITLE
[GOBBLIN-1370] Switch flow resume to be a restli action

### DIFF
--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-api/src/main/idl/org.apache.gobblin.service.flowexecutions.restspec.json
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-api/src/main/idl/org.apache.gobblin.service.flowexecutions.restspec.json
@@ -10,13 +10,10 @@
       "type" : "org.apache.gobblin.service.FlowStatusId",
       "params" : "com.linkedin.restli.common.EmptyRecord"
     },
-    "supports" : [ "delete", "get", "partial_update" ],
+    "supports" : [ "delete", "get" ],
     "methods" : [ {
       "method" : "get",
       "doc" : "Retrieve the FlowExecution with the given key"
-    }, {
-      "method" : "partial_update",
-      "doc" : "Resume a failed {@link FlowExecution} from the point before failure. This is specified by a partial update patch which\n sets executionStatus to RUNNING."
     }, {
       "method" : "delete",
       "doc" : "Kill the FlowExecution with the given key"
@@ -41,7 +38,11 @@
       } ]
     } ],
     "entity" : {
-      "path" : "/flowexecutions/{id}"
+      "path" : "/flowexecutions/{id}",
+      "actions" : [ {
+        "name" : "resume",
+        "doc" : "Resume a failed {@link FlowExecution} from the point before failure."
+      } ]
     }
   }
 }

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-api/src/main/snapshot/org.apache.gobblin.service.flowexecutions.snapshot.json
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-api/src/main/snapshot/org.apache.gobblin.service.flowexecutions.snapshot.json
@@ -216,13 +216,10 @@
         "type" : "org.apache.gobblin.service.FlowStatusId",
         "params" : "com.linkedin.restli.common.EmptyRecord"
       },
-      "supports" : [ "delete", "get", "partial_update" ],
+      "supports" : [ "delete", "get" ],
       "methods" : [ {
         "method" : "get",
         "doc" : "Retrieve the FlowExecution with the given key"
-      }, {
-        "method" : "partial_update",
-        "doc" : "Resume a failed {@link FlowExecution} from the point before failure. This is specified by a partial update patch which\n sets executionStatus to RUNNING."
       }, {
         "method" : "delete",
         "doc" : "Kill the FlowExecution with the given key"
@@ -247,7 +244,11 @@
         } ]
       } ],
       "entity" : {
-        "path" : "/flowexecutions/{id}"
+        "path" : "/flowexecutions/{id}",
+        "actions" : [ {
+          "name" : "resume",
+          "doc" : "Resume a failed {@link FlowExecution} from the point before failure."
+        } ]
       }
     }
   }

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-client/src/main/java/org/apache/gobblin/service/FlowExecutionClient.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-client/src/main/java/org/apache/gobblin/service/FlowExecutionClient.java
@@ -17,14 +17,11 @@
 
 package org.apache.gobblin.service;
 
-import com.linkedin.data.DataMap;
-import com.linkedin.restli.client.DeleteRequest;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
-import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,17 +33,15 @@ import com.linkedin.r2.RemoteInvocationException;
 import com.linkedin.r2.transport.common.Client;
 import com.linkedin.r2.transport.common.bridge.client.TransportClientAdapter;
 import com.linkedin.r2.transport.http.client.HttpClientFactory;
+import com.linkedin.restli.client.ActionRequest;
+import com.linkedin.restli.client.DeleteRequest;
 import com.linkedin.restli.client.FindRequest;
 import com.linkedin.restli.client.GetRequest;
-import com.linkedin.restli.client.PartialUpdateRequest;
 import com.linkedin.restli.client.Response;
 import com.linkedin.restli.client.RestClient;
-import com.linkedin.restli.client.UpdateRequest;
 import com.linkedin.restli.common.CollectionResponse;
 import com.linkedin.restli.common.ComplexResourceKey;
 import com.linkedin.restli.common.EmptyRecord;
-import com.linkedin.restli.common.PatchRequest;
-import com.linkedin.restli.internal.server.util.DataMapUtils;
 
 
 /**
@@ -177,15 +172,10 @@ public class FlowExecutionClient implements Closeable {
     LOG.debug("resumeFlowExecution with groupName " + flowStatusId.getFlowGroup() + " flowName " +
         flowStatusId.getFlowName() + " flowExecutionId " + flowStatusId.getFlowExecutionId());
 
-    String patchJson = "{\"$set\":{\"executionStatus\":\"RUNNING\"}}";
-    DataMap dataMap = DataMapUtils.readMap(IOUtils.toInputStream(patchJson));
-    PatchRequest<FlowExecution> flowExecutionPatch = PatchRequest.createFromPatchDocument(dataMap);
+    ActionRequest<Void> resumeRequest = _flowexecutionsRequestBuilders.actionResume()
+        .id(new ComplexResourceKey<>(flowStatusId, new EmptyRecord())).build();
 
-    PartialUpdateRequest<FlowExecution> partialUpdateRequest =
-        _flowexecutionsRequestBuilders.partialUpdate().id(new ComplexResourceKey<>(flowStatusId, new EmptyRecord()))
-            .input(flowExecutionPatch).build();
-
-    FlowClientUtils.sendRequestWithRetry(_restClient.get(), partialUpdateRequest, FlowexecutionsRequestBuilders.getPrimaryResource());
+    FlowClientUtils.sendRequestWithRetry(_restClient.get(), resumeRequest, FlowexecutionsRequestBuilders.getPrimaryResource());
   }
 
   /**

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowExecutionResource.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowExecutionResource.java
@@ -20,15 +20,17 @@ package org.apache.gobblin.service;
 import java.util.List;
 
 import com.google.inject.Inject;
-import com.linkedin.data.DataMap;
 import com.linkedin.restli.common.ComplexResourceKey;
 import com.linkedin.restli.common.EmptyRecord;
-import com.linkedin.restli.common.PatchRequest;
 import com.linkedin.restli.server.PagingContext;
+import com.linkedin.restli.server.PathKeys;
+import com.linkedin.restli.server.ResourceLevel;
 import com.linkedin.restli.server.UpdateResponse;
+import com.linkedin.restli.server.annotations.Action;
 import com.linkedin.restli.server.annotations.Context;
 import com.linkedin.restli.server.annotations.Finder;
 import com.linkedin.restli.server.annotations.Optional;
+import com.linkedin.restli.server.annotations.PathKeysParam;
 import com.linkedin.restli.server.annotations.QueryParam;
 import com.linkedin.restli.server.annotations.RestLiCollection;
 import com.linkedin.restli.server.resources.ComplexKeyResourceTemplate;
@@ -63,24 +65,12 @@ public class FlowExecutionResource extends ComplexKeyResourceTemplate<FlowStatus
   }
 
   /**
-   * Resume a failed {@link FlowExecution} from the point before failure. This is specified by a partial update patch which
-   * sets executionStatus to RUNNING.
-   * @param key {@link FlowStatusId} of flow to resume
-   * @param flowExecutionPatch {@link PatchRequest} which is expected to set executionStatus to RUNNING
-   * @return {@link UpdateResponse}
+   * Resume a failed {@link FlowExecution} from the point before failure.
+   * @param pathKeys key of {@link FlowExecution} specified in path
    */
-  @Override
-  public UpdateResponse update(ComplexResourceKey<FlowStatusId, EmptyRecord> key, PatchRequest<FlowExecution> flowExecutionPatch) {
-    DataMap dataMap = flowExecutionPatch.getPatchDocument().getDataMap("$set");
-    if (dataMap != null) {
-      String status = dataMap.getString("executionStatus");
-      if (status != null && status.equalsIgnoreCase(ExecutionStatus.RUNNING.name())) {
-        return this.flowExecutionResourceHandler.resume(key);
-      }
-    }
-
-    throw new UnsupportedOperationException("Only flow resume is supported for FlowExecution update, which is specified by "
-        + "setting executionStatus field to RUNNING");
+  @Action(name="resume",resourceLevel= ResourceLevel.ENTITY)
+  public void resume(@PathKeysParam PathKeys pathKeys) {
+    this.flowExecutionResourceHandler.resume(pathKeys.get("id"));
   }
 
   /**

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowExecutionResourceHandler.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowExecutionResourceHandler.java
@@ -17,21 +17,12 @@
 
 package org.apache.gobblin.service;
 
-import java.util.Collection;
 import java.util.List;
-import java.util.Properties;
 
 import com.linkedin.restli.common.ComplexResourceKey;
 import com.linkedin.restli.common.EmptyRecord;
-import com.linkedin.restli.common.PatchRequest;
-import com.linkedin.restli.server.CreateResponse;
 import com.linkedin.restli.server.PagingContext;
 import com.linkedin.restli.server.UpdateResponse;
-import com.linkedin.restli.server.annotations.Context;
-import com.linkedin.restli.server.annotations.Optional;
-import com.linkedin.restli.server.annotations.QueryParam;
-
-import org.apache.gobblin.runtime.api.FlowSpecSearchObject;
 
 
 public interface FlowExecutionResourceHandler {
@@ -48,7 +39,7 @@ public interface FlowExecutionResourceHandler {
   /**
    * Resume a failed {@link FlowExecution} from the point before failure
    */
-  public UpdateResponse resume(ComplexResourceKey<FlowStatusId, EmptyRecord> key);
+  public void resume(ComplexResourceKey<FlowStatusId, EmptyRecord> key);
 
   /**
    * Kill a running {@link FlowExecution}

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowExecutionResourceLocalHandler.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowExecutionResourceLocalHandler.java
@@ -69,7 +69,7 @@ public class FlowExecutionResourceLocalHandler implements FlowExecutionResourceH
   }
 
   @Override
-  public UpdateResponse resume(ComplexResourceKey<FlowStatusId, EmptyRecord> key) {
+  public void resume(ComplexResourceKey<FlowStatusId, EmptyRecord> key) {
     throw new UnsupportedOperationException("Resume should be handled in GobblinServiceFlowConfigResourceHandler");
   }
 

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/orchestration/DagManager.java
@@ -520,9 +520,9 @@ public class DagManager extends AbstractIdleService {
         ExecutionStatus executionStatus = node.getValue().getExecutionStatus();
         if (executionStatus.equals(FAILED) || executionStatus.equals(CANCELLED)) {
           node.getValue().setExecutionStatus(PENDING_RESUME);
+          Map<String, String> jobMetadata = TimingEventUtils.getJobMetadata(Maps.newHashMap(), node.getValue());
+          this.eventSubmitter.get().getTimingEvent(TimingEvent.LauncherTimings.JOB_PENDING_RESUME).stop(jobMetadata);
         }
-        Map<String, String> jobMetadata = TimingEventUtils.getJobMetadata(Maps.newHashMap(), node.getValue());
-        this.eventSubmitter.get().getTimingEvent(TimingEvent.LauncherTimings.JOB_PENDING_RESUME).stop(jobMetadata);
 
         // Set flowStartTime so that flow SLA will be based on current time instead of original flow
         node.getValue().setFlowStartTime(flowResumeTime);

--- a/gobblin-service/src/main/java/org/apache/gobblin/service/modules/restli/GobblinServiceFlowExecutionResourceHandler.java
+++ b/gobblin-service/src/main/java/org/apache/gobblin/service/modules/restli/GobblinServiceFlowExecutionResourceHandler.java
@@ -71,7 +71,7 @@ public class GobblinServiceFlowExecutionResourceHandler implements FlowExecution
   }
 
   @Override
-  public UpdateResponse resume(ComplexResourceKey<FlowStatusId, EmptyRecord> key) {
+  public void resume(ComplexResourceKey<FlowStatusId, EmptyRecord> key) {
     String flowGroup = key.getKey().getFlowGroup();
     String flowName = key.getKey().getFlowName();
     Long flowExecutionId = key.getKey().getFlowExecutionId();
@@ -79,7 +79,6 @@ public class GobblinServiceFlowExecutionResourceHandler implements FlowExecution
       HelixUtils.throwErrorIfNotLeader(this.helixManager);
     }
     this.eventBus.post(new ResumeFlowEvent(flowGroup, flowName, flowExecutionId));
-    return new UpdateResponse(HttpStatus.S_200_OK);
   }
 
   @Override


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1370


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):

Flow resume was previously represented as a partial update, which makes it a pretty confusing API. But restli actually supports an API for actions, which is a much simpler and more obvious way to represent a triggered action like resuming a flow.

With this method, the url to request resuming a flow looks like `https://localhost:6956/gobblinservice/flowexecutions/(flowGroup:testGroup1,flowName:testFlow1,flowExecutionId:1611270235422)?action=resume`

Also fixed a bug that all jobs were being set to `PENDING_RESUME` instead of only the failed/cancelled ones in `DagManager`.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tested locally

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

