### PR TITLE
[GOBBLIN-1359] Fix the error that Exception thrown by writer be swallowed by Reactivex and cause jobs to hang

### DIFF
--- a/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/org/apache/gobblin/configuration/ConfigurationKeys.java
@@ -357,6 +357,8 @@ public class ConfigurationKeys {
   public static final String DEFAULT_FORK_RECORD_QUEUE_TIMEOUT_UNIT = TimeUnit.MILLISECONDS.name();
   public static final String FORK_MAX_WAIT_MININUTES = "fork.max.wait.minutes";
   public static final long DEFAULT_FORK_MAX_WAIT_MININUTES = 60;
+  public static final String FORK_FINISHED_CHECK_INTERVAL = "fork.finished.check.interval";
+  public static final long DEFAULT_FORK_FINISHED_CHECK_INTERVAL = 1000;
   public static final String FORK_CLOSE_WRITER_ON_COMPLETION = "fork.closeWriterOnCompletion";
   public static final boolean DEFAULT_FORK_CLOSE_WRITER_ON_COMPLETION = false;
 

--- a/gobblin-core-base/src/main/java/org/apache/gobblin/source/extractor/extract/FlushingExtractor.java
+++ b/gobblin-core-base/src/main/java/org/apache/gobblin/source/extractor/extract/FlushingExtractor.java
@@ -40,7 +40,6 @@ import org.apache.gobblin.commit.CommitStep;
 import org.apache.gobblin.configuration.WorkUnitState;
 import org.apache.gobblin.metrics.MetricContextUtils;
 import org.apache.gobblin.publisher.DataPublisher;
-import org.apache.gobblin.runtime.JobShutdownException;
 import org.apache.gobblin.runtime.StateStoreBasedWatermarkStorage;
 import org.apache.gobblin.source.extractor.CheckpointableWatermark;
 import org.apache.gobblin.source.extractor.DataRecordException;

--- a/gobblin-core-base/src/main/java/org/apache/gobblin/source/extractor/extract/FlushingExtractor.java
+++ b/gobblin-core-base/src/main/java/org/apache/gobblin/source/extractor/extract/FlushingExtractor.java
@@ -108,8 +108,8 @@ public abstract class FlushingExtractor<S, D> extends EventBasedExtractor<S, D> 
   protected Long flushIntervalMillis;
 
   protected Long timeOfLastFlush = System.currentTimeMillis();
-  private FlushAckable lastFlushAckable;
-  private boolean hasOutstandingFlush = false;
+  protected FlushAckable lastFlushAckable;
+  protected boolean hasOutstandingFlush = false;
   private Optional<DataPublisher> flushPublisher = Optional.absent();
   protected WorkUnitState workUnitState;
 
@@ -332,7 +332,7 @@ public abstract class FlushingExtractor<S, D> extends EventBasedExtractor<S, D> 
   /**
    * {@link Ackable} for waiting for the flush control message to be processed
    */
-  private static class FlushAckable implements Ackable {
+  protected static class FlushAckable implements Ackable {
     private Throwable error;
     private final CountDownLatch processed;
 

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaStreamingExtractor.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaStreamingExtractor.java
@@ -17,9 +17,6 @@
 
 package org.apache.gobblin.source.extractor.extract.kafka;
 
-import io.reactivex.Emitter;
-import io.reactivex.Flowable;
-import io.reactivex.functions.BiConsumer;
 import java.io.IOException;
 import java.util.AbstractMap;
 import java.util.ArrayList;
@@ -33,8 +30,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -61,16 +56,12 @@ import org.apache.gobblin.configuration.WorkUnitState;
 import org.apache.gobblin.kafka.client.DecodeableKafkaRecord;
 import org.apache.gobblin.kafka.client.GobblinKafkaConsumerClient;
 import org.apache.gobblin.kafka.client.KafkaConsumerRecord;
-import org.apache.gobblin.metadata.GlobalMetadata;
 import org.apache.gobblin.metrics.ContextAwareGauge;
 import org.apache.gobblin.metrics.Tag;
 import org.apache.gobblin.metrics.kafka.KafkaSchemaRegistry;
 import org.apache.gobblin.metrics.kafka.SchemaRegistryException;
-import org.apache.gobblin.records.RecordStreamWithMetadata;
-import org.apache.gobblin.runtime.JobShutdownException;
 import org.apache.gobblin.source.extractor.CheckpointableWatermark;
 import org.apache.gobblin.source.extractor.ComparableWatermark;
-import org.apache.gobblin.source.extractor.DataRecordException;
 import org.apache.gobblin.source.extractor.Watermark;
 import org.apache.gobblin.source.extractor.WatermarkSerializerHelper;
 import org.apache.gobblin.source.extractor.extract.FlushingExtractor;
@@ -78,7 +69,6 @@ import org.apache.gobblin.source.extractor.extract.LongWatermark;
 import org.apache.gobblin.source.workunit.WorkUnit;
 import org.apache.gobblin.stream.FlushRecordEnvelope;
 import org.apache.gobblin.stream.RecordEnvelope;
-import org.apache.gobblin.stream.StreamEntity;
 import org.apache.gobblin.util.ClassAliasResolver;
 import org.apache.gobblin.util.ClustersNames;
 import org.apache.gobblin.util.ConfigUtils;

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaStreamingExtractor.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaStreamingExtractor.java
@@ -17,6 +17,9 @@
 
 package org.apache.gobblin.source.extractor.extract.kafka;
 
+import io.reactivex.Emitter;
+import io.reactivex.Flowable;
+import io.reactivex.functions.BiConsumer;
 import java.io.IOException;
 import java.util.AbstractMap;
 import java.util.ArrayList;
@@ -30,6 +33,8 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -56,12 +61,16 @@ import org.apache.gobblin.configuration.WorkUnitState;
 import org.apache.gobblin.kafka.client.DecodeableKafkaRecord;
 import org.apache.gobblin.kafka.client.GobblinKafkaConsumerClient;
 import org.apache.gobblin.kafka.client.KafkaConsumerRecord;
+import org.apache.gobblin.metadata.GlobalMetadata;
 import org.apache.gobblin.metrics.ContextAwareGauge;
 import org.apache.gobblin.metrics.Tag;
 import org.apache.gobblin.metrics.kafka.KafkaSchemaRegistry;
 import org.apache.gobblin.metrics.kafka.SchemaRegistryException;
+import org.apache.gobblin.records.RecordStreamWithMetadata;
+import org.apache.gobblin.runtime.JobShutdownException;
 import org.apache.gobblin.source.extractor.CheckpointableWatermark;
 import org.apache.gobblin.source.extractor.ComparableWatermark;
+import org.apache.gobblin.source.extractor.DataRecordException;
 import org.apache.gobblin.source.extractor.Watermark;
 import org.apache.gobblin.source.extractor.WatermarkSerializerHelper;
 import org.apache.gobblin.source.extractor.extract.FlushingExtractor;
@@ -69,6 +78,7 @@ import org.apache.gobblin.source.extractor.extract.LongWatermark;
 import org.apache.gobblin.source.workunit.WorkUnit;
 import org.apache.gobblin.stream.FlushRecordEnvelope;
 import org.apache.gobblin.stream.RecordEnvelope;
+import org.apache.gobblin.stream.StreamEntity;
 import org.apache.gobblin.util.ClassAliasResolver;
 import org.apache.gobblin.util.ClustersNames;
 import org.apache.gobblin.util.ConfigUtils;

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaStreamingExtractor.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaStreamingExtractor.java
@@ -129,10 +129,7 @@ public class KafkaStreamingExtractor<S> extends FlushingExtractor<S, DecodeableK
       log.error("Interrupted when attempting to shutdown metrics collection threads.");
     }
     this.shutdownRequested.set(true);
-    // In case hasOutstandingFlush, we need to manually nack the ackable to make sure the CountDownLatch not hang
-    if (this.hasOutstandingFlush) {
-      this.lastFlushAckable.nack(new IOException("Extractor already shutdown"));
-    }
+    super.shutdown();
   }
 
   @ToString

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaStreamingExtractor.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/org/apache/gobblin/source/extractor/extract/kafka/KafkaStreamingExtractor.java
@@ -129,6 +129,10 @@ public class KafkaStreamingExtractor<S> extends FlushingExtractor<S, DecodeableK
       log.error("Interrupted when attempting to shutdown metrics collection threads.");
     }
     this.shutdownRequested.set(true);
+    // In case hasOutstandingFlush, we need to manually nack the ackable to make sure the CountDownLatch not hang
+    if (this.hasOutstandingFlush) {
+      this.lastFlushAckable.nack(new IOException("Extractor already shutdown"));
+    }
   }
 
   @ToString

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/StreamModelTaskRunner.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/StreamModelTaskRunner.java
@@ -89,7 +89,7 @@ public class StreamModelTaskRunner {
     // by publish, so set the shutdownRequested flag on cancel to stop the extractor
     Flowable streamWithShutdownOnCancel = connectableStream.doOnCancel(() -> {
       this.shutdownRequested.set(true);
-      // In the case that extractor sucks in reading record when cancel get called, we call shutdown again to force it
+      // In the case that extractor stuck in reading record when cancel get called, we call shutdown again to force it
       this.extractor.shutdown();
     });
 

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/StreamModelTaskRunner.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/StreamModelTaskRunner.java
@@ -89,6 +89,7 @@ public class StreamModelTaskRunner {
     // by publish, so set the shutdownRequested flag on cancel to stop the extractor
     Flowable streamWithShutdownOnCancel = connectableStream.doOnCancel(() -> {
       this.shutdownRequested.set(true);
+      // In the case that extractor sucks in reading record when cancel get called, we call shutdown again to force it
       this.extractor.shutdown();
     });
 

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/StreamModelTaskRunner.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/StreamModelTaskRunner.java
@@ -76,6 +76,7 @@ public class StreamModelTaskRunner {
 
   protected void run() throws Exception {
     long maxWaitInMinute = taskState.getPropAsLong(ConfigurationKeys.FORK_MAX_WAIT_MININUTES, ConfigurationKeys.DEFAULT_FORK_MAX_WAIT_MININUTES);
+    long initialDelay = taskState.getPropAsLong(ConfigurationKeys.FORK_FINISHED_CHECK_INTERVAL, ConfigurationKeys.DEFAULT_FORK_FINISHED_CHECK_INTERVAL);
 
     // Get the fork operator. By default IdentityForkOperator is used with a single branch.
     ForkOperator forkOperator = closer.register(this.taskContext.getForkOperator());
@@ -86,7 +87,10 @@ public class StreamModelTaskRunner {
 
     // The cancel is not propagated to the extractor's record generator when it has been turned into a hot Flowable
     // by publish, so set the shutdownRequested flag on cancel to stop the extractor
-    Flowable streamWithShutdownOnCancel = connectableStream.doOnCancel(() -> this.shutdownRequested.set(true));
+    Flowable streamWithShutdownOnCancel = connectableStream.doOnCancel(() -> {
+      this.shutdownRequested.set(true);
+      this.extractor.shutdown();
+    });
 
     stream = stream.withRecordStream(streamWithShutdownOnCancel);
 
@@ -149,11 +153,12 @@ public class StreamModelTaskRunner {
         this.task.configureStreamingFork(fork);
       }
     }
-
-    connectableStream.connect();
+    new Thread(() -> {
+      connectableStream.connect();
+    }).start();
 
     if (!ExponentialBackoff.awaitCondition().callable(() -> this.forks.keySet().stream().map(Optional::get).allMatch(Fork::isDone)).
-        initialDelay(1000L).maxDelay(1000L).maxWait(TimeUnit.MINUTES.toMillis(maxWaitInMinute)).await()) {
+        initialDelay(initialDelay).maxDelay(initialDelay).maxWait(TimeUnit.MINUTES.toMillis(maxWaitInMinute)).await()) {
       throw new TimeoutException("Forks did not finish withing specified timeout.");
     }
   }

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/fork/Fork.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/fork/Fork.java
@@ -27,7 +27,6 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableList;
 import com.google.common.io.Closer;
 
 import edu.umd.cs.findbugs.annotations.SuppressWarnings;

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/fork/Fork.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/fork/Fork.java
@@ -227,6 +227,10 @@ public class Fork<S, D> implements Closeable, FinalState, RecordStreamConsumer<S
           r.ack();
         }
       }, e -> {
+          // Handle writer close in error case since onComplete will not call when exception happens
+          if (this.writer.isPresent()) {
+            this.writer.get().close();
+          }
           logger.error("Failed to process record.", e);
           verifyAndSetForkState(ForkState.RUNNING, ForkState.FAILED);
           },

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/fork/Fork.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/fork/Fork.java
@@ -229,7 +229,7 @@ public class Fork<S, D> implements Closeable, FinalState, RecordStreamConsumer<S
         }
       }, e -> {
           logger.error("Failed to process record.", e);
-          throw(new RuntimeException(e));
+          verifyAndSetForkState(ForkState.RUNNING, ForkState.FAILED);
           },
         () -> {
           if (this.writer.isPresent()) {

--- a/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnAppLauncher.java
+++ b/gobblin-yarn/src/main/java/org/apache/gobblin/yarn/GobblinYarnAppLauncher.java
@@ -835,7 +835,8 @@ public class GobblinYarnAppLauncher {
       LOGGER.debug("All containerLaunchContext tokens: {} present in file {} ", credentials.getAllTokens(), System.getenv(HADOOP_TOKEN_FILE_LOCATION));
     }
 
-    TokenUtils.getAllFSTokens(new Configuration(), credentials, renewerName, null, ConfigUtils.getStringList(this.config, TokenUtils.OTHER_NAMENODES));
+    TokenUtils.getAllFSTokens(new Configuration(), credentials, renewerName,
+        Optional.absent(), ConfigUtils.getStringList(this.config, TokenUtils.OTHER_NAMENODES));
 
     Closer closer = Closer.create();
     try {


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1359


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):

After the first change https://github.com/apache/incubator-gobblin/pull/3200, we still see the job hang if onNext throw error after a long processing time (i.e. 5 mins). 
And after investigating, we see the ConnectableFlowable.connect() which is supposed to return immediately does not return even the flow is finished and canceled. And the root cause is that in this case where consumer is super slow, extractor is sleeping on lastFlushAckable.waitForAck(), but the control message will never be processed, so the extractor just hang there.
So the solution will be 1. Make the call of connect in another thread, and let the sequence code get executed which is to periodically check whether the job finished. This is to make job respect fork timeout
2. In flow.doFinal(), call the shutdown again to make sure shutdown can be processed even extractor is sleep in readRecord. And in shutdown process, manually nack the Ackable to wake up the thread.  

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Run end to end test on Azkaban: 
1. For normal case, record get processed and write out correctly, also verify that the timeout for fork can take effect
2. For bad case where write is slow, we simulate the situation and make sure the exception thrown by writer can be catch and fail the job. Also I use jstack to make sure we do not have any thread hanging in this case (after the task restart)
3. For bad case where writer throw exception right away, make sure the exception will fail the task and cause task to retry

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

