### PR TITLE
GOBBLIN-1374: Generate a unique staging path in FS SpecProducer for writing job specs

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/FsSpecProducer.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/api/FsSpecProducer.java
@@ -21,6 +21,7 @@ import java.io.OutputStream;
 import java.net.URI;
 import java.util.List;
 import java.util.Properties;
+import java.util.UUID;
 import java.util.concurrent.Future;
 
 import org.apache.avro.file.DataFileWriter;
@@ -140,7 +141,7 @@ public class FsSpecProducer implements SpecProducer<Spec> {
     Path jobSpecPath = new Path(this.specConsumerPath, jobSpec.getUri());
 
     //Write the new JobSpec to a temporary path first.
-    Path tmpDir = new Path(this.specConsumerPath, "_tmp");
+    Path tmpDir = new Path(this.specConsumerPath, UUID.randomUUID().toString());
     if (!fs.exists(tmpDir)) {
       fs.mkdirs(tmpDir);
     }
@@ -155,6 +156,10 @@ public class FsSpecProducer implements SpecProducer<Spec> {
 
     //Rename the JobSpec from temporary to final location.
     HadoopUtils.renamePath(fs, tmpJobSpecPath, jobSpecPath, true);
+
+    //Delete the temporary path once the jobspec has been moved to its final publish location.
+    log.info("Deleting {}", tmpJobSpecPath.getParent().toString());
+    fs.delete(tmpJobSpecPath.getParent(), true);
   }
 
 }


### PR DESCRIPTION
…riting job specs

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1374


### Description
- [x] Here are some details about my PR, including screenshots (if applicable):
Current implementation writes the job specs to a fixed staging location before the specs get renamed to a final publish location. To avoid concurrent producers writing to the same file, we generate a unique staging location. 


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Existing unit tests.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

